### PR TITLE
reply MrGeislinger's comment

### DIFF
--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -244,8 +244,8 @@ def fetch_interruption_log_records(
     events for each resource.
 
   Raises:
-    RuntimeError: If the number of log entries reaches the `max_log_results`
-      limit.
+    RuntimeError: Raised when log entries exceed a hardcoded limit, in
+      which case a manual inspection may be more appropriate.
   """
   start_time = datetime.datetime.fromtimestamp(
       time_range.start, tz=datetime.timezone.utc
@@ -296,7 +296,7 @@ def fetch_interruption_log_records(
           int(aware_timestamp.timestamp())
       )
 
-  if entry_count == max_results:
+  if entry_count >= max_results:
     raise RuntimeError(f'Log entries limit reached ({max_results} entries).')
 
   return list(event_records.values())


### PR DESCRIPTION
# Description

reply [MrGeislinger's comment](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/863#discussion_r2325491134)

Rephrase the docstring and check entry_count >= max_results instead of
equality.

# Tests

GCE DAGs

- **interruption_validation_gce_bare_metal_preemption**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_bare_metal_preemption/grid)
- **interruption_validation_gce_defragmentation**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_defragmentation/grid)
- **interruption_validation_gce_eviction**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_eviction/grid)
- **interruption_validation_gce_host_error**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_host_error/grid)
- **interruption_validation_gce_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_hwsw_maintenance/grid)
- **interruption_validation_gce_migrate_on_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_migrate_on_hwsw_maintenance/grid)
- **interruption_validation_gce_other**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gce_other/grid)

GKE DAGs

- **interruption_validation_gke_bare_metal_preemption**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_bare_metal_preemption/grid)
- **interruption_validation_gke_defragmentation**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_defragmentation/grid)
- **interruption_validation_gke_eviction**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_eviction/grid)
- **interruption_validation_gke_host_error**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_host_error/grid)
- **interruption_validation_gke_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_hwsw_maintenance/grid)
- **interruption_validation_gke_migrate_on_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_migrate_on_hwsw_maintenance/grid)
- **interruption_validation_gke_other**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/interruption_validation_gke_other/grid)


# Airflow/Composer

- GCP Composer name: `dennis-airflow-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

# Required Variables

- `INTERRUPTION_PROJECT_ID`:
  - The GCP project ID where the metric and log from. (Default to _**tpu-prod-env-one-vm**_)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.