### PR TITLE
Add a new DAG to test if the output consistency between tpu-info CLI tool output and monitoring output.

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,8 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/dev/**
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,13 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/dev/**
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,14 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/dev/**
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -1,7 +1,12 @@
 name: Require Checklist
 on:
   pull_request:
+    branch:
+      - tpu-obs/dev/**
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,8 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - tpu-obs/dev/**
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/tpu_observability/tpu_info_tcu_dags.py
+++ b/dags/tpu_observability/tpu_info_tcu_dags.py
@@ -1,0 +1,343 @@
+"""A DAG orchestrates the process of verifying TensorCore utilization metrics.
+
+This is done by comparing data from Cloud Logging and Cloud Monitoring.
+"""
+
+import dataclasses
+import datetime
+import logging
+import pathlib
+import re
+from typing import List
+
+from airflow import models
+from airflow.decorators import task
+from airflow.exceptions import AirflowException
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.utils.trigger_rule import TriggerRule
+from google.cloud import logging_v2 as gcp_logging
+from google.cloud import monitoring_v3
+from google.cloud.monitoring_v3 import types
+
+from dags.common.vm_resource import Project, Region, Zone
+
+
+@dataclasses.dataclass
+class Info:
+  """Configuration for the GKE Node Pool and Monitoring."""
+  project_id: str
+  region: str
+  zone: str
+  cluster_name: str
+  container_name: str
+  yaml_file_name: str
+  yaml_path: str
+
+
+def compare_utilization_values(
+    log_values: List[float],
+    monitoring_values: List[float],
+    tolerance: float = 1.0
+) -> bool:
+  """Compares two sets of utilization values and returns the comparison result."""
+  if len(log_values) != len(monitoring_values):
+    raise AirflowException(f"Data count mismatch. Data count mismatch. Logs have {log_values} values, "
+        f"Monitoring has {monitoring_values}."
+    )
+
+
+  logging.info("--- Comparison Results ---")
+  logging.info("Tolerance: %s", tolerance)
+  logging.info(
+      "%s%s%s%s%s",
+      f"{'Device':<12}",
+      f"{'Log Value':<12}",
+      f"{'Monitor Value':<15}",
+      f"{'Difference':<12}",
+      f"{'Result':<10}",
+  )
+  logging.info("-" * 65)
+
+  all_passed = True
+  for i, (log_val, mon_val) in enumerate(zip(log_values, monitoring_values)):
+    diff = abs(log_val - mon_val)
+    passed = diff < tolerance
+    if not passed:
+      all_passed = False
+    logging.info(
+        "%-12s %-12.2f %-15.2f %-12.2f %-10s",
+        f"Device {i}", log_val, mon_val, diff, 'PASS' if passed else 'FAIL'
+    )
+
+  logging.info("-" * 65)
+
+  return all_passed
+
+
+@task.sensor(poke_interval=30, timeout=600, mode="reschedule")
+def wait_for_jobset_start_logs(info: Info, job_apply_time_str: str) -> bool:
+  """Waits for the first log entry indicating the job has started.
+
+  This task polls Cloud Logging for a specific log pattern that appears
+  shortly after the TPU job begins execution within the specified container.
+  It times out if no such log is found within a defined period.
+
+  Args:
+    info: An Info dataclass instance containing project and cluster details.
+    job_apply_time_str: The ISO formatted string of the time the job was
+      applied.
+  """
+  log_client = gcp_logging.Client(project=info.project_id)
+  datetime_job_apply_time = datetime.datetime.fromisoformat(job_apply_time_str)
+
+  lql_query = (
+      f'logName="projects/{info.project_id}/logs/stdout" AND '
+      'resource.type="k8s_container" AND '
+      f'resource.labels.cluster_name="{info.cluster_name}" AND '
+      f'resource.labels.container_name="{info.container_name}" AND '
+      'textPayload =~ "printTimestamp.*"'
+  )
+  full_filter = f'timestamp>="{job_apply_time_str}" AND ({lql_query})'
+
+  response_iterator = log_client.list_entries(
+      filter_=full_filter, order_by=gcp_logging.DESCENDING, max_results=1
+  )
+  latest_entry = next(iter(response_iterator), None)
+
+  return latest_entry and latest_entry.timestamp > datetime_job_apply_time
+
+
+@task
+def format_node_list(bash_output: str) -> List[str]:
+  """Converts multi-line BashOperator output into a Python list of strings."""
+  if not bash_output or not bash_output.strip():
+    logging.warning("Received empty node list from bash task.")
+    return []
+
+  node_list = bash_output.strip().split()
+
+  return node_list
+
+
+@task
+def verify_tensorcore_utilization(
+    info: Info, node_name: str, job_apply_time: str
+) -> bool:
+  """Fetches utilization from logs and monitoring for a single node and compares them."""
+  datetime_job_apply_time = datetime.datetime.fromisoformat(job_apply_time)
+  end_time_utc = datetime_job_apply_time + datetime.timedelta(minutes=10)
+
+  log_client = gcp_logging.Client(project=info.project_id)
+
+  lql_query = (
+      f'logName="projects/{info.project_id}/logs/stdout" AND '
+      'resource.type="k8s_container" AND '
+      f'resource.labels.cluster_name="{info.cluster_name}" AND '
+      f'resource.labels.container_name="{info.container_name}" AND '
+      f'labels."compute.googleapis.com/resource_name":"{node_name}"'
+  )
+  full_filter = f'timestamp>="{job_apply_time}" AND ({lql_query})'
+  logging.info("Executing log query for node %s:%s", node_name, full_filter)
+
+  response_iterator = log_client.list_entries(
+      filter_=full_filter, order_by=gcp_logging.ASCENDING
+  )
+  util_values, search_timestamp, in_tensorcore_section = [], None, False
+  for entry in response_iterator:
+    log_text = entry.payload
+    if not isinstance(log_text, str):
+      continue
+    if not search_timestamp:
+      ts_match = re.search(r"printTimestamp:\s*(\d+)", log_text)
+      if ts_match:
+        search_timestamp = int(ts_match.group(1))
+    if "TensorCore Utilization" in log_text:
+      in_tensorcore_section = True
+      continue
+    if in_tensorcore_section:
+      match = re.search(r"│\s*\d+\s*│\s*([\d.]+)%", log_text)
+      if match:
+        util_values.append(float(match.group(1)))
+    if len(util_values) == 4:
+      break
+
+  mon_client = monitoring_v3.MetricServiceClient()
+  request = monitoring_v3.ListTimeSeriesRequest(
+      name=f"projects/{info.project_id}",
+      filter=(
+          "metric.type ="
+          ' "kubernetes.io/node/accelerator/tensorcore_utilization" AND'
+          f' resource.labels.cluster_name = "{info.cluster_name}" AND'
+          f' resource.labels.node_name = "{node_name}"'
+      ),
+      interval=types.TimeInterval({
+          "end_time": {"seconds": int(end_time_utc.timestamp())},
+          "start_time": {"seconds": int(datetime_job_apply_time.timestamp())},
+      }),
+      view="FULL",
+  )
+  time_series_data = mon_client.list_time_series(request)
+  metric_values = {}
+  for ts in time_series_data:
+    accelerator_id = ts.metric.labels["accelerator_id"]
+    closest_point, min_diff = None, float("inf")
+    for point in ts.points:
+      diff = abs(point.interval.end_time.timestamp() - search_timestamp)
+      if diff < min_diff:
+        min_diff, closest_point = diff, point
+    if closest_point:
+      metric_values[accelerator_id] = round(closest_point.value.double_value, 2)
+
+  if not metric_values:
+    logging.error("No matching monitoring data found for node %s.", node_name)
+    return False
+
+  monitoring_values = [
+      metric_values[key]
+      for key in sorted(
+          metric_values.keys(), key=lambda x: int(x.split("-")[-1])
+      )
+  ]
+  return compare_utilization_values(util_values, monitoring_values)
+
+
+@task
+def summarize_results(
+    verification_results: List[bool], active_nodes: List[str]
+):
+  """Summarizes the results of the TensorCore utilization verification.
+
+  This function logs the number of nodes verified, how many passed, and raises
+  an AirflowException if any node failed the verification.
+
+  Args:
+    verification_results: A list of booleans, where each boolean indicates
+      whether the verification passed (True) or failed (False) for a node.
+    active_nodes: A list of node names that were included in the verification.
+  """
+  if not active_nodes:
+    logging.info("No active nodes were found. Grand Result: SKIPPED")
+    return
+
+  total_successful_nodes = sum(1 for result in verification_results if result)
+
+  logging.info("Total nodes verified: %d", len(active_nodes))
+  logging.info("Nodes that passed verification: %d", total_successful_nodes)
+
+  return total_successful_nodes == len(active_nodes)
+
+
+with models.DAG(
+    dag_id="tp_info_tensorcore_utilization_dag",
+    start_date=datetime.datetime(2025, 8, 15),
+    schedule=None,
+    catchup=False,
+    tags=["gke", "tpu-info", "tensorcore-utilization"],
+    description=(
+        "This DAG verifies TensorCore utilization metrics by comparing data"
+        " from Cloud Logging and Cloud Monitoring."
+    ),
+    doc_md="""
+      # TensorCore Utilization Verification DAG
+      # This DAG verifies TensorCore utilization metrics by comparing data from Cloud Logging and Cloud Monitoring.""",
+) as dag:
+
+  cluster_info = Info(
+      project_id=models.Variable.get(
+          "TCU_PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
+      ),
+      cluster_name=models.Variable.get(
+          "TCU_CLUSTER_NAME", default_var="yuna-xpk-v6e"
+      ),
+      region=models.Variable.get(
+          "TCU_REGION", default_var=Region.ASIA_NORTHEAST1.value
+      ),
+      zone=models.Variable.get(
+          "TCU_ZONE", default_var=Zone.ASIA_NORTHEAST1_B.value
+      ),
+      yaml_file_name=models.Variable.get(
+          "YAML_FILE_NAME", default_var="v6e-tpu-info-workload.yaml"
+      ),
+      yaml_path=models.Variable.get(
+          "YAML_PATH",
+          default_var=str(
+              pathlib.Path(__file__).parent.resolve()
+              / "v6e-tpu-info-workload.yaml"
+          ),
+      ),
+      container_name=models.Variable.get(
+          "CONTAINER_NAME", default_var="jax-tpu-job"
+      ),
+  )
+
+  run_workload = BashOperator(
+      task_id="run_workload",
+      # Set KUBECONFIG to an isolated path to prevent race conditions on a
+      # shared Airflow worker. This forces gcloud and kubectl to use a
+      # temporary, task-specific config file instead of the default
+      # ~/.kube/config, ensuring this task connects to the correct cluster
+      # without conflicts.
+      bash_command=f"""
+
+        export KUBECONFIG=/tmp/kubeconfig
+        gsutil cp gs://us-east1-dennis-airflow-tes-a24588e9-bucket/data/{cluster_info.yaml_file_name} \\
+                /tmp/{cluster_info.yaml_file_name}
+
+        gcloud container clusters get-credentials {cluster_info.cluster_name} \
+            --region {cluster_info.region} \
+            --project {cluster_info.project_id}
+
+        kubectl --kubeconfig $KUBECONFIG apply -f /tmp/{cluster_info.yaml_file_name} -n default
+
+        echo $(date -u +"%Y-%m-%dT%H:%M:%S.%3N%:z")
+        """,
+  )
+
+  get_active_nodes_bash = BashOperator(
+      task_id="get_active_nodes_bash",
+      bash_command=f"""
+    export KUBECONFIG=/tmp/kubeconfig
+
+    echo "Configuring kubectl to connect to cluster: {cluster_info.cluster_name}"
+    gcloud container clusters get-credentials {cluster_info.cluster_name} \
+        --region {cluster_info.region} \
+        --project {cluster_info.project_id}
+
+    NODE_LIST_JSON=$(kubectl get pods -n default -o jsonpath='{{.items[*].spec.nodeName}}' | tr ' ' '\\n')
+    echo $NODE_LIST_JSON
+    """,
+      do_xcom_push=True,
+  )
+
+  end_workload = BashOperator(
+      task_id="end_workload",
+      depends_on_past=False,
+      trigger_rule=TriggerRule.ALL_DONE,
+      bash_command=f"""
+        export KUBECONFIG=/tmp/kubeconfig
+
+        gcloud container clusters get-credentials {cluster_info.cluster_name} \\
+            --region {cluster_info.region} \\
+            --project {cluster_info.project_id} \\
+
+        kubectl delete jobsets --all -n default --timeout=60s # Add a timeout for deletion
+        """,
+  )
+
+  job_apply_time = run_workload.output
+
+  logs_are_ready = wait_for_jobset_start_logs(
+      cluster_info, job_apply_time_str=job_apply_time
+  )
+
+  active_node_list = format_node_list(bash_output=get_active_nodes_bash.output)
+
+  run_workload >> logs_are_ready >> get_active_nodes_bash >> active_node_list
+
+  verification_outcomes = verify_tensorcore_utilization.partial(
+      info=cluster_info, job_apply_time=job_apply_time
+  ).expand(node_name=active_node_list)
+
+  summary_task = summarize_results(verification_outcomes, active_node_list)
+
+  summary_task >> end_workload

--- a/dags/tpu_observability/tpu_info_tcu_dags.py
+++ b/dags/tpu_observability/tpu_info_tcu_dags.py
@@ -55,7 +55,6 @@ def compare_tensorcore_utilization_values(
     tolerance: float = 1.0,
 ):
   """Compares two lists of utilization values within a given tolerance."""
-  """Compares two lists of utilization values within a given tolerance."""
   if len(cmd_values) != len(monitoring_values):
     raise AirflowException(
         f"For pod {pod_name}, data count mismatch. TPU-Info has"
@@ -272,9 +271,9 @@ def query_to_wait_for_jobset_start(
           f' resource.labels.node_name = "{pod_name}"'
       ),
       interval=types.TimeInterval({
-              "end_time": {"seconds": int(end_time_utc.timestamp())},
-              "start_time": {"seconds": int(datetime_job_apply_time.timestamp())},
-          }),
+          "end_time": {"seconds": int(end_time_utc.timestamp())},
+          "start_time": {"seconds": int(datetime_job_apply_time.timestamp())},
+      }),
       view="FULL",
   )
   time_series_data = mon_client.list_time_series(request)
@@ -332,7 +331,9 @@ def get_tpu_info_from_pod(kubeconfig: str, pod_name: str) -> str:
 
 @task
 def get_monitoring_data(
-    info: Info, pod_name: str, job_apply_time: str
+    info: Info,
+    pod_name: str,
+    job_apply_time: str
 ) -> List[dict[str, Any]]:
   """Gets Cloud Monitoring data for a specific pod."""
   logging.info("Getting monitoring data for pod: %s...", pod_name)
@@ -380,7 +381,8 @@ def parse_and_compare_utilization(comparison_data: tuple) -> bool:
 
   if not metric_values:
     raise AirflowException(
-        f"Failed to extract metric values from monitoring data for pod {pod_name}."
+        "Failed to extract metric values from monitoring data for pod"
+        f" {pod_name}."
     )
 
   monitoring_values = [
@@ -403,7 +405,8 @@ def parse_and_compare_utilization(comparison_data: tuple) -> bool:
 
   if not util_values:
     raise AirflowException(
-        f"Failed to parse TensorCore utilization from tpu-info output for pod {pod_name}."
+        "Failed to parse TensorCore utilization from tpu-info output for pod"
+        f" {pod_name}."
     )
 
   compare_tensorcore_utilization_values(
@@ -440,11 +443,11 @@ def summarize_results(verification_results: List[bool], active_pods: List[str]):
       "Pods that passed verification (succeeded): %d", total_successful_pods
   )
 
-  if total_successful_pods != len(active_pods):
+  if total_successful_pods != total_expected_pods:
     raise AirflowException(
         "Grand Result: FAILURE - The number of passed comparisons "
         f"({total_successful_pods}) did not meet the threshold of "
-        f"{len(active_pods)}. Active pods: {active_pods}"
+        f"{total_expected_pods}. Active pods: {active_pods}"
     )
 
 
@@ -461,7 +464,8 @@ with models.DAG(
     ),
     doc_md="""
       # TensorCore Utilization Verification DAG
-      # This DAG verifies TensorCore utilization metrics by comparing data from Cloud Logging and Cloud Monitoring.""",
+      # This DAG verifies TensorCore utilization metrics by comparing data from
+      # Cloud Logging and Cloud Monitoring.""",
 ) as dag:
   cluster_info = Info(
       project_id=models.Variable.get(

--- a/dags/tpu_observability/tpu_info_tcu_dags.py
+++ b/dags/tpu_observability/tpu_info_tcu_dags.py
@@ -331,9 +331,7 @@ def get_tpu_info_from_pod(kubeconfig: str, pod_name: str) -> str:
 
 @task
 def get_monitoring_data(
-    info: Info,
-    pod_name: str,
-    job_apply_time: str
+    info: Info, pod_name: str, job_apply_time: str
 ) -> List[dict[str, Any]]:
   """Gets Cloud Monitoring data for a specific pod."""
   logging.info("Getting monitoring data for pod: %s...", pod_name)

--- a/dags/tpu_observability/tpu_info_tcu_dags.py
+++ b/dags/tpu_observability/tpu_info_tcu_dags.py
@@ -335,7 +335,8 @@ def get_tpu_info_from_pod(kubeconfig: str, pod_name: str) -> str:
 def fetch_parse_and_compare_utilization(
     info: Info,
     job_apply_time: str,
-    comparison_data: Tuple[str, str],) -> bool:
+    comparison_data: Tuple[str, str],
+) -> bool:
   """Parses outputs from Monitoring and tpu-info, then compares them."""
   pod_name, tpu_info_text = comparison_data
   logging.info("Getting monitoring data for pod: %s...", pod_name)
@@ -400,9 +401,7 @@ def fetch_parse_and_compare_utilization(
         f" {pod_name}."
     )
 
-  compare_metric_values(
-      util_values, monitoring_values, pod_name
-  )
+  compare_metric_values(util_values, monitoring_values, pod_name)
   return True
 
 
@@ -512,11 +511,8 @@ with models.DAG(
   )
 
   verify_utilization_per_pod = fetch_parse_and_compare_utilization.partial(
-      info=cluster_info,
-      job_apply_time=apply_time
-  ).expand(
-      comparison_data=active_pods.zip(tpu_info_outputs)
-  )
+      info=cluster_info, job_apply_time=apply_time
+  ).expand(comparison_data=active_pods.zip(tpu_info_outputs))
 
   summary = summarize_results.override(
       task_id="summarize_results", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/tpu_info_tcu_dags.py
+++ b/dags/tpu_observability/tpu_info_tcu_dags.py
@@ -265,10 +265,10 @@ def query_to_wait_for_jobset_start(
   request = monitoring_v3.ListTimeSeriesRequest(
       name=f"projects/{info.project_id}",
       filter=(
-          "metric.type ="
-          ' "kubernetes.io/node/accelerator/tensorcore_utilization" AND'
-          f' resource.labels.cluster_name = "{info.cluster_name}" AND'
-          f' resource.labels.node_name = "{pod_name}"'
+          "metric.type = "
+          '"kubernetes.io/container/accelerator/tensorcore_utilization" AND '
+          f'resource.labels.cluster_name = "{info.cluster_name}" AND '
+          f'resource.labels.pod_name = "{pod_name}"'
       ),
       interval=types.TimeInterval({
           "end_time": {"seconds": int(end_time_utc.timestamp())},

--- a/dags/tpu_observability/utils/jobset_yaml_generator.py
+++ b/dags/tpu_observability/utils/jobset_yaml_generator.py
@@ -1,0 +1,176 @@
+"""Utility to generate YAML for a Kubernetes JobSet for TPU workloads."""
+import dataclasses
+from typing import Dict, List, Optional
+import yaml
+
+
+@dataclasses.dataclass
+class YamlConfig:
+  """A data structure to store dynamic parameters for the JobSet YAML.
+
+  This class centralizes all configurable parts of the YAML, making DAGs
+  cleaner and more maintainable.
+  """
+  # Metadata
+  jobset_name: str
+  namespace: str
+
+  # Failure Policy
+  max_restarts: int
+
+  # ReplicatedJob Spec
+  replicated_job_name: str
+  replicas: int
+
+  # Job Template Spec
+  backoff_limit: int
+  completions: int
+  parallelism: int
+
+  # Pod Template Spec
+  node_selector: Optional[Dict[str, str]]
+
+  # Container Spec
+  container_name: str
+  image: str
+  tpu_cores_per_pod: int
+  command: Optional[List[str]]
+  command_args: Optional[List[str]]
+
+  # Volume Spec
+  volume_name: Optional[str]
+  config_map_name: Optional[str]
+
+
+def create_jobset_yaml(
+    jobset_name: str = "tpu-info-v6e-workload",
+    namespace: str = "default",
+    max_restarts: int = 5,
+    replicated_job_name: str = "tpu-job-slice",
+    replicas: int = 2,
+    backoff_limit: int = 0,
+    completions: int = 4,
+    parallelism: int = 4,
+    image: str = "python:3.10",
+    container_name: str = "jax-tpu-job",
+    tpu_cores_per_pod: int = 4,
+    node_selector: Optional[Dict[str, str]] = None,
+    command: Optional[List[str]] = None,
+    command_args: Optional[List[str]] = None,
+    volume_name: Optional[str] = None,
+    config_map_name: Optional[str] = None,
+) -> str:
+  """Dynamically generates the YAML configuration for a Kubernetes JobSet.
+
+  Args:
+      jobset_name (str): The name of the JobSet.
+      namespace (str): The namespace where the JobSet will be created.
+      max_restarts (int): The maximum number of restarts for the JobSet's
+        failure policy.
+      replicated_job_name (str): The name of the ReplicatedJob.
+      replicas (int): The number of replicas for the ReplicatedJob.
+      backoff_limit (int): The backoff limit for the job template.
+      completions (int): The number of completions for each job.
+      parallelism (int): The parallelism for each job.
+      image (str): The container image to use.
+      container_name (str): The name of the container within the pod.
+      tpu_cores_per_pod (int): The number of TPU cores requested per pod.
+      node_selector (Optional[Dict[str, str]]): The node selector for pod
+        scheduling.
+      command (Optional[List[str]]): The main command to run in the container.
+      command_args (Optional[List[str]]): The arguments for the command.
+      volume_name (Optional[str]): The name of the volume to mount.
+      config_map_name (Optional[str]): The name of the ConfigMap to use. If
+        None, no volume is mounted.
+
+  Returns:
+      str: The formatted YAML string.
+  """
+  if node_selector is None:
+    node_selector = {
+        "cloud.google.com/gke-tpu-accelerator": "tpu-v6e-slice",
+        "cloud.google.com/gke-tpu-topology": "4x4",
+    }
+
+  if command_args is None:
+    command_args = ["""
+            echo "sleep..."
+            sleep 10000
+            """]
+
+  jobset_dict = {
+      "apiVersion": "jobset.x-k8s.io/v1alpha2",
+      "kind": "JobSet",
+      "metadata": {
+          "name": jobset_name,
+          "annotations": {
+              "alpha.jobset.sigs.k8s.io/exclusive-topology": (
+                  "cloud.google.com/gke-nodepool"
+              )
+          },
+          "namespace": namespace,
+      },
+      "spec": {
+          "failurePolicy": {
+              "restartStrategy": "BlockingRecreate",
+              "maxRestarts": max_restarts,
+          },
+          "replicatedJobs": [{
+              "name": replicated_job_name,
+              "replicas": replicas,
+              "template": {
+                  "spec": {
+                      "backoffLimit": backoff_limit,
+                      "completions": completions,
+                      "parallelism": parallelism,
+                      "completionMode": "Indexed",
+                      "template": {
+                          "spec": {
+                              "hostNetwork": True,
+                              "dnsPolicy": "ClusterFirstWithHostNet",
+                              "subdomain": "headless-svc",
+                              "restartPolicy": "Never",
+                              "nodeSelector": node_selector,
+                              "containers": [{
+                                  "name": container_name,
+                                  "image": image,
+                                  "ports": [
+                                      {"containerPort": 8471},
+                                      {"containerPort": 8080},
+                                      {"containerPort": 8431},
+                                  ],
+                                  "securityContext": {"privileged": True},
+                                  "command": command,
+                                  "args": command_args,
+                                  "stdin": True,
+                                  "tty": True,
+                                  "resources": {
+                                      "requests": {
+                                          "google.com/tpu": tpu_cores_per_pod
+                                      },
+                                      "limits": {
+                                          "google.com/tpu": tpu_cores_per_pod
+                                      },
+                                  },
+                              }],
+                          }
+                      },
+                  }
+              },
+          }],
+      },
+  }
+
+  if config_map_name:
+    pod_spec = jobset_dict["spec"]["replicatedJobs"][0]["template"]["spec"][
+        "template"
+    ]["spec"]
+    pod_spec["containers"][0]["volumeMounts"] = [
+        {"name": volume_name, "mountPath": "/app"}
+    ]
+    pod_spec["volumes"] = [{
+        "name": volume_name,
+        "configMap": {"name": config_map_name},
+    }]
+
+  return yaml.dump(jobset_dict, sort_keys=False)

--- a/dags/tpu_observability/utils/jobset_yaml_generator.py
+++ b/dags/tpu_observability/utils/jobset_yaml_generator.py
@@ -11,6 +11,7 @@ class YamlConfig:
   This class centralizes all configurable parts of the YAML, making DAGs
   cleaner and more maintainable.
   """
+
   # Metadata
   jobset_name: str
   namespace: str
@@ -93,10 +94,12 @@ def create_jobset_yaml(
     }
 
   if command_args is None:
-    command_args = ["""
+    command_args = [
+        """
             echo "sleep..."
             sleep 10000
-            """]
+            """
+    ]
 
   jobset_dict = {
       "apiVersion": "jobset.x-k8s.io/v1alpha2",
@@ -165,9 +168,10 @@ def create_jobset_yaml(
     pod_spec = jobset_dict["spec"]["replicatedJobs"][0]["template"]["spec"][
         "template"
     ]["spec"]
-    pod_spec["containers"][0]["volumeMounts"] = [
-        {"name": volume_name, "mountPath": "/app"}
-    ]
+    pod_spec["containers"][0]["volumeMounts"] = [{
+        "name": volume_name,
+        "mountPath": "/app",
+    }]
     pod_spec["volumes"] = [{
         "name": volume_name,
         "configMap": {"name": config_map_name},

--- a/dags/tpu_observability/utils/monitoring.py
+++ b/dags/tpu_observability/utils/monitoring.py
@@ -1,0 +1,121 @@
+"""Utility functions for querying Google Cloud Monitoring data."""
+import datetime
+import logging
+from typing import List, Optional, Union
+
+from airflow.exceptions import AirflowException
+from google.cloud import monitoring_v3
+from google.cloud.monitoring_v3 import types
+
+# Define a type hint for the flexible time inputs.
+TimeInput = Union[datetime.datetime, str, int, float]
+
+
+def _to_timestamp_seconds(time_input: TimeInput, arg_name: str) -> int:
+  """Internal helper to convert a flexible time input into an integer Unix timestamp."""
+  if isinstance(time_input, datetime.datetime):
+    return int(time_input.timestamp())
+  elif isinstance(time_input, (int, float)):
+    # Input is already a Unix timestamp, ensure it's an integer.
+    return int(time_input)
+  elif isinstance(time_input, str):
+    try:
+      dt_object = datetime.datetime.fromisoformat(
+          time_input.replace("Z", "+00:00")
+      )
+      return int(dt_object.timestamp())
+    except ValueError:
+      raise AirflowException(
+          f"Invalid ISO 8601 format for {arg_name}: '{time_input}'"
+      )
+  else:
+    raise TypeError(
+        f"Unsupported type for {arg_name}: {type(time_input)}. "
+        "Must be datetime, str (ISO 8601), int, or float (Unix timestamp)."
+    )
+
+
+def query_time_series(
+    project_id: str,
+    filter_str: str,
+    start_time: TimeInput,
+    end_time: TimeInput,
+    aggregation: Optional[types.Aggregation] = None,
+    view: Union[
+        str, types.ListTimeSeriesRequest.TimeSeriesView
+    ] = types.ListTimeSeriesRequest.TimeSeriesView.FULL,
+    page_size: Optional[int] = None,
+) -> List[types.TimeSeries]:
+  """A reusable function to query time series data from Google Cloud Monitoring.
+
+  This function provides a flexible interface to the list_time_series API,
+  with robust error handling and convenient parameter types.
+
+  Args:
+      project_id: The Google Cloud project ID.
+      filter_str: A Cloud Monitoring filter string that specifies which time
+        series should be returned.
+        Example: 'metric.type = "your/metric" AND resource.labels.instance_id
+          = "123"'
+      start_time: The start of the time interval. Can be a datetime object, an
+        ISO 8601 string, or a Unix timestamp (int/float).
+      end_time: The end of the time interval. Can be a datetime object, an ISO
+        8601 string, or a Unix timestamp (int/float).
+      aggregation: An Aggregation object that specifies how to align and combine
+        time series. Defaults to None (raw data).
+      view: The level of detail to return. Can be the TimeSeriesView enum (e.g.,
+        TimeSeriesView.FULL) or a string ("FULL", "HEADERS"). Defaults to FULL.
+      page_size: The maximum number of results to return per page.
+
+  Returns:
+      A list of TimeSeries objects matching the query.
+
+  Raises:
+      ValueError: If the time format or view string is invalid.
+      google.api_core.exceptions.GoogleAPICallError: If the API call fails.
+  """
+  logging.info("Querying monitoring data for project '%s'", project_id)
+  logging.info("Filter: %s", filter_str)
+
+  client = monitoring_v3.MetricServiceClient()
+  project_name = f"projects/{project_id}"
+
+  try:
+    start_seconds = _to_timestamp_seconds(start_time, arg_name="start_time")
+    end_seconds = _to_timestamp_seconds(end_time, arg_name="end_time")
+  except (ValueError, TypeError) as e:
+    logging.error("Time conversion error: %s", e)
+    raise
+
+  interval = types.TimeInterval(
+      start_time={"seconds": start_seconds},
+      end_time={"seconds": end_seconds},
+  )
+
+  if isinstance(view, str):
+    try:
+      # Convert string like "FULL" to the enum member TimeSeriesView.FULL
+      view_enum = types.ListTimeSeriesRequest.TimeSeriesView[view.upper()]
+    except KeyError:
+      raise ValueError(
+          f"Invalid view string: '{view}'. Must be 'FULL' or 'HEADERS'."
+      )
+  else:
+    view_enum = view
+
+  request_kwargs = {
+      "name": project_name,
+      "filter": filter_str,
+      "interval": interval,
+      "view": view_enum,
+  }
+  if aggregation:
+    request_kwargs["aggregation"] = aggregation
+  if page_size:
+    request_kwargs["page_size"] = page_size
+
+  request = monitoring_v3.ListTimeSeriesRequest(**request_kwargs)
+
+  results = client.list_time_series(request)
+
+  return results


### PR DESCRIPTION
# Description
This change adds a new DAG which automates the process of going through the lifecycle of a node pool and verifies whether the node pool status is reported correctly.

This DAG requires an existing cluster. It will create a node-pool under the specified cluster, and clean it up after the tests.

# Tests
  - Dag Name : tpu_info_tensorcore_utilization_dag
  - Airflow test results: https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/tp_info_tensorcore_utilization_dag/grid?tab=graph&dag_run_id=manual__2025-08-20T08%3A51%3A58.290819%2B00%3A00

## Airflow/Composer
- GCP Composer name: `dennis-airflow-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`
 
## Required Variables
- **Cluster Information** (This DAG requires an existing cluster)
  - `PROJECT_ID`: The GCP project ID where the cluster resides. (Default to _**tpu-prod-env-one-vm**_)
  - `CLUSTER_NAME`: The name of the target GKE cluster. (Default to _**yuna-xpk-v6e**_)
  - `REGION`: The region of the GKE cluster. (Default to _**asia-northeast1**_)
  - `ZONE`: The zone of the GKE nodes. (Default to _**asia-northeast1-b**_)
- **Workload Infomation**
  - `YAML_FILE_NAME`: The name of the workload file. (Default to _**v6e-tpu-info-workload.yaml**_)
  - `YAML_PATH`: The workload yaml file path. (Default to _**str(pathlib.Path(__file__).parent.resolve() / "v6e-tpu-info-workload.yaml")**_)
  - `CONTAINER_NAME`: The container name of the workload . (Default to _**jax-tpu-job**_)

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.