### PR TITLE
Node Pool Status DAGs Update

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,9 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/user/**
+      - orbax/user/**
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,14 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/user/**
+      - orbax/user/**
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,15 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/user/**
+      - orbax/user/**
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -1,7 +1,13 @@
 name: Require Checklist
 on:
   pull_request:
+    branch: 
+      - tpu-obs/user/**
+      - orbax/user/**
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,9 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
+    branch: 
+      - tpu-obs/user/**
+      - orbax/user/**
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -38,7 +38,6 @@ with models.DAG(
         parameters and verifies that the status changes to error.
     """,
 ) as dag:
-
   node_pool_info = node_pool.Info(
       project_id=models.Variable.get(
           "PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -1,12 +1,13 @@
-"""Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
-"""
+"""A Dag to validate the status of a GKE node pool through its lifecycle."""
 
 import copy
 import datetime
 
 from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags.common.vm_resource import Project
+from dags.common.vm_resource import Region
 from dags.common.vm_resource import Zone
 from dags.map_reproducibility.utils import constants
 from dags.tpu_observability.utils import node_pool_util as node_pool
@@ -14,7 +15,7 @@ from dags.tpu_observability.utils import node_pool_util as node_pool
 
 with models.DAG(
     dag_id="gke_node_pool_status",
-    start_date=datetime.datetime(2025, 7, 30),
+    start_date=datetime.datetime(2025, 8, 1),
     schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
     catchup=False,
     tags=["gke", "tpu-observability", "node-pool-status"],
@@ -48,7 +49,9 @@ with models.DAG(
       node_pool_name=models.Variable.get(
           "NODE_POOL_NAME", default_var="yuna-v6e-autotest"
       ),
-      location=models.Variable.get("LOCATION", default_var="asia-northeast1"),
+      location=models.Variable.get(
+          "LOCATION", default_var=Region.ASIA_NORTHEAST1.value
+      ),
       node_locations=models.Variable.get(
           "NODE_LOCATIONS", default_var=Zone.ASIA_NORTHEAST1_B.value
       ),
@@ -110,7 +113,7 @@ with models.DAG(
 
   task_id = "cleanup_node_pool"
   cleanup_node_pool = node_pool.delete.override(
-      task_id=task_id, trigger_rule="all_done"
+      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
   )(node_pool=node_pool_info).as_teardown(
       setups=create_node_pool,
   )
@@ -121,9 +124,9 @@ with models.DAG(
   create_problematic_node_pool_info = node_pool.create.override(
       task_id=task_id
   )(
+      node_pool=problematic_node_pool_info,
       # The failure is intentionally ignored because we want to validate
       # that the status of the node pool (which fails to be created) is "ERROR".
-      node_pool=problematic_node_pool_info,
       ignore_failure=True,
   )
 
@@ -134,12 +137,12 @@ with models.DAG(
 
   task_id = "cleanup_wrong_node_pool"
   cleanup_wrong_node_pool = node_pool.delete.override(
-      task_id=task_id, trigger_rule="all_done"
+      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
   )(node_pool=problematic_node_pool_info).as_teardown(
       setups=create_problematic_node_pool_info,
   )
 
-  normal_path_flow = (
+  normal_flow = (
       create_node_pool
       >> wait_for_provisioning
       >> wait_for_running
@@ -151,7 +154,7 @@ with models.DAG(
       >> cleanup_node_pool
   )
 
-  wrong_path_flow = (
+  flow_for_error_state = (
       create_problematic_node_pool_info
       >> wait_for_error
       >> cleanup_wrong_node_pool

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -1,5 +1,4 @@
-"""Manages the lifecycle of a GKE node pool and verifies its status as an Airflow DAG.
-"""
+"""Utility functions for managing GKE node pools."""
 
 import dataclasses
 import enum
@@ -11,13 +10,13 @@ import time
 from typing import List
 
 from airflow.decorators import task
+from airflow.exceptions import AirflowFailException
 from google import auth
 from google.cloud import monitoring_v3
 from google.cloud.monitoring_v3 import types
 from googleapiclient import discovery
 
 
-dataclass = dataclasses.dataclass
 logger = logging.getLogger(__name__)
 
 
@@ -75,8 +74,8 @@ def create(node_pool: Info, ignore_failure: bool = False) -> None:
   process = subprocess.run(
       command, shell=True, check=True, capture_output=True, text=True
   )
-  logger.debug("STDOUT message: %s", process.stdout)
-  logger.debug("STDERR message: %s", process.stderr)
+  logger.info("STDOUT message: %s", process.stdout)
+  logger.info("STDERR message: %s", process.stderr)
 
 
 @task
@@ -94,8 +93,8 @@ def delete(node_pool: Info) -> None:
   process = subprocess.run(
       command, shell=True, check=True, capture_output=True, text=True
   )
-  logger.debug("STDOUT message: %s", process.stdout)
-  logger.debug("STDERR message: %s", process.stderr)
+  logger.info("STDOUT message: %s", process.stdout)
+  logger.info("STDERR message: %s", process.stderr)
 
 
 def list_nodes(node_pool: Info) -> List[str]:
@@ -135,16 +134,17 @@ def list_nodes(node_pool: Info) -> List[str]:
 
   instance_group = nodepool.get("instanceGroupUrls", [])
   if not instance_group:
-    raise RuntimeError(
+    raise AirflowFailException(
         f"No instance groups found for node pool {node_pool.node_pool_name}."
     )
 
   node_names = []
 
   for url in instance_group:
-    # Extract the the name of an instance group from an URL like this:
+    # Extract the {instance_group_name} segments from an URL:
     # https://www.googleapis.com/compute/v1/projects/tpu-prod-env-one-vm/zones/asia-northeast1-b/instanceGroups/gke-yuna-xpk-v6e-2-yuna-xpk-v6e-2-np--b3a745c7-grp
-    # in which, `gke-yuna-xpk-v6e-2-yuna-xpk-v6e-2-np--b3a745c7-grp` is the of the instance group
+    # in which, `gke-yuna-xpk-v6e-2-yuna-xpk-v6e-2-np--b3a745c7-grp`
+    # is the of the instance group
     match = re.search(r"instanceGroupManagers/([\w-]+)", url)
     if not match:
       logging.warning("Could not parse instance group URL: %s", url)
@@ -195,7 +195,7 @@ def delete_one_random_node(node_pool: Info) -> None:
 
   nodes_list = list_nodes(node_pool)
   if not nodes_list:
-    raise ValueError(
+    raise AirflowFailException(
         f"No nodes found in node pool '{node_pool.node_pool_name}'. "
         "Cannot proceed with node deletion."
     )
@@ -216,8 +216,8 @@ def delete_one_random_node(node_pool: Info) -> None:
   process = subprocess.run(
       command, shell=True, check=True, capture_output=True, text=True
   )
-  logger.debug("STDOUT message: %s", process.stdout)
-  logger.debug("STDERR message: %s", process.stderr)
+  logger.info("STDOUT message: %s", process.stdout)
+  logger.info("STDERR message: %s", process.stderr)
 
 
 def _query_status_metric(node_pool: Info) -> Status:
@@ -244,8 +244,7 @@ def _query_status_metric(node_pool: Info) -> Status:
           f'resource.labels.cluster_name = "{node_pool.cluster_name}" '
           f'resource.labels.node_pool_name = "{node_pool.node_pool_name}"'
       ),
-      interval=types.TimeInterval(
-          {
+      interval=types.TimeInterval({
               "end_time": {"seconds": now},
               # Metrics are sampled every 60s and stored in the GCP backend,
               # but it may take up to 2 minutes for the data to become
@@ -254,8 +253,7 @@ def _query_status_metric(node_pool: Info) -> Status:
               # A 5-minute window is an arbitrary but sufficient choice to
               # ensure we can retrieve the latest metric data.
               "start_time": {"seconds": now - 300},
-          }
-      ),
+          }),
       view="FULL",
   )
 

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -245,15 +245,15 @@ def _query_status_metric(node_pool: Info) -> Status:
           f'resource.labels.node_pool_name = "{node_pool.node_pool_name}"'
       ),
       interval=types.TimeInterval({
-              "end_time": {"seconds": now},
-              # Metrics are sampled every 60s and stored in the GCP backend,
-              # but it may take up to 2 minutes for the data to become
-              # available on the client side.
-              # Therefore, a longer time interval is necessary.
-              # A 5-minute window is an arbitrary but sufficient choice to
-              # ensure we can retrieve the latest metric data.
-              "start_time": {"seconds": now - 300},
-          }),
+          "end_time": {"seconds": now},
+          # Metrics are sampled every 60s and stored in the GCP backend,
+          # but it may take up to 2 minutes for the data to become
+          # available on the client side.
+          # Therefore, a longer time interval is necessary.
+          # A 5-minute window is an arbitrary but sufficient choice to
+          # ensure we can retrieve the latest metric data.
+          "start_time": {"seconds": now - 300},
+      }),
       view="FULL",
   )
 


### PR DESCRIPTION
# Description
This change adds a new DAG which automates the process of going through the lifecycle of a node pool and verifies whether the node pool status is reported correctly.

This DAG requires an existing cluster. It will create a node-pool under the specified cluster, and clean it up after the tests.

# Tests
  - Dag Name : gke_node_pool_status
  - Airflow test results: https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/gke_node_pool_status/grid?tab=graph

## Airflow/Composer
- GCP Composer name: `dennis-airflow-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`
 
## Required Variables
- **Cluster Information** (This DAG requires an existing cluster)
  - `PROJECT_ID`: The GCP project ID where the cluster resides. (Default to _**tpu-prod-env-one-vm**_)
  - `CLUSTER_NAME`: The name of the target GKE cluster. (Default to _**yuna-xpk-v6e-2**_)
  - `LOCATION`: The region of the GKE cluster. (Default to _**asia-northeast1**_)
- **Node Pool Configurations**
  - `NODE_POOL_NAME`: The base name for the new node pool. (Default to _**yuna-v6e-autotest**_)
  - `NODE_LOCATIONS`: The zone for the nodes in the normal test path. (Default to _**asia-northeast1-b**_)
  - `NUM_NODES`: The number of nodes to create in the pool. (Default to _**4**_)
  - `MACHINE_TYPE`: The machine type for the GKE nodes. (Default to _**ct6e-standard-4t**_)
  - `TPU_TOPOLOGY`: The TPU topology for the node pool. (Default to _**4x4**_)
  - `ERROR_NODE_LOCATIONS`: An invalid zone used to intentionally trigger an error state for testing. (Default to _**asia-east1-c**_)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.