### PR TITLE
fix setup error and some run_model error

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,8 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - maxtext/dev/**
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,13 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - maxtext/dev/**
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,14 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - maxtext/dev/**
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -1,7 +1,12 @@
 name: Require Checklist
 on:
   pull_request:
+    branch:
+      - maxtext/dev/**
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,8 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
+    branch:
+      - maxtext/dev/**
     types: [opened, synchronize, edited]
 
   push:


### PR DESCRIPTION
# Description

#### **Resolved Issues**
1. `setup`: Corrected the script to install and use `Python 3.12`, as required by MaxText. Adopted the official MaxText standard procedure, using its `setup.sh` script which leverages the `uv` installer with the `--resolution=lowest flag`.
2. `run_model`: Set the `MAXENGINE_CONFIG_FILEPATH` and `TOKENIZER_PATH` environment variables to point to the correct locations.

----

#### **Current Blocker**
Now facing an issue in `run_model`:
```
jaxlib._jax.XlaRuntimeError: INVALID_ARGUMENT: Couldn't find parameter 1
```
**Possible Root Cause:** This error indicates a version incompatibility between the latest MaxText source code and the public pre-trained model weights (`gs://inference-benchmarks/models/llama2-70b-chat/quant/int8_`)we are using.

# Tests

[maxtext_inference_offline_benchmark_0916_fix](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/maxtext_inference_offline_benchmark_0916_fix/grid?search=maxtext_inference_offline_benchmark_0916_fix&task_id=maxtext_inference_offline_benchmark-v6e-8.run_model&dag_run_id=manual__2025-09-16T07%3A11%3A51.555432%2B00%3A00&tab=logs)

[setup](https://paste.googleplex.com/6481808162160640)

[run_model](https://paste.googleplex.com/6711744554729472)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [ ] I have made or will make corresponding changes to the doc if needed.