### PR TITLE
Add a new DAG that tests ECM checkpoint local restoring feature

### DIFF
--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -66,6 +66,7 @@ BRANDEN_V = "bvandermoon"
 ABHINAV_S = "abhinavclemson"
 XUEFENG_G = "xuefgu"
 CAMILO_Q = "camiloCienet"
+DEPP_L = "ooops678"
 
 # MLCompass
 ORTI_B = "ortibazar"

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -181,7 +181,9 @@ with models.DAG(
           emergency restore mechanism.
       3.  **Validate Restore:** The DAG inspects the application logs to confirm 
           that an `'emergency_restore'` event occurred.
-      4.  **Validate Checkpoint Integrity:** It then verifies that the training job resumed and continued to save checkpoints correctly after the restore, ensuring no data was lost.
+      4.  **Validate Checkpoint Integrity:** It then verifies that the training job 
+          resumed and continued to save checkpoints correctly after the restore, 
+          ensuring no data was lost.
       """,
     concurrency=2,
 ) as dag:

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -1,0 +1,286 @@
+"""A DAG to run MaxText EMC.
+Validates the local checkpoints are restored as expected
+"""
+
+import datetime
+import posixpath
+from typing import Optional
+from dataclasses import dataclass
+
+from airflow import models
+from airflow.utils.task_group import TaskGroup
+
+from dags import composer_env
+from dags import gcs_bucket
+from dags.common import test_owner
+from dags.common.vm_resource import DockerImage
+from dags.common.vm_resource import XpkClusters
+from dags.multipod.configs import gke_config
+from dags.multipod.configs.common import SetupMode
+from dags.orbax.util import validation_util
+from dags.orbax.util import checkpoint_util
+from xlml.utils.xpk import BRANCH_ABHINAV_MTC
+from xlml.utils.gke import zone_to_region
+
+DAG_TEST_NAME = "maxtext_emc_orbax_res_local"
+BASE_OUTPUT_DIR = gcs_bucket.MTC_AUTOMATION_BUCKET
+SCHEDULE = "0 23 * * *" if composer_env.is_prod_env() else None
+
+DOCKER_IMAGES = [(SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_ORBAX_HEAD)]
+RAM_DISK = "/local"
+
+
+@dataclass
+class Checkpointing:
+  """Represents the information of a checkpointing mechanism.
+
+  Attributes:
+    name: A unique name for the checkpointing configuration.
+    use_replicator: Indicates whether a replicator is enabled.
+  """
+
+  name: str
+  use_replicator: bool
+
+
+@dataclass
+class TestConfig:
+  """Holds the general configuration for a checkpointing test."""
+
+  cluster: XpkClusters
+  machine_type: str
+  accelerator: str
+  slices: list[int]
+  model_name: str
+  short_id: str
+  replicator_backup_time: int
+  step: int
+  local_checkpoint_step: int
+  checkpoint_step: int
+  ram_disk_size: str
+  cpc_config: checkpoint_util.CheckpointConfiguration
+
+  def __init__(
+      self,
+      cluster: XpkClusters,
+      machine_type: str,
+      accelerator: str,
+      slices: list[int],
+      model_name: str,
+      short_id: str,
+      replicator_backup_time: int,
+      step: int,
+      local_checkpoint_step: int,
+      ram_disk_size_in_mi: str,
+      checkpoint_step: Optional[int] = None,
+  ):
+    """Initializes the test configurations.
+
+    Args:
+      cluster: The specified cluster to be used for the test.
+      machine_type: The type of machine (e.g., GPU, TPU).
+      accelerator: The type of accelerator (e.g., GPU, TPU) to use.
+      slices: The number of slices to be used.
+      model_name: The name of the model being tested.
+      short_id: A short identifier for the test run.
+      replicator_backup_time: The allowed time for replicator takes to backup
+        and store checkpoint to bucket
+      step: The current step of the training process.
+      local_checkpoint_step: The step interval for local checkpoints.
+      ram_disk_size_in_mi: The size in mebibytes (Mi) about the RAM disk in the
+        CSI driver. The unit is in mebibytes (Mi) but the value should be passed
+        as a string with the unit, e.g., "2G" or "2048M". Defaults to "100G"".
+      checkpoint_step: The step interval for the checkpoints store in the
+        bucket.
+    """
+
+    self.cluster = cluster
+    self.machine_type = machine_type
+    self.accelerator = accelerator
+    self.slices = slices
+    self.model_name = model_name
+    self.short_id = short_id
+    self.replicator_backup_time = replicator_backup_time
+    self.step = step
+    self.local_checkpoint_step = local_checkpoint_step
+    self.checkpoint_step = checkpoint_step
+    self.ram_disk_size = ram_disk_size_in_mi
+    self.cpc_config = checkpoint_util.CheckpointConfiguration(
+        project_id=self.cluster.project,
+        region=zone_to_region(self.cluster.zone),
+        cluster_name=self.cluster.name,
+        gcs_bucket=gcs_bucket.MTC_AUTOMATION_BUCKET.removeprefix("gs://"),
+        ramdisk_memory_in_mi=self.ram_disk_size,
+        machine_type=self.machine_type,
+    )
+
+  def generate_workload_command(
+      self,
+      cp: Checkpointing,
+      checkpoint_dir: str,
+      out_folder: str,
+      slice_number: int,
+  ) -> str:
+    run_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M")
+    run_name = f"{self.short_id}-{cp.name}-{slice_number}x-{self.accelerator}-{run_time}"
+    return (
+        "export TPU_PREMAPPED_BUFFER_SIZE=52428800000 && "
+        "export TPU_PREMAPPED_BUFFER_TRANSFER_THRESHOLD_BYTES=52428800000 && "
+        "python3 -m MaxText.train MaxText/configs/base.yml "
+        "remat_policy=full "
+        "global_parameter_scale=1 "
+        f"base_output_directory={posixpath.join(BASE_OUTPUT_DIR, out_folder)} "
+        "dataset_type=synthetic "
+        f"steps={self.step} "
+        "per_device_batch_size=1 "
+        "max_target_length=256 "
+        f"model_name={self.model_name} "
+        "per_device_batch_size=2 "
+        "reuse_example_batch=1 "
+        "enable_emergency_checkpoint=true "
+        f"checkpoint_period={self.checkpoint_step} "
+        f"local_checkpoint_directory={checkpoint_dir} "
+        f"local_checkpoint_period={self.local_checkpoint_step} "
+        f"run_name={run_name}",
+    )
+
+
+with models.DAG(
+    dag_id=DAG_TEST_NAME,
+    start_date=datetime.datetime(2025, 6, 30),
+    schedule_interval=SCHEDULE,
+    catchup=False,
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "nightly",
+        "orbax",
+    ],
+    description="DAG to verify MaxText's emergency restore from local checkpoints after a node interruption.",
+    doc_md="""
+      # MaxText Emergency Restore from Local Checkpoint Validation DAG
+
+      ### Description
+      This DAG validates the emergency restore capability of MaxText from local
+      checkpoints. It simulates a node failure during a training job and verifies
+      that the job can successfully resume from the last saved local checkpoint.
+      This test is critical for ensuring the resilience of long-running training
+      jobs against hardware failures.
+
+      ### Prerequisites
+      - An existing GKE cluster with the Multi-tier Checkpointing (MTC)
+        configuration enabled, which provides the necessary CSI driver for
+        RAM disk (`/local`).
+      - A GCS bucket for storing logs and base model outputs.
+
+      ### Procedures
+      1.  **Apply MTC Configuration:** A `CheckpointingPolicyConfiguration` (CPC)
+          is applied to the cluster to set up the MTC environment.
+      2.  **Run MaxText with Interruption:** A MaxText training job is initiated.
+          During its execution, a node interruption is simulated to trigger the
+          emergency restore mechanism.
+      3.  **Validate Restore:** The DAG inspects the application logs to confirm that an `'emergency_restore'` event occurred.
+      4.  **Validate Checkpoint Integrity:** It then verifies that the training job resumed and continued to save checkpoints correctly after the restore, ensuring no data was lost.
+      """,
+    concurrency=2,
+) as dag:
+  test_configs = [
+      TestConfig(
+          cluster=XpkClusters.TPU_V5P_128_CLUSTER_ORBAX,
+          machine_type="ct5p-hightpu-4t",
+          accelerator="v5p-128",
+          slices=[2],
+          model_name="llama2-7b",
+          short_id="max-res-loc",
+          replicator_backup_time=30,
+          step=150,
+          checkpoint_step=20,
+          local_checkpoint_step=20,
+          ram_disk_size_in_mi="800000Mi",
+      ),
+  ]
+
+  checkpointing = Checkpointing(name="emc", use_replicator=False)
+
+  for mode, image in DOCKER_IMAGES:
+    for test_config in test_configs:
+      for slice_num in test_config.slices:
+        wait_delete_cpc = checkpoint_util.wait_for_cpc_deletion.override(
+            trigger_rule="all_done"
+        )(test_config.cpc_config)
+
+        apply_cpc = checkpoint_util.apply_cpc(test_config.cpc_config)
+        workload_command = test_config.generate_workload_command(
+            cp=checkpointing,
+            checkpoint_dir=RAM_DISK,
+            out_folder="maxtext_emc_orbax_res_local",
+            slice_number=slice_num,
+        )
+
+        start_time = validation_util.generate_timestamp()
+        maxtext_chkpt_run_test = gke_config.get_gke_config(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}-{checkpointing.name}",
+            run_model_cmds=workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+        ).run_with_node_interruption(
+            ramdisk_directory=RAM_DISK,
+            mtc_enabled=True,
+            xpk_branch=BRANCH_ABHINAV_MTC,
+            skip_post_process=True,
+        )
+
+        cleanup_command = (f"rm -rf {RAM_DISK}/*",)
+        ram_disk_cleanup = gke_config.get_gke_config(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}-cl",
+            run_model_cmds=cleanup_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+        ).run(
+            ramdisk_directory=RAM_DISK,
+            mtc_enabled=True,
+            xpk_branch=BRANCH_ABHINAV_MTC,
+            skip_post_process=True,
+        )
+
+        end_time = validation_util.generate_timestamp()
+
+        validate_is_restoring = validation_util.validate_log_exist(
+            project_id=test_config.cluster.project,
+            location=zone_to_region(test_config.cluster.zone),
+            cluster_name=test_config.cluster.name,
+            text_filter="\"'event_type': 'emergency_restore'\"",
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        total_steps = test_config.step
+        k = test_config.local_checkpoint_step
+        last_step = test_config.step - 1
+        steps_to_validate = [*range(0, total_steps, k), last_step]
+
+        validate_log = validation_util.validate_checkpoint_at_steps_are_saved(
+            project_id=test_config.cluster.project,
+            location=zone_to_region(test_config.cluster.zone),
+            cluster_name=test_config.cluster.name,
+            start_time=start_time,
+            end_time=end_time,
+            steps_to_validate=steps_to_validate,
+        )
+
+        (
+            wait_delete_cpc
+            >> apply_cpc
+            >> start_time
+            >> maxtext_chkpt_run_test
+            >> ram_disk_cleanup
+            >> end_time
+            >> validate_is_restoring
+            >> validate_log
+        )

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -179,7 +179,8 @@ with models.DAG(
       2.  **Run MaxText with Interruption:** A MaxText training job is initiated.
           During its execution, a node interruption is simulated to trigger the
           emergency restore mechanism.
-      3.  **Validate Restore:** The DAG inspects the application logs to confirm that an `'emergency_restore'` event occurred.
+      3.  **Validate Restore:** The DAG inspects the application logs to confirm 
+          that an `'emergency_restore'` event occurred.
       4.  **Validate Checkpoint Integrity:** It then verifies that the training job resumed and continued to save checkpoints correctly after the restore, ensuring no data was lost.
       """,
     concurrency=2,

--- a/dags/orbax/util/validation_util.py
+++ b/dags/orbax/util/validation_util.py
@@ -313,3 +313,33 @@ def list_log_entries(
 
   logging.info(f"Log filter constructed: {log_filter}")
   return list(logging_client.list_entries(filter_=log_filter))
+
+
+@task
+def validate_log_exist(
+    project_id: str,
+    location: str,
+    cluster_name: str,
+    namespace: str = "default",
+    pod_pattern: str = "*",
+    container_name: Optional[str] = None,
+    text_filter: Optional[str] = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
+) -> None:
+  """Validate the workload log text filter it is found during training."""
+
+  entries = list_log_entries(
+      project_id=project_id,
+      location=location,
+      cluster_name=cluster_name,
+      namespace=namespace,
+      pod_pattern=pod_pattern,
+      container_name=container_name,
+      text_filter=text_filter,
+      start_time=start_time,
+      end_time=end_time,
+  )
+
+  if not entries:
+    raise AirflowFailException("The log history is empty!")

--- a/plugins/allow_list.txt
+++ b/plugins/allow_list.txt
@@ -22,3 +22,4 @@ interruption_validation_gke_migrate_on_hwsw_maintenance
 interruption_validation_gke_other
 maxtext_emc_and_mtc_orbax_save_local
 maxtext_mtc_orbax_save_gcs
+maxtext_emc_orbax_res_local

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -201,6 +201,184 @@ class XpkTask(BaseTask):
 
     return group
 
+  def run_with_node_interruption(
+      self,
+      *,
+      gcs_location: Optional[airflow.XComArg] = None,
+      use_vertex_tensorboard: bool = False,
+      use_pathways: bool = False,
+      skip_post_process: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      last_node: bool = False,
+  ) -> DAGNode:
+    """Run a test job within a docker image.
+
+       Will run a workload with an organic interruption of a GKE node.
+       Then is expected to automatically restart and continuing running.
+
+    Attributes:
+      gcs_location: GCS path for all artifacts of the test.
+      use_vertex_tensorboard: Set to True to view workload data on
+        Vertex AI Tensorboard.
+
+    Returns:
+      A task group with the following tasks chained: run_model and
+      post_process.
+    """
+    with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
+      run_model, gcs_path = self.run_model_with_node_interruption(
+          gcs_location,
+          use_vertex_tensorboard,
+          use_pathways,
+          ramdisk_directory,
+          mtc_enabled,
+          xpk_branch,
+          last_node,
+      )
+      if not skip_post_process:
+        run_model >> self.post_process(gcs_path)
+    return group
+
+  def run_model_with_node_interruption(
+      self,
+      gcs_location: Optional[airflow.XComArg] = None,
+      use_vertex_tensorboard: bool = False,
+      use_pathways: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      last_node: bool = False,
+  ) -> DAGNode:
+    """Run the TPU/GPU test in `task_test_config` using xpk.
+
+      Different behaviour for testing node interruption.
+
+    Attributes:
+      gcs_location: GCS path for all artifacts of the test.
+      use_vertex_tensorboard: Set to True to view workload data on
+        Vertex AI Tensorboard.
+
+    Returns:
+      A DAG node that executes the model test.
+    """
+    with TaskGroup(group_id="run_model") as group:
+      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+      if gcs_location:
+        gcs_path = gcs_location
+      else:
+        gcs_path = name_format.generate_gcs_folder_location(
+            self.task_test_config.gcs_subfolder,
+            self.task_test_config.benchmark_id,
+        )
+
+      launch_workload_with_interruption = (
+          self.launch_workload_with_node_interruption(
+              workload_id,
+              gcs_path,
+              use_vertex_tensorboard,
+              use_pathways,
+              ramdisk_directory,
+              mtc_enabled,
+              xpk_branch,
+              last_node,
+          )
+      )
+
+      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
+          timeout=int(self.task_test_config.timeout.total_seconds()),
+      )(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=self.task_gcp_config.zone[:-2],
+          cluster_name=self.task_test_config.cluster_name,
+      )
+
+      clean_up_workload = xpk.clean_up_workload(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          xpk_branch=xpk_branch,
+      )
+
+      (
+          (workload_id, gcs_path)
+          >> launch_workload_with_interruption
+          >> wait_for_workload_completion
+          >> clean_up_workload
+      )
+    return group, gcs_path
+
+  def launch_workload_with_node_interruption(
+      self,
+      workload_id: str,
+      gcs_path: str,
+      use_vertex_tensorboard: bool,
+      use_pathways: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      last_node: bool = False,
+  ) -> DAGNode:
+    """Create the workload and wait for it to provision."""
+    with TaskGroup(group_id="launch_workload_with_interruption") as group:
+      run_workload = xpk.run_workload.override(
+          owner=self.task_test_config.task_owner
+      )(
+          task_id="run_workload",
+          cluster_project=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          benchmark_id=self.task_test_config.benchmark_id,
+          workload_id=workload_id,
+          gcs_path=gcs_path,
+          docker_image=self.task_test_config.docker_image,
+          accelerator_type=self.task_test_config.accelerator.name,
+          run_cmds=self.task_test_config.test_script,
+          num_slices=self.task_test_config.num_slices,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=use_pathways,
+          ramdisk_directory=ramdisk_directory,
+          mtc_enabled=mtc_enabled,
+          xpk_branch=xpk_branch,
+      )
+      wait_for_workload_start = xpk.wait_for_workload_start.override(
+          timeout=self.workload_provision_timeout.total_seconds()
+      )(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=self.task_gcp_config.zone[:-2],
+          cluster_name=self.task_test_config.cluster_name,
+      )
+      wait_to_reach_step_to_interrupt = xpk.wait_for_reach_step_to_interrupt(
+          task_id="wait_to_reach_step_to_interrupt",
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=self.task_gcp_config.zone[:-2],
+          cluster_name=self.task_test_config.cluster_name,
+          step_to_interrupt="40",
+      )
+      run_node_interruption = xpk.delete_node.override(
+          owner=self.task_test_config.task_owner
+      )(
+          project=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          workload_id=workload_id,
+          dry_run=False,
+          last_node=last_node,
+      )
+
+      (
+          run_workload
+          >> wait_for_workload_start
+          >> wait_to_reach_step_to_interrupt
+          >> run_node_interruption
+      )
+      return group
+
   def run_with_name_gen_and_quarantine(
       self,
       quarantine_task_group,


### PR DESCRIPTION
# Description

This change adds a new DAG which automates the process of checking ECM checkpoint are restored locally as expected.

# Tests
- Dag Name: maxtext_emc_orbax_res01_restore_local
- Airflow test results: https://00bd7f16ee7e45da99e04dee351b40d8-dot-us-east1.composer.googleusercontent.com/dags/maxtext_emc_orbax_res01_restore_local/grid (tested with gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly:2025-08-18 docker image)

## Airflow/Composer
- GCP Composer name: `ml-automation-solutions-orbax` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Required Variables
- **Cluster Information** (This DAG requires an existing cluster)
  - `PROJECT_ID`: The GCP project ID where the cluster resides. (Default to **_tpu-prod-env-one-vm_**)
  - `CLUSTER_NAME`: The name of the target GKE cluster. (Default to **_qmcgarry-auto_**)
  - `REGION`: The region of the GKE cluster. (Default to **_asia-northeast1_**)
  - `ZONE`: The zone of TPU chips. (Default to **_asia-northeast1-b_**)
- **Workload Infomation**
  - `YAML_FILE_NAME`: The name of the workload file. (Default to **_workload.yaml_**)
  - `YAML_PATH`: The workload yaml file path. (Default to **_gs://cienet-tpu-observability-airflow/workloads/_**)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.