### PR TITLE
Add TPU observability DAGs change_node_pool_label.py (haven't tested yet)

### DIFF
--- a/dags/tpu_observability/change_node_pool_label.py
+++ b/dags/tpu_observability/change_node_pool_label.py
@@ -1,0 +1,108 @@
+"""A DAG to validate the status of a GKE node pool after changing its node label."""
+
+import datetime
+
+from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
+
+from dags.common.vm_resource import Project, Region, Zone
+from dags.map_reproducibility.utils import constants
+from dags.tpu_observability.utils import node_pool_util as node_pool
+
+
+with models.DAG(
+    dag_id="change_node_pool_label",
+    start_date=datetime.datetime(2025, 9, 30),
+    schedule=constants.Schedule.WEEKDAY_PST_6PM_EXCEPT_THURSDAY,
+    catchup=False,
+    tags=["gke", "tpu-observability", "change-node-pool-label"],
+    description=(
+        "This DAG tests the GKE nodel pool's status by changing its label and "
+        "confirming the state transitions are correct."
+    ),
+    doc_md="""
+      # GKE Node Pool Status Validation DAG
+
+      ### Description
+      This DAG automates the process of creating a GKE
+      node pool, changing its node pool label, and verifying whether the node pool status is reported correctly.
+
+      ### Prerequisites
+      This test requires an existing cluster.
+
+      ### Procedures
+      It creates a node pool, waits for it from provisioning to be running,
+      changes the node pool label to trigger reconciliation, waits for it to become
+      running again, and finally cleans up.
+      The node pool will be cleaned up after the tests.
+    """,
+) as dag:
+  node_pool_info = node_pool.Info(
+      project_id=models.Variable.get(
+          "PROJECT_ID", default_var=Project.TPU_PROD_ENV_ONE_VM.value
+      ),
+      cluster_name=models.Variable.get(
+          "CLUSTER_NAME", default_var="ryan-cluster-asia"
+      ),
+      node_pool_name=models.Variable.get(
+          "NODE_POOL_NAME", default_var="ryan-v6e-autotest"
+      ),
+      location=models.Variable.get(
+          "LOCATION", default_var=Region.ASIA_NORTHEAST1.value
+      ),
+      node_locations=models.Variable.get(
+          "NODE_LOCATIONS", default_var=Zone.ASIA_NORTHEAST1_B.value
+      ),
+      num_nodes=models.Variable.get("NUM_NODES", default_var=4),
+      machine_type=models.Variable.get(
+          "MACHINE_TYPE", default_var="ct6e-standard-4t"
+      ),
+      tpu_topology=models.Variable.get("TPU_TOPOLOGY", default_var="4x4"),
+  )
+
+  task_id = "create_node_pool"
+  create_node_pool = node_pool.create.override(task_id=task_id)(
+      node_pool=node_pool_info
+  )
+
+  task_id = "wait_for_provisioning"
+  wait_for_provisioning = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.PROVISIONING
+  )
+
+  task_id = "wait_for_running"
+  wait_for_running = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.RUNNING
+  )
+
+  task_id = "change_node_label"
+  change_node_label = node_pool.change_node_label.override(task_id=task_id)(
+      node_pool=node_pool_info
+  )
+
+  task_id = "wait_for_reconciling"
+  wait_for_reconciling = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.RECONCILING
+  )
+
+  task_id = "wait_for_recovered"
+  wait_for_recovered = node_pool.wait_for_status.override(task_id=task_id)(
+      node_pool=node_pool_info, status=node_pool.Status.RUNNING
+  )
+
+  task_id = "cleanup_node_pool"
+  cleanup_node_pool = node_pool.delete.override(
+      task_id=task_id, trigger_rule=TriggerRule.ALL_DONE
+  )(node_pool=node_pool_info).as_teardown(
+      setups=create_node_pool,
+  )
+
+  normal_flow = (
+      create_node_pool
+      >> wait_for_provisioning
+      >> wait_for_running
+      >> change_node_label
+      >> wait_for_reconciling
+      >> wait_for_recovered
+      >> cleanup_node_pool
+  )

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -405,3 +405,28 @@ def wait_for_availability(
       timeout,
   )
   return availability == state
+
+@task
+def change_node_label(node_pool: Info) -> None:
+  """Change the label of the specified GKE node pool.
+
+  This function changes the label of the given node pool.
+
+  Args:
+      node_pool: An instance of the Info class that encapsulates
+        the configuration and metadata of a GKE node pool.
+  """
+
+  command = (
+      f"gcloud container node-pools update {node_pool.node_pool_name} "
+      f"--cluster={node_pool.cluster_name} "
+      "--labels=test_key=test_value "
+      f"--region={node_pool.node_locations} "
+      "--quiet"
+  )
+
+  process = subprocess.run(
+      command, shell=True, check=True, capture_output=True, text=True
+  )
+  logging.info("STDOUT message: %s", process.stdout)
+  logging.info("STDERR message: %s", process.stderr)


### PR DESCRIPTION
# Description
This change adds a new DAG, which validate the status of a GKE node pool after changing its node label.

# Tests
- Dag Name: change_node_pool_label
- Airflow test results: WIP
This automation is crucial for ensuring the node pool status is reported correctly after changing its node pool label.

This DAG requires access to a pre-existing GKE cluster to run its tests.
Use gcloud command create cluster manually or 
[Cluster Env:](https://pantheon.corp.google.com/kubernetes/clusters/details/asia-northeast1/ryan-cluster-asia/nodes?project=tpu-prod-env-one-vm&supportedpurview=project)
- Project ID: tpu-prod-env-one-vm
- Cluster Name: ryan-cluster-asia
- Location: asia-northeast1

[Airflow/Composer Env: ](WIP)
 
Need setup/obtain parameters for a DAG:
Following this [doc](https://docs.google.com/document/d/19QTZGHBQr8hZ_JswOxQkw0-tUWoSCN7FrlxIeUwBEno/edit?resourcekey=0-QJ8ofJTT3AQDifmSBitdDQ&tab=t.0#heading=h.oi4pw8q0k50h)
- PROJECT_ID: The target Google Cloud Project ID. (Default: tpu-prod-env-one-vm)
- CLUSTER_NAME: The name of the existing GKE cluster. (Default: ryan-cluster-asia)
- NODE_POOL_NAME: The base name for the new node pool. (Default: ryan-v6e-autotest)
- LOCATION: The region of the GKE cluster. (Default: asia-northeast1)
- NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default: asia-northeast1-b)
- NUM_NODES: The number of nodes to create in the pool. (Default: 4)
- MACHINE_TYPE: The machine type for the GKE nodes. (Default: ct6e-standard-4t)
- TPU_TOPOLOGY: The TPU topology for the node pool. (Default: 4x4)

Test result: WIP

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.