### PR TITLE
Fixs for code review

### DIFF
--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -73,7 +73,7 @@ with models.DAG(
       name="emc", enable_multi_tier_checkpointing=False
   )
   test_configs = [
-      test_config_util.Checkpointing(
+      test_config_util.TestConfig(
           cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           machine_type="ct5p-hightpu-4t",
           accelerator="v5p-128",
@@ -84,7 +84,7 @@ with models.DAG(
           step=150,
           checkpoint_step=20,
           local_checkpoint_step=20,
-          base_dir=test_config_utilDEFAULT_BUCKET,
+          base_dir=test_config_util.DEFAULT_BUCKET,
       ),
   ]
 


### PR DESCRIPTION
# Description

This change adds a new DAG which automates the process of checking ECM checkpoint are restored locally as expected.

# Tests
- Dag Name: maxtext_emc_orbax_res01_restore_local
- Airflow test results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/dags/maxtext_emc_orbax_res_local/grid (tested with gcr.io/tpu-prod-env-multipod/maxtext_jax_nightly@sha256:f8cd199fd622a4619eb6945bf84f9b20625b29f5ff30edcbeb4b05b6699cce7b docker image)

## Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Required Variables
- **Cluster Information** (This DAG requires an existing cluster)
  - `PROJECT_ID`: The GCP project ID where the cluster resides. (Default to **_tpu-prod-env-one-vm_**)
  - `CLUSTER_NAME`: The name of the target GKE cluster. (Default to **_qmcgarry-auto_**)
  - `REGION`: The region of the GKE cluster. (Default to **_asia-northeast1_**)
  - `ZONE`: The zone of TPU chips. (Default to **_asia-northeast1-b_**)
- **Workload Infomation**
  - `YAML_FILE_NAME`: The name of the workload file. (Default to **_workload.yaml_**)
  - `YAML_PATH`: The workload yaml file path. (Default to **_gs://cienet-tpu-observability-airflow/workloads/_**)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.