### PR TITLE
Adds a new DAG to test "Jobset Ready Healthiness" metric

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -53,7 +53,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "gke_node_pool_label_update": DefaultTimeout,
         "gke_node_pool_status": DefaultTimeout,
         "jobset_rollback_ttr": dt.timedelta(minutes=90),
-        "jobset_ttr_node_pool_ressize": dt.timedelta(minutes=90),
+        "jobset_ttr_node_pool_resize": dt.timedelta(minutes=90),
         "jobset_ttr_pod_delete": dt.timedelta(minutes=90),
         "multi_host_nodepool_rollback": DefaultTimeout,
         "node_pool_ttr_disk_size": dt.timedelta(minutes=90),

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -62,6 +62,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "tpu_sdk_monitoring_validation": DefaultTimeout,
         "jobset_ttr_kill_process": dt.timedelta(minutes=90),
         "jobset_uptime_validation": dt.timedelta(minutes=90),
+        "jobset_healthiness_ready": dt.timedelta(minutes=90),
         "tpu_info_metrics_verification": DefaultTimeout,
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -53,7 +53,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "gke_node_pool_label_update": DefaultTimeout,
         "gke_node_pool_status": DefaultTimeout,
         "jobset_rollback_ttr": dt.timedelta(minutes=90),
-        "jobset_ttr_node_pool_resize": dt.timedelta(minutes=90),
+        "jobset_ttr_node_pool_ressize": dt.timedelta(minutes=90),
         "jobset_ttr_pod_delete": dt.timedelta(minutes=90),
         "multi_host_nodepool_rollback": DefaultTimeout,
         "node_pool_ttr_disk_size": dt.timedelta(minutes=90),

--- a/dags/tpu_observability/jobset_healthiness_ready.py
+++ b/dags/tpu_observability/jobset_healthiness_ready.py
@@ -1,0 +1,201 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to test "Jobset Ready Healthiness" metric."""
+
+import datetime
+
+from airflow import models
+from airflow.decorators import task
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
+
+from dags import composer_env
+from dags.tpu_observability.utils import jobset_util as jobset
+from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.utils.jobset_util import JobSet, Workload
+from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+
+
+# Keyword arguments are generated dynamically at runtime (pylint does not
+# know this signature).
+with models.DAG(  # pylint: disable=unexpected-keyword-arg
+    dag_id="jobset_healthiness_ready",
+    start_date=datetime.datetime(2025, 8, 10),
+    schedule="30 19 * * *" if composer_env.is_prod_env() else None,
+    catchup=False,
+    tags=[
+        "cloud-ml-auto-solutions",
+        "jobset",
+        "healthiness",
+        "tpu-obervability",
+        "TPU",
+        "v6e-16",
+    ],
+    description=(
+        "This DAG tests the 'Ready' status of jobset healthiness by "
+        "comparing the number of 'Ready' replicas before and after "
+        "a jobset is running."
+    ),
+    doc_md="""
+      # JobSet Healthiness Test For the "Ready" Status
+
+      ### Description
+      This DAG automates the process of creating node-pools, ensuring the
+      correct number of "Ready" replicas appear, then launching a jobset on
+      multiple replicas to ensure the correct number begin running.
+
+      ### Prerequisites
+      This test requires an existing cluster to run.
+
+      ### Procedures
+      First two node-pools are created. The validation test is then run to
+      check if the number of "Ready" replicas is 0. A jobset is then launched
+      which uses 2 replicas. Once the jobset is running the jobs should
+      quickly enter the "Ready" state. The number of found replicas is
+      tested against the number of replicas which should be "Ready". If they
+      match the DAG is a success.
+      """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+
+    @task
+    def generate_second_node_pool_name(
+        node_pool_info: node_pool.Info,
+    ) -> str:
+      """Generates a second node pool name."""
+      return f"{node_pool_info.node_pool_name}-2"
+
+    jobset_config = JobSet(
+        jobset_name="jobset-healthiness-ready",
+        namespace="default",
+        max_restarts=0,
+        replicated_job_name="tpu-job-slice",
+        replicas=2,
+        backoff_limit=0,
+        completions=4,
+        parallelism=4,
+        tpu_accelerator_type="tpu-v6e-slice",
+        tpu_topology="4x4",
+        container_name="jax-tpu-worker",
+        image="python:3.11",
+        tpu_cores_per_pod=4,
+    )
+
+    # Keyword arguments are generated dynamically at runtime (pylint does not
+    # know this signature).
+    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}"
+    ):
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="jobset_healthiness_ready",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
+      cluster_info_2 = node_pool.copy_node_pool_info_with_override(
+          info=cluster_info,
+          node_pool_name=generate_second_node_pool_name(cluster_info),
+      )
+
+      # Keyword arguments are generated dynamically at runtime (pylint does not
+      # know this signature).
+      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+          group_id="create_node_pool"
+      ) as create_node_pool:
+        create_first_node_pool = node_pool.create.override(
+            task_id="node_pool_1",
+            retries=2,
+        )(
+            node_pool=cluster_info,
+        )
+
+        create_second_node_pool = node_pool.create.override(
+            task_id="node_pool_2",
+            retries=2,
+        )(
+            node_pool=cluster_info_2,
+        )
+
+      validate_zero_replicas = jobset.validate_jobset_replica_number(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          replica_type="ready",
+          correct_replica_num=0,
+      )
+
+      start_workload = jobset.run_workload(
+          node_pool=cluster_info,
+          yaml_config=jobset_config.generate_yaml(
+              workload_script=Workload.IDLE_READY_TPU_20M
+          ),
+          namespace=jobset_config.namespace,
+      )
+
+      validate_ready_replicas = jobset.validate_jobset_replica_number(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          replica_type="ready",
+          correct_replica_num=jobset_config.replicas,
+      )
+
+      cleanup_workload = jobset.end_workload.override(
+          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+      )(
+          node_pool=cluster_info,
+          jobset_name=jobset_config.jobset_name,
+          namespace=jobset_config.namespace,
+      ).as_teardown(
+          setups=start_workload
+      )
+
+      # Keyword arguments are generated dynamically at runtime (pylint does not
+      # know this signature).
+      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+          group_id="cleanup_node_pool"
+      ) as cleanup_node_pool:
+        cleanup_first_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool_1",
+            trigger_rule=TriggerRule.ALL_DONE,
+            retries=2,
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        cleanup_second_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool_2",
+            trigger_rule=TriggerRule.ALL_DONE,
+            retries=2,
+        )(node_pool=cluster_info_2).as_teardown(
+            setups=create_node_pool,
+        )
+
+      # Airflow uses >> for task chaining, which is pointless for pylint.
+      # pylint: disable=pointless-statement
+      (
+          cluster_info
+          >> cluster_info_2
+          >> create_node_pool
+          >> validate_zero_replicas
+          >> start_workload
+          >> validate_ready_replicas
+          >> cleanup_workload
+          >> cleanup_node_pool
+      )
+      # pylint: enable=pointless-statement

--- a/dags/tpu_observability/jobset_healthiness_ready.py
+++ b/dags/tpu_observability/jobset_healthiness_ready.py
@@ -121,14 +121,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       ) as create_node_pool:
         create_first_node_pool = node_pool.create.override(
             task_id="node_pool_1",
-            retries=2,
         )(
             node_pool=cluster_info,
         )
 
         create_second_node_pool = node_pool.create.override(
             task_id="node_pool_2",
-            retries=2,
         )(
             node_pool=cluster_info_2,
         )
@@ -173,7 +171,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         cleanup_first_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_1",
             trigger_rule=TriggerRule.ALL_DONE,
-            retries=2,
         )(node_pool=cluster_info).as_teardown(
             setups=create_node_pool,
         )
@@ -181,7 +178,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         cleanup_second_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_2",
             trigger_rule=TriggerRule.ALL_DONE,
-            retries=2,
         )(node_pool=cluster_info_2).as_teardown(
             setups=create_node_pool,
         )

--- a/dags/tpu_observability/jobset_healthiness_ready.py
+++ b/dags/tpu_observability/jobset_healthiness_ready.py
@@ -71,9 +71,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       This test requires an existing cluster to run.
 
       ### Procedures
-      First two node-pools are created. The validation test is then run to
+      A node-pool is created. The validation test is then run to
       check if the number of "Ready" replicas is 0. A jobset is then launched
-      which uses 2 replicas. Once the jobset is running the jobs should
+      which uses 1 replica. Once the jobset is running the jobs should
       quickly enter the "Ready" state. The number of found replicas is
       tested against the number of replicas which should be "Ready". If they
       match the DAG is a success.
@@ -82,15 +82,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    @task
-    def generate_second_node_pool_name(
-        node_pool_info: node_pool.Info,
-    ) -> str:
-      """Generates a second node pool name."""
-      return f"{node_pool_info.node_pool_name}-2"
-
-    # Keyword arguments are generated dynamically at runtime (pylint does not
-    # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
@@ -113,27 +104,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool_selector=selector,
       )
 
-      cluster_info_2 = node_pool.copy_node_pool_info_with_override(
-          info=cluster_info,
-          node_pool_name=generate_second_node_pool_name(cluster_info),
-      )
-
       # Keyword arguments are generated dynamically at runtime (pylint does not
       # know this signature).
-      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-          group_id="create_node_pool"
-      ) as create_node_pool:
-        create_first_node_pool = node_pool.create.override(
-            task_id="node_pool_1",
-        )(
-            node_pool=cluster_info,
-        )
-
-        create_second_node_pool = node_pool.create.override(
-            task_id="node_pool_2",
-        )(
-            node_pool=cluster_info_2,
-        )
+      create_node_pool = node_pool.create.override(
+          task_id="create_node_pool",
+      )(
+          node_pool=cluster_info,
+      )
 
       validate_zero_replicas = jobset.validate_jobset_replica_number(
           node_pool=cluster_info,
@@ -142,10 +119,10 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           pre_startup=True,
       )
 
-      start_workload = jobset.run_workload(
+      startup = jobset.create_jobset_startup_group(
           node_pool=cluster_info,
           jobset_config=jobset_config,
-          workload_type=Workload.IDLE_READY_TPU_20M,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
       validate_ready_replicas = jobset.validate_jobset_replica_number(
@@ -161,36 +138,23 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
       ).as_teardown(
-          setups=start_workload
+          setups=startup.jobset_start_time
       )
 
-      # Keyword arguments are generated dynamically at runtime (pylint does not
-      # know this signature).
-      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-          group_id="cleanup_node_pool"
-      ) as cleanup_node_pool:
-        cleanup_first_node_pool = node_pool.delete.override(
-            task_id="cleanup_node_pool_1",
-            trigger_rule=TriggerRule.ALL_DONE,
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
-
-        cleanup_second_node_pool = node_pool.delete.override(
-            task_id="cleanup_node_pool_2",
-            trigger_rule=TriggerRule.ALL_DONE,
-        )(node_pool=cluster_info_2).as_teardown(
-            setups=create_node_pool,
-        )
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool",
+          trigger_rule=TriggerRule.ALL_DONE,
+      )(node_pool=cluster_info).as_teardown(
+          setups=create_node_pool,
+      )
 
       chain(
           selector,
           jobset_config,
           cluster_info,
-          cluster_info_2,
           create_node_pool,
           validate_zero_replicas,
-          start_workload,
+          startup.task_group,
           validate_ready_replicas,
           cleanup_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/jobset_healthiness_ready.py
+++ b/dags/tpu_observability/jobset_healthiness_ready.py
@@ -144,10 +144,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       start_workload = jobset.run_workload(
           node_pool=cluster_info,
-          yaml_config=jobset_config.generate_yaml(
-              workload_script=Workload.IDLE_READY_TPU_20M
-          ),
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
+          workload_type=Workload.IDLE_READY_TPU_20M,
       )
 
       validate_ready_replicas = jobset.validate_jobset_replica_number(
@@ -161,8 +159,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
       )(
           node_pool=cluster_info,
-          jobset_name=jobset_config.jobset_name,
-          namespace=jobset_config.namespace,
+          jobset_config=jobset_config,
       ).as_teardown(
           setups=start_workload
       )

--- a/dags/tpu_observability/jobset_healthiness_ready.py
+++ b/dags/tpu_observability/jobset_healthiness_ready.py
@@ -139,7 +139,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
           replica_type="ready",
-          correct_replica_num=0,
+          pre_startup=True,
       )
 
       start_workload = jobset.run_workload(
@@ -152,7 +152,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
           replica_type="ready",
-          correct_replica_num=jobset_config.replicas,
+          pre_startup=False,
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_ready.py
+++ b/dags/tpu_observability/jobset_healthiness_ready.py
@@ -18,6 +18,7 @@ import datetime
 
 from airflow import models
 from airflow.decorators import task
+from airflow.models.baseoperator import chain
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
@@ -25,15 +26,25 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import JobSet, Workload
-from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
+
+DAG_ID = "jobset_healthiness_ready"
+DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
+SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
-    dag_id="jobset_healthiness_ready",
+    dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 10),
-    schedule="30 19 * * *" if composer_env.is_prod_env() else None,
+    schedule=SCHEDULE if composer_env.is_prod_env() else None,
+    dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
     tags=[
         "cloud-ml-auto-solutions",
@@ -78,35 +89,28 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       """Generates a second node pool name."""
       return f"{node_pool_info.node_pool_name}-2"
 
-    jobset_config = JobSet(
-        jobset_name="jobset-healthiness-ready",
-        namespace="default",
-        max_restarts=0,
-        replicated_job_name="tpu-job-slice",
-        replicas=2,
-        backoff_limit=0,
-        completions=4,
-        parallelism=4,
-        tpu_accelerator_type="tpu-v6e-slice",
-        tpu_topology="4x4",
-        container_name="jax-tpu-worker",
-        image="python:3.11",
-        tpu_cores_per_pod=4,
-    )
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
+      selector = jobset.generate_node_pool_selector("jobset_healthiness_ready")
+
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+          node_pool_selector=selector,
+      )
+
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
           task_id="build_node_pool_info_from_gcs_yaml"
       )(
           gcs_path=GCS_CONFIG_PATH,
-          dag_name="jobset_healthiness_ready",
+          dag_name=DAG_ID,
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
       )
 
       cluster_info_2 = node_pool.copy_node_pool_info_with_override(
@@ -182,16 +186,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             setups=create_node_pool,
         )
 
-      # Airflow uses >> for task chaining, which is pointless for pylint.
-      # pylint: disable=pointless-statement
-      (
-          cluster_info
-          >> cluster_info_2
-          >> create_node_pool
-          >> validate_zero_replicas
-          >> start_workload
-          >> validate_ready_replicas
-          >> cleanup_workload
-          >> cleanup_node_pool
+      chain(
+          selector,
+          jobset_config,
+          cluster_info,
+          cluster_info_2,
+          create_node_pool,
+          validate_zero_replicas,
+          start_workload,
+          validate_ready_replicas,
+          cleanup_workload,
+          cleanup_node_pool,
       )
-      # pylint: enable=pointless-statement

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -65,15 +65,6 @@ class Workload:
   Each workload is a JSON-escaped string, ready to be used as a shell argument.
   """
 
-  IDLE_READY_TPU_20M = json.dumps(
-      textwrap.dedent(
-          """
-          sleep 1200
-          """
-      ),
-      ensure_ascii=False,
-  )
-
   JAX_TPU_BENCHMARK = json.dumps(
       textwrap.dedent(
           """

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -950,3 +950,17 @@ def ensure_no_jobset_uptime_data(
     logging.info("Stability period passed with no data detected.")
     return True
   return False
+
+
+@task.sensor(poke_interval=30, timeout=900, mode="reschedule")
+def validate_jobset_replica_number(
+    node_pool: node_pool_info,
+    jobset_config: JobSet,
+    replica_type: str,
+    correct_replica_num: int,
+):
+  name = jobset_config.replicated_job_name
+  found_replica_number = get_replica_num(
+      replica_type=replica_type, job_name=name, node_pool=node_pool
+  )
+  return found_replica_number == correct_replica_num

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -957,10 +957,12 @@ def validate_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet,
     replica_type: str,
-    correct_replica_num: int,
+    pre_startup: bool,
 ):
   name = jobset_config.replicated_job_name
   found_replica_number = get_replica_num(
       replica_type=replica_type, job_name=name, node_pool=node_pool
   )
-  return found_replica_number == correct_replica_num
+  if pre_startup:
+    return found_replica_number == 0
+  return found_replica_number == jobset_config.replicas

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -65,6 +65,15 @@ class Workload:
   Each workload is a JSON-escaped string, ready to be used as a shell argument.
   """
 
+  IDLE_READY_TPU_20M = json.dumps(
+      textwrap.dedent(
+          """
+          sleep 1200
+          """
+      ),
+      ensure_ascii=False,
+  )
+
   JAX_TPU_BENCHMARK = json.dumps(
       textwrap.dedent(
           """

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
# Description
This change adds a new DAG that automatically checks if the correct number of replicas appear for a jobset's "Ready" status.

# Tests
- DAG Name: jobset_healthiness_ready
- Airflow test runs: https://b371d513bb74418681c3aab7b27bbf12-dot-us-east1.composer.googleusercontent.com/dags/jobset_healthiness_ready/grid?tab=logs&dag_run_id=manual__2025-12-23T20%3A36%3A17.106112%2B00%3A00&task_id=v6e.cleanup_node_pool__1

## Airflow / Composer Environment
- GCP Project: cienet-cmcs
- Composer Environment: tpu-obs-testing
- Composer Version: 2.13.1

## Required Variables
- Cluster Information (This DAG requires an existing cluster)

  - `PROJECT_ID`: cienet-cmcs
  - `CLUSTER_NAME`: tpu-observability-automation-prod
  - `LOCATION`: us-central1
  - `NODE_LOCATIONS`: us-central1-b

- Node Pool / Machine Configuration

  - `NUM_NODE_POOL`: 2
  - `NODE_POOL_NAMES`: jobset-healthiness-ready-v6e / jobset-healthiness-ready-v6e-2
  - `NUM_NODES`: 4
  - `MACHINE_TYPE`: ct6e-standard-4t
  - `TPU_TOPOLOGY`: 4x4


# Checklist
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.