### PR TITLE
reply reviewer's comment - have each parameter on its own separate line

### DIFF
--- a/dags/tpu_observability/interruption_validation_dag.py
+++ b/dags/tpu_observability/interruption_validation_dag.py
@@ -543,7 +543,8 @@ def create_interruption_dag(
                 proper_time_range: TimeRange,
             ) -> List[EventRecord]:
               return fetch_interruption_metric_records(
-                  configs, proper_time_range
+                  configs,
+                  proper_time_range,
               )
 
             proper_time_range = determine_time_range(configs)
@@ -556,7 +557,8 @@ def create_interruption_dag(
                 proper_time_range,
             )
             check_event_count = validate_interruption_count(
-                metric_records, log_records
+                metric_records,
+                log_records,
             )
 
             (


### PR DESCRIPTION
# Description

Improve the existing validate_interruption_count_* DAG.

This change replies reviewer's comment: have each parameter on its own separate line.

# Tests

GCE DAGs

- **validate_interruption_count_gce_bare_metal_preemption**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_bare_metal_preemption/grid)
- **validate_interruption_count_gce_defragmentation**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_defragmentation/grid)
- **validate_interruption_count_gce_eviction**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_eviction/grid)
- **validate_interruption_count_gce_host_error**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_host_error/grid)
- **validate_interruption_count_gce_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_hwsw_maintenance/grid)
- **validate_interruption_count_gce_migrate_on_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_migrate_on_hwsw_maintenance/grid)
- **validate_interruption_count_gce_other**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gce_other/grid)

GKE DAGs

- **validate_interruption_count_gke_bare_metal_preemption**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_bare_metal_preemption/grid)
- **validate_interruption_count_gke_defragmentation**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_defragmentation/grid)
- **validate_interruption_count_gke_eviction**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_eviction/grid)
- **validate_interruption_count_gke_host_error**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_host_error/grid)
- **validate_interruption_count_gke_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_hwsw_maintenance/grid)
- **validate_interruption_count_gke_migrate_on_hwsw_maintenance**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_migrate_on_hwsw_maintenance/grid)
- **validate_interruption_count_gke_other**: [Test Results](https://8ea616621be647bea7fd8d5e664abcb1-dot-us-east1.composer.googleusercontent.com/dags/validate_interruption_count_gke_other/grid)


# Airflow/Composer

- GCP Composer name: `dennis-airflow-test` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
