### PR TITLE
Fix dag06 for code review and conflicts (maxtext_emc_orbax_res_gcs)

### DIFF
--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -12,13 +12,7 @@ from dags.common.vm_resource import DockerImage
 from dags.common.vm_resource import XpkClusters
 from dags.multipod.configs import gke_config
 from dags.multipod.configs.common import SetupMode
-<<<<<<< HEAD
 from dags.orbax.util import checkpoint_util, test_config_util, validation_util
-=======
-from dags.orbax.util import checkpoint_util
-from dags.orbax.util import orbax
-from dags.orbax.util import validation_util
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
 from xlml.utils.gke import zone_to_region
 from xlml.utils.xpk import BRANCH_ABHINAV_MTC
 
@@ -79,11 +73,7 @@ with models.DAG(
       name="emc", enable_multi_tier_checkpointing=False
   )
   test_configs = [
-<<<<<<< HEAD
       test_config_util.TestConfig(
-=======
-      orbax.TestConfig(
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
           cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           machine_type="ct5p-hightpu-4t",
           accelerator="v5p-128",
@@ -118,10 +108,7 @@ with models.DAG(
         workload_command = test_config.generate_workload_command(
             checkpoint_dir=test_config_util.DEFAULT_RAM_DISK,
             run_name=run_name,
-<<<<<<< HEAD
             slice_num=slice_num,
-=======
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
             out_folder="maxtext_emc_orbax_res_local",
             enable_multi_tier_checkp=checkpointing.enable_multi_tier_checkpointing,
         )
@@ -154,10 +141,7 @@ with models.DAG(
                 project_id=test_config.cluster.project,
                 location=zone_to_region(test_config.cluster.zone),
                 cluster_name=test_config.cluster.name,
-<<<<<<< HEAD
                 pod_pattern=".*0-0",
-=======
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
                 interrupt_at_step=40,
                 start_time=start_time,
                 end_time=end_time,

--- a/dags/orbax/maxtext_emc_save_gcs.py
+++ b/dags/orbax/maxtext_emc_save_gcs.py
@@ -71,11 +71,7 @@ with models.DAG(
       name="emc", enable_multi_tier_checkpointing=False
   )
   test_configs = [
-<<<<<<< HEAD
       test_config_util.TestConfig(
-=======
-      orbax.TestConfig(
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
           cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           machine_type="ct5p-hightpu-4t",
           accelerator="v5p-128",

--- a/dags/orbax/maxtext_mtc_emergency_save_local.py
+++ b/dags/orbax/maxtext_mtc_emergency_save_local.py
@@ -23,10 +23,7 @@ from xlml.utils.xpk import BRANCH_ABHINAV_MTC
 from xlml.utils.gke import zone_to_region
 from dags.orbax.util import test_config_util
 
-<<<<<<< HEAD
 
-=======
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
 SCHEDULE = "0 13 * * *" if composer_env.is_prod_env() else None
 DAG_TEST_NAME = "maxtext_emc_and_mtc_orbax_save_local"
 
@@ -85,11 +82,7 @@ with models.DAG(
   # Only one set of test configurations (e.g., v5p-128) is supported at the moment.
   # Other configurations (e.g., v5e and/or v6e) may be introduced later.
   test_configs = [
-<<<<<<< HEAD
       test_config_util.TestConfig(
-=======
-      orbax.TestConfig(
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
           cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           machine_type="ct5p-hightpu-4t",
           accelerator="v5p-128",

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -66,11 +66,7 @@ with models.DAG(
     concurrency=2,
 ) as dag:
   test_configs = [
-<<<<<<< HEAD
       test_config_util.TestConfig(
-=======
-      orbax.TestConfig(
->>>>>>> aa886409 (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
           cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           machine_type="ct5p-hightpu-4t",
           accelerator="v5p-128",

--- a/dags/orbax/maxtext_mtc_save_gcs.py
+++ b/dags/orbax/maxtext_mtc_save_gcs.py
@@ -73,11 +73,7 @@ with models.DAG(
       name="mtc", enable_multi_tier_checkpointing=True
   )
   test_configs = [
-<<<<<<< HEAD
       test_config_util.TestConfig(
-=======
-      orbax.TestConfig(
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
           cluster=XpkClusters.TPU_V5P_128_CLUSTER,
           machine_type="ct5p-hightpu-4t",
           accelerator="v5p-128",

--- a/dags/orbax/util/validation_util.py
+++ b/dags/orbax/util/validation_util.py
@@ -432,17 +432,12 @@ def validate_restored_correct_checkpoint(
   if not entries:
     raise AirflowFailException("No event_type found in the log.")
 
-<<<<<<< HEAD
   saved_steps_before_restore = []
-=======
-  save_step_before_restore = None
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)
   for entry in entries:
     if not isinstance(entry, logging_api.StructEntry):
       raise AirflowFailException(
           "Log entry must be contain a jsonPayload attribute."
       )
-<<<<<<< HEAD
 
     message = entry.payload.get("message")
 
@@ -524,36 +519,3 @@ def get_gcs_checkpoint(output_path: str) -> List[str]:
   files = hook.list(bucket_name=bucket_name, prefix=prefix)
   logging.info(f"Files ===> {files}")
   return files
-=======
-    message = entry.payload.get("message")
-    if not message:
-      continue
-
-    if re.search(r"'event_type': 'save'", message):
-      match = re.search(r"'step': (\d+)", message)
-      if match:
-        save_step_before_restore = int(match.group(1))
-      else:
-        raise AirflowFailException(
-            f"Found save event with no step number, message: {message}"
-        )
-    elif re.search(r"'event_type': '(emergency_)?restore'", message):
-      logging.info("Found restore event: %s", message)
-      if save_step_before_restore is None:
-        raise AirflowFailException(
-            "Found a restore event before any save event."
-        )
-      match = re.search(r"'step':\s*(?:np\.int32\()?(\d+)", message)
-      if match and int(match.group(1)) >= interrupt_at_step:
-        return
-
-      raise AirflowFailException(
-          f"Restore event did not contain the expected step. Expect step "
-          f"{match.group(1)} to be greater than or equal to step "
-          f"{interrupt_at_step}, but the log was: {message}."
-      )
-
-  raise AirflowFailException(
-      "Failed to validate that restored happened at correct step."
-  )
->>>>>>> 0b0501bd (Add a new DAG that tests Maxtext EMC restoring from GCS feature)


### PR DESCRIPTION
# Description
A DAG to test MaxText EMC restoring from GCS feature.

# Tests
- Dag Name: `maxtext_emc_orbax_res_gcs`
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/dags/maxtext_emc_orbax_res_gcs/grid

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.