### PR TITLE
Feat: dag suspended status validation

### DIFF
--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -62,6 +62,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "tpu_sdk_monitoring_validation": DefaultTimeout,
         "jobset_ttr_kill_process": dt.timedelta(minutes=90),
         "jobset_uptime_validation": dt.timedelta(minutes=90),
+        "jobset_healthiness_suspended": dt.timedelta(minutes=30),
         "tpu_info_metrics_verification": DefaultTimeout,
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -176,7 +176,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         cleanup_first_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_1",
             trigger_rule=TriggerRule.ALL_DONE,
-            retries=2,
         )(node_pool=node_pool_info).as_teardown(
             setups=create_node_pool,
         )
@@ -184,7 +183,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         cleanup_second_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_2",
             trigger_rule=TriggerRule.ALL_DONE,
-            retries=2,
         )(node_pool=node_pool_info_2).as_teardown(
             setups=create_node_pool,
         )

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -137,7 +137,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       suspend_jobset = jobset.suspended_jobset.override(
-        task_id="suspend_jobset"
+          task_id="suspend_jobset"
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
@@ -156,9 +156,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=node_pool_info, jobset_config=jobset_config
-      ).as_teardown(
+      )(node_pool=node_pool_info, jobset_config=jobset_config).as_teardown(
           setups=start_workload
       )
 

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -145,8 +145,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           namespace=jobset_config.namespace,
       )
 
-      suspend_jobset = jobset.suspended_jobset(
-          node_pool=node_pool_info, jobset_name=jobset_config.jobset_name
+      suspend_jobset = jobset.k8s_suspend_jobset_command(
+          jobset_name=jobset_config.jobset_name,
+          namespace=jobset_config.namespace,
       )
 
       validate_suspended_replicas = jobset.validate_jobset_replica_number(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -20,6 +20,7 @@ from airflow import models
 from airflow.decorators import task
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
+from airflow.models.baseoperator import chain
 
 from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
@@ -188,17 +189,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             setups=create_node_pool,
         )
 
-      # Airflow uses >> for task chaining, which is pointless for pylint.
-      # pylint: disable=pointless-statement
-      (
-          node_pool_info
-          >> node_pool_info_2
-          >> create_node_pool
-          >> validate_zero_replicas
-          >> start_workload
-          >> suspend_jobset
-          >> validate_suspended_replicas
-          >> cleanup_workload
-          >> cleanup_node_pool
+      chain(
+          node_pool_info,
+          node_pool_info_2,
+          create_node_pool,
+          validate_zero_replicas,
+          start_workload,
+          suspend_jobset,
+          validate_suspended_replicas,
+          cleanup_workload,
+          cleanup_node_pool,
       )
-      # pylint: enable=pointless-statement

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -146,8 +146,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )
 
       suspend_jobset = jobset.suspended_jobset(
-          node_pool=node_pool_info,
-          jobset_name=jobset_config.jobset_name
+          node_pool=node_pool_info, jobset_name=jobset_config.jobset_name
       )
 
       validate_suspended_replicas = jobset.validate_jobset_replica_number(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -79,6 +79,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       """Generates a second node pool name."""
       return f"{pool_info.node_pool_name}-2"
 
+    @task
+    def get_jobset_replica_number(jobset_conf: jobset.JobSet) -> int:
+      """Gets the number of replicas for the jobset."""
+      return jobset_conf.replicas
+
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
@@ -151,7 +156,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           replica_type="suspended",
-          correct_replica_num=jobset_config.replicas,
+          correct_replica_num=get_jobset_replica_number(jobset_config),
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -1,0 +1,198 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to test "Jobset Ready Healthiness" metric."""
+
+import datetime
+
+from airflow import models
+from airflow.decorators import task
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
+
+from dags import composer_env
+from dags.tpu_observability.utils import jobset_util as jobset
+from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.utils.jobset_util import JobSet, Workload
+from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+
+
+# Keyword arguments are generated dynamically at runtime (pylint does not
+# know this signature).
+with models.DAG(  # pylint: disable=unexpected-keyword-arg
+    dag_id="jobset_healthiness_ready",
+    start_date=datetime.datetime(2025, 8, 10),
+    schedule="30 19 * * *" if composer_env.is_prod_env() else None,
+    catchup=False,
+    tags=[
+        "cloud-ml-auto-solutions",
+        "jobset",
+        "healthiness",
+        "tpu-obervability",
+        "TPU",
+        "v6e-16",
+    ],
+    description=(
+        "This DAG tests the 'Ready' status of jobset healthiness by "
+        "comparing the number of 'Ready' replicas before and after "
+        "a jobset is running."
+    ),
+    doc_md="""
+      # JobSet Healthiness Test For the "Ready" Status
+      ### Description
+      This DAG automates the process of creating node-pools, ensuring the
+      correct number of "Ready" replicas appear, then launching a jobset on
+      multiple replicas to ensure the correct number begin running.
+      ### Prerequisites
+      This test requires an existing cluster to run.
+      ### Procedures
+      First two node-pools are created. The validation test is then run to
+      check if the number of "Ready" replicas is 0. A jobset is then launched
+      which uses 2 replicas. Once the jobset is running the jobs should
+      quickly enter the "Ready" state. The number of found replicas is
+      tested against the number of replicas which should be "Ready". If they
+      match the DAG is a success.
+      """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+
+    @task
+    def generate_second_node_pool_name(
+        node_pool_info: node_pool.Info,
+    ) -> str:
+      """Generates a second node pool name."""
+      return f"{node_pool_info.node_pool_name}-2"
+
+    jobset_config = JobSet(
+        jobset_name="jobset-healthiness-ready",
+        namespace="default",
+        max_restarts=0,
+        replicated_job_name="tpu-job-slice",
+        replicas=2,
+        backoff_limit=0,
+        completions=4,
+        parallelism=4,
+        tpu_accelerator_type="tpu-v6e-slice",
+        tpu_topology="4x4",
+        container_name="jax-tpu-worker",
+        image="python:3.11",
+        tpu_cores_per_pod=4,
+    )
+
+    # Keyword arguments are generated dynamically at runtime (pylint does not
+    # know this signature).
+    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}"
+    ):
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name="jobset_healthiness_suspended",
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
+
+      cluster_info_2 = node_pool.copy_node_pool_info_with_override(
+          info=cluster_info,
+          node_pool_name=generate_second_node_pool_name(cluster_info),
+      )
+
+      # Keyword arguments are generated dynamically at runtime (pylint does not
+      # know this signature).
+      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+          group_id="create_node_pool"
+      ) as create_node_pool:
+        create_first_node_pool = node_pool.create.override(
+            task_id="node_pool_1",
+            retries=2,
+        )(
+            node_pool=cluster_info,
+        )
+
+        create_second_node_pool = node_pool.create.override(
+            task_id="node_pool_2",
+            retries=2,
+        )(
+            node_pool=cluster_info_2,
+        )
+
+      validate_zero_replicas = jobset.validate_jobset_replica_number(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          replica_type="ready",
+          correct_replica_num=0,
+      )
+
+      start_workload = jobset.run_workload(
+          node_pool=cluster_info,
+          yaml_config=jobset_config.generate_yaml(
+              workload_script=Workload.JAX_TPU_BENCHMARK
+          ),
+          namespace=jobset_config.namespace,
+      )
+
+      validate_ready_replicas = jobset.validate_jobset_replica_number(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          replica_type="ready",
+          correct_replica_num=jobset_config.replicas,
+      )
+
+      cleanup_workload = jobset.end_workload.override(
+          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+      )(
+          node_pool=cluster_info,
+          jobset_name=jobset_config.jobset_name,
+          namespace=jobset_config.namespace,
+      ).as_teardown(
+          setups=start_workload
+      )
+
+      # Keyword arguments are generated dynamically at runtime (pylint does not
+      # know this signature).
+      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+          group_id="cleanup_node_pool"
+      ) as cleanup_node_pool:
+        cleanup_first_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool_1",
+            trigger_rule=TriggerRule.ALL_DONE,
+            retries=2,
+        )(node_pool=cluster_info).as_teardown(
+            setups=create_node_pool,
+        )
+
+        cleanup_second_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool_2",
+            trigger_rule=TriggerRule.ALL_DONE,
+            retries=2,
+        )(node_pool=cluster_info_2).as_teardown(
+            setups=create_node_pool,
+        )
+
+      # Airflow uses >> for task chaining, which is pointless for pylint.
+      # pylint: disable=pointless-statement
+      (
+          cluster_info
+          >> cluster_info_2
+          >> create_node_pool
+          >> validate_zero_replicas
+          >> start_workload
+          >> validate_ready_replicas
+          >> cleanup_workload
+          >> cleanup_node_pool
+      )
+      # pylint: enable=pointless-statement

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -31,13 +31,20 @@ from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     GCS_JOBSET_CONFIG_PATH,
 )
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
+
+DAG_ID = "jobset_healthiness_suspended"
+DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
+SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
+
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
-    dag_id="jobset_healthiness_suspended",
+    dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 10),
-    schedule="30 19 * * *" if composer_env.is_prod_env() else None,
+    schedule=SCHEDULE if composer_env.is_prod_env() else None,
+    dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
     tags=[
         "cloud-ml-auto-solutions",

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -26,8 +26,8 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import JobSet, Workload
-from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
-
+from dags.tpu_observability.configs.common import MachineConfigMap
+from dags.tpu_observability.configs.common import GCS_CONFIG_PATH
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -141,7 +141,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           job_status=ReplicatedJobStatus.SUSPENDED,
-          expected_replica_number="{{ ti.xcom_pull(task_ids=ti.task_id.rsplit('.', 1)[0] + '.build_jobset_dict_from_gcs_yaml')['replicas'] }}",
+          xcom_argument=jobset_config,
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -47,7 +47,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     schedule=SCHEDULE if composer_env.is_prod_env() else None,
     dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
-    render_template_as_native_obj=True,
     tags=[
         "cloud-ml-auto-solutions",
         "jobset",
@@ -142,10 +141,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           job_status=ReplicatedJobStatus.SUSPENDED,
-          expected_replica_number=(
-              "{{ ti.xcom_pull(task_ids=ti.task_id.rsplit('.', 1)[0]"
-              "+'.build_jobset_dict_from_gcs_yaml')['replicas'] }}"
-          ),
+          expected_replica_number="{{ ti.xcom_pull(task_ids=ti.task_id.rsplit('.', 1)[0] + '.build_jobset_dict_from_gcs_yaml')['replicas'] }}",
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -40,7 +40,7 @@ SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
-with models.DAG( # pylint: disable=unexpected-keyword-arg
+with models.DAG(  # pylint: disable=unexpected-keyword-arg
     dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 10),
     schedule=SCHEDULE if composer_env.is_prod_env() else None,

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -80,13 +80,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     config = machine.value
 
     @task
-    def generate_second_node_pool_name(
-        pool_info: node_pool.Info,
-    ) -> str:
-      """Generates a second node pool name."""
-      return f"{pool_info.node_pool_name}-2"
-
-    @task
     def get_jobset_replica_number(jobset_conf: jobset.JobSet) -> int:
       """Gets the number of replicas for the jobset."""
       return jobset_conf.replicas
@@ -117,7 +110,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           group_id="create_node_pool"
       ) as create_node_pool:
         create_first_node_pool = node_pool.create.override(
-            task_id="node_pool_1",
+            task_id="node_pool",
         )(
             node_pool=node_pool_info,
         )
@@ -128,7 +121,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           replica_type="suspended",
-          correct_replica_num=0,
+          expected_replica_number=0,
       )
 
       start_workload = jobset.run_workload.override(task_id="start_workload")(
@@ -152,7 +145,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           replica_type="suspended",
-          correct_replica_num=get_jobset_replica_number(jobset_config),
+          expected_replica_number=get_jobset_replica_number(jobset_config),
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -26,7 +26,7 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
-from dags.tpu_observability.utils.jobset_util import ReplicaType
+from dags.tpu_observability.utils.jobset_util import ReplicaStatus
 from dags.tpu_observability.configs.common import (
     MachineConfigMap,
     GCS_CONFIG_PATH,
@@ -121,7 +121,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
-          replica_type=ReplicaType.SUSPENDED,
+          replica_type=ReplicaStatus.SUSPENDED,
           expected_replica_number=0,
       )
 
@@ -145,7 +145,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
-          replica_type=ReplicaType.SUSPENDED,
+          replica_type=ReplicaStatus.SUSPENDED,
           expected_replica_number=get_jobset_replica_number(jobset_config),
       )
 

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -68,7 +68,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       ### Prerequisites
       This test requires an existing cluster to run.
       ### Procedures
-      First two node-pools are created. The validation test is then run to
+      First a node-pool is created. The validation test is then run to
       check if the number of "Suspended" replicas is 0. Once the jobset is
       running the jobs should quickly enter the "Ready" state. Then using
       command to suspend entire jobset. The number of found replicas is

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -26,6 +26,7 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.utils.jobset_util import ReplicaType
 from dags.tpu_observability.configs.common import (
     MachineConfigMap,
     GCS_CONFIG_PATH,
@@ -120,7 +121,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
-          replica_type="suspended",
+          replica_type=ReplicaType.SUSPENDED,
           expected_replica_number=0,
       )
 
@@ -144,7 +145,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
-          replica_type="suspended",
+          replica_type=ReplicaType.SUSPENDED,
           expected_replica_number=get_jobset_replica_number(jobset_config),
       )
 

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -85,7 +85,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      jobset_config = jobset.build_jobset_dict_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name="jobset_healthiness_suspended",
       )
@@ -141,7 +141,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           job_status=ReplicatedJobStatus.SUSPENDED,
-          xcom_argument=jobset_config,
+          expected_replica_number=jobset_config["replicas"],
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -57,24 +57,24 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     ],
     description=(
         "This DAG tests the 'Suspended' status of jobset healthiness by "
-        "comparing the number of 'Ready' replicas before and after "
+        "comparing the number of 'suspended' replicas before and after "
         "a jobset is running."
     ),
     doc_md="""
       # JobSet Healthiness Test For the "Suspended" Status
       ### Description
       This DAG automates the process of creating node-pools, ensuring the
-      correct number of "Ready" replicas appear, then launching a jobset on
+      correct number of "Suspended" replicas appear, then launching a jobset on
       multiple replicas to ensure the correct number begin running.
       ### Prerequisites
       This test requires an existing cluster to run.
       ### Procedures
       First two node-pools are created. The validation test is then run to
-      check if the number of "Suspended" replicas is 0. A jobset is then launched
-      which uses 2 replicas. Once the jobset is running the jobs should
-      quickly enter the "Ready" state. Then using command to suspend entire jobset.
-      The number of found replicas is tested against the number of replicas which
-      should be "Suspended". If they match the DAG is a success.
+      check if the number of "Suspended" replicas is 0. Once the jobset is
+      running the jobs should quickly enter the "Ready" state. Then using
+      command to suspend entire jobset. The number of found replicas is
+      tested against the number of replicas which should be "Suspended".
+      If they match the DAG is a success.
       """,
 ) as dag:
   for machine in MachineConfigMap:

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -80,17 +80,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    @task
-    def get_jobset_replica_number(jobset_conf: jobset.JobSet) -> int:
-      """Gets the number of replicas for the jobset."""
-      return jobset_conf.replicas
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_dict_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name="jobset_healthiness_suspended",
       )
@@ -146,7 +141,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           job_status=ReplicatedJobStatus.SUSPENDED,
-          expected_replica_number=get_jobset_replica_number(jobset_config),
+          expected_replica_number=jobset_config.map(lambda x: x["replicas"]),
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -37,10 +37,10 @@ from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, ge
 DAG_ID = "jobset_healthiness_suspended"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
-
-with models.DAG(  # pylint: disable=unexpected-keyword-arg
+with models.DAG( # pylint: disable=unexpected-keyword-arg
     dag_id=DAG_ID,
     start_date=datetime.datetime(2025, 8, 10),
     schedule=SCHEDULE if composer_env.is_prod_env() else None,
@@ -111,11 +111,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      node_pool_info_2 = node_pool.copy_node_pool_info_with_override(
-          info=node_pool_info,
-          node_pool_name=generate_second_node_pool_name(node_pool_info),
-      )
-
       # Keyword arguments are generated dynamically at runtime (pylint does not
       # know this signature).
       with TaskGroup(  # pylint: disable=unexpected-keyword-arg
@@ -125,12 +120,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             task_id="node_pool_1",
         )(
             node_pool=node_pool_info,
-        )
-
-        create_second_node_pool = node_pool.create.override(
-            task_id="node_pool_2",
-        )(
-            node_pool=node_pool_info_2,
         )
 
       validate_zero_replicas = jobset.wait_for_jobset_replica_number.override(
@@ -174,26 +163,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       # Keyword arguments are generated dynamically at runtime (pylint does not
       # know this signature).
-      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-          group_id="cleanup_node_pool"
-      ) as cleanup_node_pool:
-        cleanup_first_node_pool = node_pool.delete.override(
-            task_id="cleanup_node_pool_1",
-            trigger_rule=TriggerRule.ALL_DONE,
-        )(node_pool=node_pool_info).as_teardown(
-            setups=create_node_pool,
-        )
-
-        cleanup_second_node_pool = node_pool.delete.override(
-            task_id="cleanup_node_pool_2",
-            trigger_rule=TriggerRule.ALL_DONE,
-        )(node_pool=node_pool_info_2).as_teardown(
-            setups=create_node_pool,
-        )
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool",
+          trigger_rule=TriggerRule.ALL_DONE,
+      )(node_pool=node_pool_info).as_teardown(
+          setups=create_node_pool,
+      )
 
       chain(
           node_pool_info,
-          node_pool_info_2,
           create_node_pool,
           validate_zero_replicas,
           start_workload,

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -26,7 +26,7 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
-from dags.tpu_observability.utils.jobset_util import ReplicaStatus
+from dags.tpu_observability.utils.jobset_util import ReplicatedJobStatus
 from dags.tpu_observability.configs.common import (
     MachineConfigMap,
     GCS_CONFIG_PATH,
@@ -121,7 +121,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
-          replica_type=ReplicaStatus.SUSPENDED,
+          job_status=ReplicatedJobStatus.SUSPENDED,
           expected_replica_number=0,
       )
 
@@ -145,7 +145,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=node_pool_info,
           jobset_config=jobset_config,
-          replica_type=ReplicaStatus.SUSPENDED,
+          job_status=ReplicatedJobStatus.SUSPENDED,
           expected_replica_number=get_jobset_replica_number(jobset_config),
       )
 

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -17,7 +17,6 @@
 import datetime
 
 from airflow import models
-from airflow.decorators import task
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 from airflow.models.baseoperator import chain

--- a/dags/tpu_observability/jobset_healthiness_suspended.py
+++ b/dags/tpu_observability/jobset_healthiness_suspended.py
@@ -47,6 +47,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     schedule=SCHEDULE if composer_env.is_prod_env() else None,
     dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
+    render_template_as_native_obj=True,
     tags=[
         "cloud-ml-auto-solutions",
         "jobset",
@@ -141,7 +142,10 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=node_pool_info,
           jobset_config=jobset_config,
           job_status=ReplicatedJobStatus.SUSPENDED,
-          expected_replica_number=jobset_config.map(lambda x: x["replicas"]),
+          expected_replica_number=(
+              "{{ ti.xcom_pull(task_ids=ti.task_id.rsplit('.', 1)[0]"
+              "+'.build_jobset_dict_from_gcs_yaml')['replicas'] }}"
+          ),
       )
 
       cleanup_workload = jobset.end_workload.override(

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -669,7 +669,7 @@ def delete_one_random_pod(
 
   Raises:
     AirflowFailException: If no running pods are found in the specified
-    namespace.
+      namespace.
   """
   running_pods = get_running_pods(
       node_pool=node_pool,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -15,6 +15,7 @@
 """Utilities for managing JobSets in GKE clusters for TPU observability."""
 
 import enum
+from collections.abc import MutableMapping
 from datetime import timedelta
 import json
 import logging
@@ -23,8 +24,9 @@ import random
 import string
 import tempfile
 import textwrap
-import dataclasses
-from typing import Final, Any
+from typing import Final, Any, Optional
+
+from pydantic import BaseModel
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
@@ -191,21 +193,21 @@ _TEMPLATE = string.Template(
 # pylint: enable=line-too-long
 
 
-@dataclasses.dataclass
-class JobSet(dict):
+class JobSet(BaseModel, MutableMapping):
   """
   Generates YAML configurations for Kubernetes JobSets and serves as a
   data transfer object specifically for Airflow XCom, 'multiple_outputs', etc.
 
-  This class is specifically designed to encapsulate data for efficient passing
-  between Airflow tasks. As a result, it does not support features that would
-  complicate its role as a serializable carrier, such as 'copy.deepcopy()',
-  'pickle' operations, or the dynamic assignment of fields not defined in the
-  data model.
+  BaseModel:
+    BaseModel is advanced version of @dataclass. we can do dynamic attribute
+      assignment, validation. More suitable in this case.
 
-  This class helps in creating JobSet YAMLs by providing a template and allowing
-  customization of various parameters like jobset name, replicas, TPU
-  configuration, and the workload script to be executed.
+  MutableMapping:
+    We avoid to use dict here. Since airflow will adapt default serialization
+      and deserialization process on dict, we might lose BaseModel's
+      features. Instead, we implement MutableMapping, so airflow would just
+      call customized serialize() and deserialize() methods defined by
+      ourselves.
 
   Attributes:
     jobset_name: The name of the JobSet.
@@ -225,49 +227,72 @@ class JobSet(dict):
     tpu_cores_per_pod: The number of TPU cores requested per pod.
   """
 
-  jobset_name: str
-  namespace: str
-  max_restarts: int
-  replicated_job_name: str
-  replicas: int
-  backoff_limit: int
-  completions: int
-  parallelism: int
-  tpu_accelerator_type: str
-  tpu_topology: str
-  container_name: str
-  image: str
-  tpu_cores_per_pod: int
-  node_pool_selector: str
-
-  def __setattr__(self, key: str, value: Any) -> None:
-    if key not in self.__class__.__dataclass_fields__:
-      raise AttributeError(f"'{key}' is not a valid attribute of JobSet.")
-    if value is None:
-      raise ValueError(f"'{key}' cannot be set to None.")
-    self[key] = value
-
-  def __getattr__(self, key: str) -> Any:
-    if key not in self.__class__.__dataclass_fields__:
-      raise AttributeError(f"'{key}' is not a valid attribute of JobSet.")
-    try:
-      return self[key]
-    except KeyError as e:
-      raise AttributeError(
-          f"'{key}' has not been set for this JobSet instance."
-      ) from e
-
-  def __setitem__(self, key: str, value: Any) -> None:
-    if key not in self.__class__.__dataclass_fields__:
-      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
-    if value is None:
-      raise ValueError(f"Key '{key}' cannot be set to None.")
-    super().__setitem__(key, value)
+  jobset_name: Optional[str] = None
+  namespace: Optional[str] = None
+  max_restarts: Optional[int] = None
+  replicated_job_name: Optional[str] = None
+  replicas: Optional[int] = None
+  backoff_limit: Optional[int] = None
+  completions: Optional[int] = None
+  parallelism: Optional[int] = None
+  tpu_accelerator_type: Optional[str] = None
+  tpu_topology: Optional[str] = None
+  container_name: Optional[str] = None
+  image: Optional[str] = None
+  tpu_cores_per_pod: Optional[int] = None
+  node_pool_selector: Optional[str] = None
 
   def __getitem__(self, key: str) -> Any:
-    if key not in self.__class__.__dataclass_fields__:
+    """Necessary MutableMapping method: allows dict-like field access."""
+
+    if key not in JobSet.model_fields:
       raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
-    return super().__getitem__(key)
+    return object.__getattribute__(self, key)
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    """Necessary MutableMapping method: allows setting field values."""
+    if key not in JobSet.model_fields:
+      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+    if value is None:
+      raise ValueError(f"Value for '{key}' cannot be None.")
+    object.__setattr__(self, key, value)
+
+  def __delitem__(self, key: str) -> None:
+    """Necessary MutableMapping method: allows deletion of fields."""
+    raise NotImplementedError("JobSet does not support field deletion.")
+
+  def __getattr__(self, key: str) -> Any:
+    """Allows attribute-style access."""
+    return self[key]
+
+  def __setattr__(self, key: str, value: Any) -> None:
+    """Allows attribute-style access."""
+    self[key] = value
+
+  def __iter__(self):
+    """Necessary MutableMapping method: iterates over non-None field keys."""
+    return (k for k, v in self.model_dump().items() if v is not None)
+
+  def __len__(self):
+    """Necessary MutableMapping method: counts non-None fields."""
+    return sum(1 for v in self.model_dump().values() if v is not None)
+
+  def serialize(self) -> dict:
+    """
+    Customized serialization method for Airflow XCom. When a JobSet instance
+    is created, it would be serialized into a Airflow database. This method
+    defines how the serialization happens, we store it as a dictionary.
+    """
+    return {k: v for k, v in self.model_dump().items() if v is not None}
+
+  @staticmethod
+  def deserialize(data: dict) -> "JobSet":
+    """
+    Customized deserialization method for Airflow XCom. When a dict instance
+    (serialized from a JobSet object)is retrieved from the Airflow database,
+    it would call this method to deserialize back into a JobSet object.
+    """
+    return JobSet(**data)
 
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.
@@ -279,7 +304,7 @@ class JobSet(dict):
     Returns:
         A string containing the complete JobSet YAML.
     """
-    params = dict(self)
+    params = {k: v for k, v in self.model_dump().items() if v is not None}
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""
@@ -543,9 +568,8 @@ def build_jobset_from_gcs_yaml(
     **overrides: Additional parameters to override default configurations.
   """
   config = gcs.load_yaml_from_gcs(gcs_path)
-  known_fields = set(JobSet.__annotations__.keys())
-  jobset = JobSet.__new__(JobSet)
-  dict.__init__(jobset, {})
+  known_fields = JobSet.model_fields.keys()
+  jobset = JobSet()
 
   cfg_defaults = config.get("jobset_defaults", {})
   dag_cfg = config.get("dag", {}).get(dag_name, {})
@@ -578,9 +602,6 @@ def run_workload(
   Returns:
     The UTC time when the workload was started.
   """
-
-  jobset_config = JobSet(**jobset_config)
-
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
@@ -630,9 +651,6 @@ def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
     jobset_name: The name of the JobSet to delete.
     namespace: The Kubernetes namespace to delete the JobSet from.
   """
-
-  jobset_config = JobSet(**jobset_config)
-
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
@@ -1019,8 +1037,6 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
     node_pool: Configuration object with cluster details.
     jobset_name: The name of the JobSet to delete.
   """
-
-  jobset_config = JobSet(**jobset_config)
 
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -342,7 +342,6 @@ class Command:
     return (
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
-        # f"--type=merge -p '{json.dumps({'spec': {'suspend': True}})}'"
         "--type=merge -p '{\"spec\": {\"suspend\": true}}'"
     )
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -143,6 +143,15 @@ class Workload:
       ensure_ascii=False,
   )
 
+  SCRIPTS = {
+      "JAX_TPU_BENCHMARK": JAX_TPU_BENCHMARK,
+  }
+
+  @classmethod
+  def get_script(cls, workload_type: str) -> str:
+    """Returns the script string."""
+    return cls.SCRIPTS.get(workload_type)
+
 
 # pylint: disable=line-too-long
 _TEMPLATE = string.Template(

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -342,7 +342,6 @@ class Command:
     return (
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
-        f"--type=merge -p '"
         f"--type=merge -p '{json.dumps({'spec': {'suspend': True}})}'"
     )
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -768,8 +768,7 @@ def wait_for_jobset_ttr_to_be_found(
 
   Args:
     node_pool (Info): An instance of the Info class containing GKE metadata.
-    jobset_config: An instance of the JobSet class representing the jobset
-    configuration.
+    jobset_config: An instance of the JobSet class representing the jobset configuration.
     start_time (TimeUtil, optional): The UTC timestamp to start polling from.
     If not provided, defaults to 60 minutes before the current time.
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -396,7 +396,7 @@ def get_replica_num(
     node_pool: The Info object containing the cluster information needed for
     the kubernetes API to connect to it.
   Returns:
-    The number of replicas of the specific type in the jobset.
+    The number of replicas of the specific status in the jobset.
   """
   api_client = gke.get_authenticated_client(
       node_pool.project_id,
@@ -1011,9 +1011,9 @@ def wait_for_jobset_replica_number(
   logging.info(
       "Checking for number of replicas of type: %s", job_status.value
   )
-  ready_replicas = get_replica_num(
+  suspended_replica_number = get_replica_num(
       job_status=job_status,
       job_name=jobset_config.replicated_job_name,
       node_pool=node_pool,
   )
-  return ready_replicas == expected_replica_number
+  return suspended_replica_number == expected_replica_number

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -575,7 +575,7 @@ def run_workload(
 
   Args:
     node_pool: Configuration object with cluster details.
-    jobset_config: The JobSet object or dict containing YAML configuration.
+    jobset_config: The JobSet object containing YAML configuration.
     workload_type: The workload script to execute.
   Returns:
     The UTC time when the workload was started.

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -195,7 +195,14 @@ _TEMPLATE = string.Template(
 @dataclasses.dataclass
 class JobSet(dict):
   """
-  Generates YAML configurations for Kubernetes JobSets.
+  Generates YAML configurations for Kubernetes JobSets and serves as a
+  data transfer object specifically for Airflow XCom, 'multiple_outputs', etc.
+
+  This class is specifically designed to encapsulate data for efficient passing
+  between Airflow tasks. As a result, it does not support features that would
+  complicate its role as a serializable carrier, such as 'copy.deepcopy()',
+  'pickle' operations, or the dynamic assignment of fields not defined in the
+  data model.
 
   This class helps in creating JobSet YAMLs by providing a template and allowing
   customization of various parameters like jobset name, replicas, TPU

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -549,12 +549,13 @@ def build_jobset_from_gcs_yaml(
   dag_id_prefix = dag_cfg.get("dag_id_prefix")
 
   jobset["jobset_name"] = _generate_jobset_name(dag_id_prefix)
-  jobset.update({
-      k: v
-      for k, v in config.get("jobset_defaults", {}).items()
-      if k in known_fields
-  })
-
+  jobset.update(
+      {
+          k: v
+          for k, v in config.get("jobset_defaults", {}).items()
+          if k in known_fields
+      }
+  )
   jobset.update({k: v for k, v in dag_cfg.items() if k in known_fields})
   jobset.update({k: v for k, v in overrides.items() if k in known_fields})
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -327,7 +327,7 @@ class Command:
     ])
 
   @staticmethod
-  def suspend_jobset(jobset_name: str, namespace: str) -> str:
+  def k8s_suspend_jobset_command(jobset_name: str, namespace: str) -> str:
     patch_content = '{"spec": {"suspend": true}}'
     return (
         f"kubectl patch jobset {jobset_name} -n {namespace} "

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -489,6 +489,70 @@ def _generate_jobset_name(dag_id_prefix: str) -> str:
   return f"{dag_id_prefix}-{timestamp}"
 
 
+def _build_jobset_config_dict(
+  gcs_path: str, dag_name: str, **overrides
+) -> dict:
+  """
+  Builds a dictionary of JobSet configuration by loading from GCS and applying
+  overrides.
+
+  Args:
+    gcs_path: The GCS path to the YAML configuration file.
+    dag_name: The name of the DAG to extract specific configurations.
+    **overrides: Additional parameters to override default configurations.
+  Returns:
+    A dictionary containing the config_dict JobSet configuration.
+  """
+
+  config = gcs.load_yaml_from_gcs(gcs_path)
+  known_fields = {f.name for f in dataclasses.fields(JobSet)}
+  config_dict = {
+      k: v
+      for k, v in config.get("jobset_defaults", {}).items()
+      if k in known_fields
+  }
+  dag_cfg = config.get("dag", {}).get(dag_name, {})
+  dag_id_prefix = dag_cfg.get("dag_id_prefix")
+
+  for k, v in dag_cfg.items():
+    if k in known_fields and v is not None:
+      config_dict[k] = v
+
+  config_dict.update({k: v for k, v in overrides.items() if k in known_fields})
+  config_dict["jobset_name"] = _generate_jobset_name(dag_id_prefix)
+
+  logging.info(
+      f"Final jobset dictionary '{config_dict['jobset_name']}' "
+      f"created for DAG '{dag_name}'"
+  )
+  return config_dict
+
+
+@task
+def build_jobset_dict_from_gcs_yaml(
+    gcs_path: str,
+    dag_name: str,
+    **overrides,
+) -> dict:
+  """
+  Builds a JobSet configuration dictionary from a GCS YAML file.
+
+  Args:
+    gcs_path: The GCS path to the YAML configuration file.
+    dag_name: The name of the DAG to extract specific configurations.
+    **overrides: Additional parameters to override default configurations.
+
+  Returns:
+    A dictionary containing the JobSet configuration.
+  """
+
+  return _build_jobset_config_dict(
+      gcs_path=gcs_path,
+      dag_name=dag_name,
+      **overrides
+  )
+
+
 @task
 def build_jobset_from_gcs_yaml(
     gcs_path: str,
@@ -503,44 +567,39 @@ def build_jobset_from_gcs_yaml(
     gcs_path: The GCS path to the YAML configuration file.
     dag_name: The name of the DAG to extract specific configurations.
     **overrides: Additional parameters to override default configurations.
+
+  Returns:
+    A JobSet instance with the final configuration ready for use in the DAG.
   """
-  config = gcs.load_yaml_from_gcs(gcs_path)
-  known_fields = {f.name for f in dataclasses.fields(JobSet)}
-  merged = {
-      k: v
-      for k, v in config.get("jobset_defaults", {}).items()
-      if k in known_fields
-  }
-  dag_cfg = config.get("dag", {}).get(dag_name, {})
-  dag_id_prefix = dag_cfg.get("dag_id_prefix")
 
-  for k, v in dag_cfg.items():
-    if k in known_fields and v is not None:
-      merged[k] = v
-
-  merged.update({k: v for k, v in overrides.items() if k in known_fields})
-  merged["jobset_name"] = _generate_jobset_name(dag_id_prefix)
-
-  logging.info(
-      f"Final JobSet '{merged['jobset_name']}' created for DAG '{dag_name}'"
+  jobset_dict = _build_jobset_config_dict(
+      gcs_path=gcs_path,
+      dag_name=dag_name,
+      **overrides
   )
-  return JobSet(**merged)
+  return JobSet(**jobset_dict)
 
 
 @task
 def run_workload(
-    node_pool: node_pool_info, jobset_config: JobSet, workload_type: Workload
+    node_pool: node_pool_info,
+    jobset_config: JobSet | dict,
+    workload_type: Workload,
 ) -> TimeUtil:
   """
   Applies the specified YAML file to the GKE cluster.
 
   Args:
     node_pool: Configuration object with cluster details.
-    jobset_config: The JobSet object containing YAML configuration.
+    jobset_config: The JobSet object or dict containing YAML configuration.
     workload_type: The workload script to execute.
   Returns:
     The UTC time when the workload was started.
   """
+
+  if isinstance(jobset_config, dict):
+    jobset_config = JobSet(**jobset_config)
+
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
@@ -577,7 +636,7 @@ def run_workload(
 
 
 @task
-def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
+def end_workload(node_pool: node_pool_info, jobset_config: JobSet | dict):
   """
   Deletes all JobSets from the GKE cluster to clean up resources.
 
@@ -590,6 +649,10 @@ def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
     jobset_name: The name of the JobSet to delete.
     namespace: The Kubernetes namespace to delete the JobSet from.
   """
+
+  if isinstance(jobset_config, dict):
+    jobset_config = JobSet(**jobset_config)
+
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
@@ -964,7 +1027,7 @@ def ensure_no_jobset_uptime_data(
 
 
 @task
-def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
+def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet | dict):
   """
   Suspend a jobset from the GKE cluster.
 
@@ -976,6 +1039,9 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
     node_pool: Configuration object with cluster details.
     jobset_name: The name of the JobSet to delete.
   """
+  if isinstance(jobset_config, dict):
+    jobset_config = JobSet(**jobset_config)
+
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
@@ -995,7 +1061,7 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
 @task.sensor(poke_interval=30, timeout=900, mode="poke")
 def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
-    jobset_config: JobSet,
+    jobset_config: JobSet | dict,
     job_status: ReplicatedJobStatus,
     expected_replica_number: int,
 ):
@@ -1008,9 +1074,14 @@ def wait_for_jobset_replica_number(
     job_status(ReplicatedJobStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
   """
+
+  if isinstance(jobset_config, dict):
+    jobset_config = JobSet(**jobset_config)
+
   logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
+
       job_name=jobset_config.replicated_job_name,
       node_pool=node_pool,
   )

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -143,15 +143,6 @@ class Workload:
       ensure_ascii=False,
   )
 
-  SCRIPTS = {
-      "JAX_TPU_BENCHMARK": JAX_TPU_BENCHMARK,
-  }
-
-  @classmethod
-  def get_script(cls, workload_type: str) -> str:
-    """Returns the script string."""
-    return cls.SCRIPTS.get(workload_type)
-
 
 # pylint: disable=line-too-long
 _TEMPLATE = string.Template(
@@ -439,8 +430,6 @@ def get_running_pods(
   with tempfile.TemporaryDirectory() as tmpdir:
     env = os.environ.copy()
     env["KUBECONFIG"] = os.path.join(tmpdir, "kubeconfig")
-
-    get_pods_cmd = Command.k8s_get_pod_name_command(jobset_name, namespace)
 
     cmd = " && ".join([
         Command.get_credentials_command(node_pool),

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -192,7 +192,6 @@ _TEMPLATE = string.Template(
 # pylint: enable=line-too-long
 
 
-@dataclasses.dataclass
 class JobSet(dict):
   """
   Generates YAML configurations for Kubernetes JobSets.
@@ -233,6 +232,11 @@ class JobSet(dict):
   image: str
   tpu_cores_per_pod: int
   node_pool_selector: str
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    for k, v in self.items():
+        setattr(self, k, v)
 
   @override
   def __getitem__(self, key):

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -339,11 +339,10 @@ class Command:
   def k8s_suspend_jobset_command(
       kubeconfig: str, jobset_name: str, namespace: str
   ) -> str:
-    patch_content = '{"spec": {"suspend": true}}'
     return (
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
-        f"--type=merge -p '{patch_content}'"
+        f"--type=merge -p '{{\"spec\": {{\"suspend\": true}}}}'"
     )
 
   class K8sGetPodsOutput(enum.Enum):
@@ -778,7 +777,7 @@ def wait_for_jobset_ttr_to_be_found(
   Args:
     node_pool (Info): An instance of the Info class containing GKE metadata.
     jobset_config: An instance of the JobSet class representing the jobset
-    configuration.
+      configuration.
     start_time (TimeUtil, optional): The UTC timestamp to start polling from.
     If not provided, defaults to 60 minutes before the current time.
 
@@ -988,7 +987,7 @@ def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet,
     replica_type: str,
-    correct_replica_num: int,
+    expected_replica_number: int,
 ):
   """
   A sensor which checks if the correct number jobset replicas in a status type.
@@ -997,7 +996,7 @@ def wait_for_jobset_replica_number(
     node_pool: Configuration object with cluster details.
     jobset_config: Configuration of JobSet which is being run.
     replica_type(str): The name of the type of status being checked for.
-    correct_replica_num(int): The expected number of replicas to be found.
+    expected_replica_number(int): The expected number of replicas to be found.
   """
   logging.info("Checking for number of replicas of type: %s", replica_type)
   ready_replicas = get_replica_num(
@@ -1005,4 +1004,4 @@ def wait_for_jobset_replica_number(
       job_name=jobset_config.replicated_job_name,
       node_pool=node_pool,
   )
-  return ready_replicas == correct_replica_num
+  return ready_replicas == expected_replica_number

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -490,7 +490,7 @@ def _generate_jobset_name(dag_id_prefix: str) -> str:
 
 
 def _build_jobset_config_dict(
-  gcs_path: str, dag_name: str, **overrides
+    gcs_path: str, dag_name: str, **overrides
 ) -> dict:
   """
   Builds a dictionary of JobSet configuration by loading from GCS and applying
@@ -547,9 +547,7 @@ def build_jobset_dict_from_gcs_yaml(
   """
 
   return _build_jobset_config_dict(
-      gcs_path=gcs_path,
-      dag_name=dag_name,
-      **overrides
+      gcs_path=gcs_path, dag_name=dag_name, **overrides
   )
 
 
@@ -573,9 +571,7 @@ def build_jobset_from_gcs_yaml(
   """
 
   jobset_dict = _build_jobset_config_dict(
-      gcs_path=gcs_path,
-      dag_name=dag_name,
-      **overrides
+      gcs_path=gcs_path, dag_name=dag_name, **overrides
   )
   return JobSet(**jobset_dict)
 
@@ -1081,7 +1077,6 @@ def wait_for_jobset_replica_number(
   logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
-
       job_name=jobset_config.replicated_job_name,
       node_pool=node_pool,
   )

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -510,24 +510,6 @@ def build_jobset_from_gcs_yaml(
 
 
 @task
-def generate_jobset_name(dag_id: str) -> str:
-  """
-  Generates a jobset name.
-
-  Args:
-    dag_id_prefix: The DAG ID to use as a prefix for the jobset name.
-    (should be shorter than 40 characters to fit k8s naming 63 characters limit)
-  Returns:
-    A string representing the generated jobset name.
-  """
-  now_utc = datetime.datetime.now(datetime.timezone.utc)
-  timestamp = now_utc.strftime("%Y%m%d%H%M%S")
-  dag_id_prefix = dag_id_prefix.replace("_", "-").lower()
-
-  return f"{dag_id_prefix}-workload-{timestamp}"
-
-
-@task
 def run_workload(
     node_pool: node_pool_info, jobset_config: JobSet, workload_type: Workload
 ) -> TimeUtil:

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -989,6 +989,7 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
 
     subprocess.run_exec(cmd, env=env)
 
+
 @task.sensor(poke_interval=30, timeout=900, mode="poke")
 def wait_for_jobset_replica_number(
     node_pool: node_pool_info,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -371,8 +371,8 @@ class Command:
     return Command.k8s_get_pods(jobset_name, namespace, output)
 
 
-class ReplicaStatus(enum.Enum):
-  """Defines replica types."""
+class ReplicatedJobStatus(enum.Enum):
+  """Defines status of a replicated job."""
 
   READY = "ready"
   SUSPENDED = "suspended"
@@ -382,7 +382,7 @@ class ReplicaStatus(enum.Enum):
 
 
 def get_replica_num(
-    replica_type: ReplicaStatus, job_name: str, node_pool: node_pool_info
+    job_status: ReplicatedJobStatus, job_name: str, node_pool: node_pool_info
 ) -> int:
   """
   Get the number of a certain type of replicas from a running jobset.
@@ -391,7 +391,7 @@ def get_replica_num(
   the number of replicas in a certain status.
 
   Args:
-    replica_type: The type of replica being searched for.
+    job_status: The status of the replicated job being searched for.
     job_name: The name of the job replica which is run from the jobset.
     node_pool: The Info object containing the cluster information needed for
     the kubernetes API to connect to it.
@@ -416,7 +416,7 @@ def get_replica_num(
   try:
     replica_job_status = jobsets["items"][0]["status"]["replicatedJobsStatus"]
     name = replica_job_status[0]["name"]
-    replicas = replica_job_status[0][replica_type.value]
+    replicas = replica_job_status[0][job_status.value]
     logging.info("Found %s replicas", replicas)
 
   except (KeyError, IndexError, TypeError) as e:
@@ -996,7 +996,7 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
 def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet,
-    replica_type: ReplicaStatus,
+    job_status: ReplicatedJobStatus,
     expected_replica_number: int,
 ):
   """
@@ -1005,14 +1005,14 @@ def wait_for_jobset_replica_number(
   Args:
     node_pool: Configuration object with cluster details.
     jobset_config: Configuration of JobSet which is being run.
-    replica_type(ReplicaStatus): The type of status being checked for.
+    job_status(ReplicatedJobStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
   """
   logging.info(
-      "Checking for number of replicas of type: %s", replica_type.value
+      "Checking for number of replicas of type: %s", job_status.value
   )
   ready_replicas = get_replica_num(
-      replica_type=replica_type,
+      job_status=job_status,
       job_name=jobset_config.replicated_job_name,
       node_pool=node_pool,
   )

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -769,7 +769,7 @@ def wait_for_jobset_ttr_to_be_found(
   Args:
     node_pool (Info): An instance of the Info class containing GKE metadata.
     jobset_config: An instance of the JobSet class representing the jobset
-      configuration.
+    configuration.
     start_time (TimeUtil, optional): The UTC timestamp to start polling from.
     If not provided, defaults to 60 minutes before the current time.
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -513,14 +513,14 @@ def generate_jobset_name(dag_id: str) -> str:
   Generates a jobset name.
 
   Args:
-    dag_id: The DAG ID to use as a prefix for the jobset name.
+    dag_id_prefix: The DAG ID to use as a prefix for the jobset name.
     (should be shorter than 40 characters to fit k8s naming 63 characters limit)
   Returns:
     A string representing the generated jobset name.
   """
   now_utc = datetime.datetime.now(datetime.timezone.utc)
   timestamp = now_utc.strftime("%Y%m%d%H%M%S")
-  dag_id_prefix = dag_id.replace("_", "-").lower()
+  dag_id_prefix = dag_id_prefix.replace("_", "-").lower()
 
   return f"{dag_id_prefix}-workload-{timestamp}"
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -195,18 +195,18 @@ _TEMPLATE = string.Template(
 
 
 class JobSet(BaseModel, MutableMapping):
-  """Generates YAML configurations for Kubernetes JobSets and serves as a
+  """
+  Generates YAML configurations for Kubernetes JobSets and serves as a
   data transfer object specifically for Airflow XCom, 'multiple_outputs', etc.
 
-  Note:
-    Extends Pydantic's BaseModel (rather than a plain dataclass) to leverage
-    runtime type validation, field coercion, and dynamic attribute assignment.
+  Extends Pydantic's BaseModel (rather than a plain dataclass) to leverage
+  runtime type validation, field coercion, and dynamic attribute assignment.
 
-    Implements MutableMapping instead of inheriting from dict to prevent
-    Airflow from invoking its default dict serialization/deserialization
-    logic, which would bypass BaseModel's field handling. By satisfying the
-    MutableMapping interface, Airflow delegates to the custom serialize() and
-    deserialize() methods defined on this class.
+  Implements MutableMapping instead of inheriting from dict to prevent
+  Airflow from invoking its default dict serialization/deserialization
+  logic, which would bypass BaseModel's field handling. By satisfying the
+  MutableMapping interface, Airflow delegates to the custom serialize() and
+  deserialize() methods defined on this class.
 
   Attributes:
     jobset_name: The name of the JobSet.
@@ -278,18 +278,34 @@ class JobSet(BaseModel, MutableMapping):
 
   def serialize(self) -> dict:
     """
-    Customized serialization method for Airflow XCom. When a JobSet instance
-    is created, it would be serialized into a Airflow database. This method
-    defines how the serialization happens, we store it as a dictionary.
+    Serializes this JobSet to a dict for Airflow XCom storage.
+
+    Because JobSet is a MutableMapping rather than a plain dict, Airflow
+    skips its default dict serialization and delegates to this method
+    instead. Only non-None fields are included to keep the payload minimal.
+
+    Returns:
+      A dict representation of this JobSet, excluding unset fields.
     """
     return {k: v for k, v in self.model_dump().items() if v is not None}
 
   @staticmethod
   def deserialize(data: dict) -> "JobSet":
     """
-    Customized deserialization method for Airflow XCom. When a dict instance
-    (serialized from a JobSet object)is retrieved from the Airflow database,
-    it would call this method to deserialize back into a JobSet object.
+    Deserializes a dict retrieved from Airflow XCom back into a JobSet.
+
+    Because JobSet is a MutableMapping rather than a plain dict, Airflow
+    skips its default dict deserialization and delegates to this method
+    instead.
+
+    Args:
+      data: A dict previously produced by serialize().
+      version: The version of the serialized data format (not used in
+        this implementation, but a required signature for Airflow
+        deserialization).
+
+    Returns:
+      A JobSet instance populated with the fields from data.
     """
     return JobSet(**data)
 
@@ -1068,8 +1084,8 @@ def wait_for_jobset_replica_number(
     jobset_config: Configuration of JobSet which is being run.
     job_status(ReplicatedJobStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
-    xcom_argument(dict): An optional argument to pull the expected replica number
-      from an XCom push. Should be in the format {"replicas": int}.
+    xcom_argument(dict): An optional argument to pull the expected replica
+      number from an XCom push. Should be in the format {"replicas": int}.
   """
 
   logging.info("Checking for number of replicas of type: %s", job_status.value)

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -265,7 +265,6 @@ class JobSet(dict):
       raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
     return super().__getitem__(key)
 
-
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.
 
@@ -1060,7 +1059,7 @@ def wait_for_jobset_replica_number(
   logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
-      job_name=jobset_config["replicated_job_name"], #tpu-job-slice
+      job_name=jobset_config["replicated_job_name"],
       node_pool=node_pool,
   )
   return suspended_replica_number == expected_replica_number

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -15,6 +15,7 @@
 """Utilities for managing JobSets in GKE clusters for TPU observability."""
 
 import enum
+import dataclasses
 from collections.abc import MutableMapping
 from datetime import timedelta
 import json

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -440,6 +440,8 @@ def get_running_pods(
     env = os.environ.copy()
     env["KUBECONFIG"] = os.path.join(tmpdir, "kubeconfig")
 
+    get_pods_cmd = Command.k8s_get_pod_name_command(jobset_name, namespace)
+
     cmd = " && ".join([
         Command.get_credentials_command(node_pool),
         Command.k8s_get_pod_name_command(

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -535,6 +535,8 @@ def build_jobset_from_gcs_yaml(
   Builds a JobSet instance by merging YAML defaults and generating
   a timestamped name based on dag_id_prefix.
 
+  update priority: jobset_defaults > dag-specific config > overrides
+
   Args:
     gcs_path: The GCS path to the YAML configuration file.
     dag_name: The name of the DAG to extract specific configurations.
@@ -545,17 +547,13 @@ def build_jobset_from_gcs_yaml(
   jobset = JobSet.__new__(JobSet)
   dict.__init__(jobset, {})
 
+  cfg_defaults = config.get("jobset_defaults", {})
   dag_cfg = config.get("dag", {}).get(dag_name, {})
   dag_id_prefix = dag_cfg.get("dag_id_prefix")
 
   jobset["jobset_name"] = _generate_jobset_name(dag_id_prefix)
-  jobset.update(
-      {
-          k: v
-          for k, v in config.get("jobset_defaults", {}).items()
-          if k in known_fields
-      }
-  )
+
+  jobset.update({k: v for k, v in cfg_defaults.items() if k in known_fields})
   jobset.update({k: v for k, v in dag_cfg.items() if k in known_fields})
   jobset.update({k: v for k, v in overrides.items() if k in known_fields})
 
@@ -583,8 +581,7 @@ def run_workload(
     The UTC time when the workload was started.
   """
 
-  if isinstance(jobset_config, dict):
-    jobset_config = JobSet(**jobset_config)
+  jobset_config = JobSet(**jobset_config)
 
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
@@ -622,7 +619,7 @@ def run_workload(
 
 
 @task
-def end_workload(node_pool: node_pool_info, jobset_config: JobSet | dict):
+def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
   """
   Deletes all JobSets from the GKE cluster to clean up resources.
 
@@ -636,8 +633,7 @@ def end_workload(node_pool: node_pool_info, jobset_config: JobSet | dict):
     namespace: The Kubernetes namespace to delete the JobSet from.
   """
 
-  if isinstance(jobset_config, dict):
-    jobset_config = JobSet(**jobset_config)
+  jobset_config = JobSet(**jobset_config)
 
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
@@ -1013,7 +1009,7 @@ def ensure_no_jobset_uptime_data(
 
 
 @task
-def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet | dict):
+def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
   """
   Suspend a jobset from the GKE cluster.
 
@@ -1025,8 +1021,8 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet | dict):
     node_pool: Configuration object with cluster details.
     jobset_name: The name of the JobSet to delete.
   """
-  if isinstance(jobset_config, dict):
-    jobset_config = JobSet(**jobset_config)
+
+  jobset_config = JobSet(**jobset_config)
 
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -243,6 +243,8 @@ class JobSet(dict):
   def __setattr__(self, key: str, value: Any) -> None:
     if key not in self.__class__.__dataclass_fields__:
       raise AttributeError(f"'{key}' is not a valid attribute of JobSet.")
+    if value is None:
+      raise ValueError(f"'{key}' cannot be set to None.")
     self[key] = value
 
   def __getattr__(self, key: str) -> Any:
@@ -258,6 +260,8 @@ class JobSet(dict):
   def __setitem__(self, key: str, value: Any) -> None:
     if key not in self.__class__.__dataclass_fields__:
       raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+    if value is None:
+      raise ValueError(f"Key '{key}' cannot be set to None.")
     super().__setitem__(key, value)
 
   def __getitem__(self, key: str) -> Any:
@@ -538,25 +542,27 @@ def build_jobset_from_gcs_yaml(
   """
   config = gcs.load_yaml_from_gcs(gcs_path)
   known_fields = set(JobSet.__annotations__.keys())
-  merged = {
-      k: v
-      for k, v in config.get("jobset_defaults", {}).items()
-      if k in known_fields
-  }
+  jobset = JobSet.__new__(JobSet)
+  dict.__init__(jobset, {})
+
   dag_cfg = config.get("dag", {}).get(dag_name, {})
   dag_id_prefix = dag_cfg.get("dag_id_prefix")
 
-  for k, v in dag_cfg.items():
-    if k in known_fields and v is not None:
-      merged[k] = v
+  jobset["jobset_name"] = _generate_jobset_name(dag_id_prefix)
+  jobset.update({
+      k: v
+      for k, v in config.get("jobset_defaults", {}).items()
+      if k in known_fields
+  })
 
-  merged.update({k: v for k, v in overrides.items() if k in known_fields})
-  merged["jobset_name"] = _generate_jobset_name(dag_id_prefix)
+  jobset.update({k: v for k, v in dag_cfg.items() if k in known_fields})
+  jobset.update({k: v for k, v in overrides.items() if k in known_fields})
 
   logging.info(
-      f"Final JobSet '{merged['jobset_name']}' created for DAG '{dag_name}'"
+      f"Final JobSet '{jobset['jobset_name']}' created for DAG '{dag_name}'"
   )
-  return JobSet(**merged)
+
+  return jobset
 
 
 @task

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -24,8 +24,7 @@ import string
 import tempfile
 import textwrap
 import dataclasses
-from typing import Final
-from typing_extensions import override
+from typing import Final, Any
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
@@ -241,28 +240,31 @@ class JobSet(dict):
   tpu_cores_per_pod: int
   node_pool_selector: str
 
-  @override
-  def __setitem__(self, key, value):
-    target_type = self.__annotations__.get(key)
-
-    if target_type is None:
-      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
-
-    if not isinstance(value, target_type):
-      raise TypeError(
-          f"Expected value of type {target_type} for key '{key}'"
-          f", got {type(value)}"
-      )
-
-    super().__setitem__(key, value)
-
-  @override
-  def __setattr__(self, key, value):
+  def __setattr__(self, key: str, value: Any) -> None:
+    if key not in self.__class__.__dataclass_fields__:
+      raise AttributeError(f"'{key}' is not a valid attribute of JobSet.")
     self[key] = value
 
-  @override
-  def __getattr__(self, key):
-    return self[key]
+  def __getattr__(self, key: str) -> Any:
+    if key not in self.__class__.__dataclass_fields__:
+      raise AttributeError(f"'{key}' is not a valid attribute of JobSet.")
+    try:
+      return self[key]
+    except KeyError as e:
+      raise AttributeError(
+          f"'{key}' has not been set for this JobSet instance."
+      ) from e
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    if key not in self.__class__.__dataclass_fields__:
+      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+    super().__setitem__(key, value)
+
+  def __getitem__(self, key: str) -> Any:
+    if key not in self.__class__.__dataclass_fields__:
+      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+    return super().__getitem__(key)
+
 
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -276,7 +276,7 @@ class JobSet(dict):
     Returns:
         A string containing the complete JobSet YAML.
     """
-    params = self
+    params = dict(self)
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""
@@ -1060,7 +1060,7 @@ def wait_for_jobset_replica_number(
   logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
-      job_name=jobset_config["replicated_job_name"],
+      job_name=jobset_config["replicated_job_name"], #tpu-job-slice
       node_pool=node_pool,
   )
   return suspended_replica_number == expected_replica_number

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -23,6 +23,7 @@ import random
 import string
 import tempfile
 import textwrap
+import dataclasses
 from typing import Final
 from typing_extensions import override
 
@@ -190,7 +191,7 @@ _TEMPLATE = string.Template(
 )
 # pylint: enable=line-too-long
 
-
+@dataclasses.dataclass
 class JobSet(dict):
   """
   Generates YAML configurations for Kubernetes JobSets.
@@ -232,24 +233,28 @@ class JobSet(dict):
   tpu_cores_per_pod: int
   node_pool_selector: str
 
-  def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
-    for k, v in self.items():
-      setattr(self, k, v)
-
-  @override
-  def __getitem__(self, key):
-    try:
-      return getattr(self, key)
-    except AttributeError:
-      return super().__getitem__(key)
-
   @override
   def __setitem__(self, key, value):
-    if hasattr(self, key):
-      setattr(self, key, value)
-    else:
-      super().__setitem__(key, value)
+    target_type = self.__annotations__.get(key)
+
+    if target_type is None:
+      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+
+    if not isinstance(value, target_type):
+      raise TypeError(
+          f"Expected value of type {target_type} for key '{key}'"
+          f", got {type(value)}"
+      )
+
+    super().__setitem__(key, value)
+
+  @override
+  def __setattr__(self, key, value):
+    self[key] = value
+
+  @override
+  def __getattr__(self, key):
+    return self[key]
 
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.
@@ -261,7 +266,7 @@ class JobSet(dict):
     Returns:
         A string containing the complete JobSet YAML.
     """
-    params = dict(self)
+    params = self
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""
@@ -512,7 +517,7 @@ def build_jobset_from_gcs_yaml(
     gcs_path: str,
     dag_name: str,
     **overrides,
-) -> dict:
+) -> JobSet:
   """
   Builds a JobSet instance by merging YAML defaults and generating
   a timestamped name based on dag_id_prefix.
@@ -548,7 +553,7 @@ def build_jobset_from_gcs_yaml(
 @task
 def run_workload(
     node_pool: node_pool_info,
-    jobset_config: JobSet | dict,
+    jobset_config: JobSet ,
     workload_type: Workload,
 ) -> TimeUtil:
   """
@@ -1026,7 +1031,7 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet | dict):
 @task.sensor(poke_interval=30, timeout=900, mode="poke")
 def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
-    jobset_config: JobSet | dict,
+    jobset_config: JobSet,
     job_status: ReplicatedJobStatus,
     expected_replica_number: int,
 ):
@@ -1042,13 +1047,10 @@ def wait_for_jobset_replica_number(
       from an XCom push. Should be in the format {"replicas": int}.
   """
 
-  if isinstance(jobset_config, dict):
-    jobset_config = JobSet(**jobset_config)
-
   logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
-      job_name=jobset_config.replicated_job_name,
+      job_name=jobset_config["replicated_job_name"],
       node_pool=node_pool,
   )
   return suspended_replica_number == expected_replica_number

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -342,7 +342,8 @@ class Command:
     return (
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
-        f"--type=merge -p '{json.dumps({'spec': {'suspend': True}})}'"
+        # f"--type=merge -p '{json.dumps({'spec': {'suspend': True}})}'"
+        "--type=merge -p '{\"spec\": {\"suspend\": true}}'"
     )
 
   class K8sGetPodsOutput(enum.Enum):

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -372,8 +372,18 @@ class Command:
     return Command.k8s_get_pods(jobset_name, namespace, output)
 
 
+class ReplicaType(enum.Enum):
+  """Defines replica types."""
+
+  READY = "ready"
+  SUSPENDED = "suspended"
+  ACTIVE = "active"
+  FAILED = "failed"
+  SUCCEEDED = "succeeded"
+
+
 def get_replica_num(
-    replica_type: str, job_name: str, node_pool: node_pool_info
+    replica_type: ReplicaType, job_name: str, node_pool: node_pool_info
 ) -> int:
   """
   Get the number of a certain type of replicas from a running jobset.
@@ -407,7 +417,7 @@ def get_replica_num(
   try:
     replica_job_status = jobsets["items"][0]["status"]["replicatedJobsStatus"]
     name = replica_job_status[0]["name"]
-    replicas = replica_job_status[0][replica_type]
+    replicas = replica_job_status[0][replica_type.value]
     logging.info("Found %s replicas", replicas)
 
   except (KeyError, IndexError, TypeError) as e:
@@ -987,7 +997,7 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
 def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet,
-    replica_type: str,
+    replica_type: ReplicaType,
     expected_replica_number: int,
 ):
   """
@@ -996,10 +1006,12 @@ def wait_for_jobset_replica_number(
   Args:
     node_pool: Configuration object with cluster details.
     jobset_config: Configuration of JobSet which is being run.
-    replica_type(str): The name of the type of status being checked for.
+    replica_type(ReplicaType): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
   """
-  logging.info("Checking for number of replicas of type: %s", replica_type)
+  logging.info(
+      "Checking for number of replicas of type: %s", replica_type.value
+  )
   ready_replicas = get_replica_num(
       replica_type=replica_type,
       job_name=jobset_config.replicated_job_name,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -768,7 +768,8 @@ def wait_for_jobset_ttr_to_be_found(
 
   Args:
     node_pool (Info): An instance of the Info class containing GKE metadata.
-    jobset_config: An instance of the JobSet class representing the jobset configuration.
+    jobset_config: An instance of the JobSet class representing the jobset
+    configuration.
     start_time (TimeUtil, optional): The UTC timestamp to start polling from.
     If not provided, defaults to 60 minutes before the current time.
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -271,13 +271,17 @@ class JobSet(BaseModel, MutableMapping):
     """Allows attribute-style access."""
     self[key] = value
 
-  def __iter__(self):
-    """Necessary MutableMapping method: iterates over non-None field keys."""
-    return (k for k, v in self.model_dump().items() if v is not None)
+  def to_dict(self) -> dict:
+    """Converts the JobSet to a dict, excluding None values."""
+    return {k: v for k, v in self.model_dump().items() if v is not None}
 
-  def __len__(self):
+  def __iter__(self) -> iter:
+    """Necessary MutableMapping method: iterates over non-None field keys."""
+    return iter(self.to_dict())
+
+  def __len__(self) -> int:
     """Necessary MutableMapping method: counts non-None fields."""
-    return sum(1 for v in self.model_dump().values() if v is not None)
+    return len(self.to_dict())
 
   def serialize(self) -> dict:
     """
@@ -290,7 +294,7 @@ class JobSet(BaseModel, MutableMapping):
     Returns:
       A dict representation of this JobSet, excluding unset fields.
     """
-    return {k: v for k, v in self.model_dump().items() if v is not None}
+    return self.to_dict()
 
   @staticmethod
   def deserialize(data: dict, version: int) -> "JobSet":
@@ -322,7 +326,7 @@ class JobSet(BaseModel, MutableMapping):
     Returns:
         A string containing the complete JobSet YAML.
     """
-    params = {k: v for k, v in self.model_dump().items() if v is not None}
+    params = self.to_dict()
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -327,6 +327,15 @@ class Command:
     ])
 
   @staticmethod
+  def k8s_delete_pod_command(
+      kubeconfig: str, pod_name: str, namespace: str
+  ) -> str:
+    return " ".join([
+        f"kubectl --kubeconfig={kubeconfig} delete pod {pod_name}",
+        f"-n {namespace} --wait=false",
+    ])
+
+  @staticmethod
   def k8s_suspend_jobset_command(
       kubeconfig: str, jobset_name: str, namespace: str
   ) -> str:

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -334,11 +334,12 @@ class Command:
     ])
 
   @staticmethod
-  def suspend_jobset(jobset_name: str) -> str:
-    return " ".join([
-        f"kubectl patch jobset {jobset_name}",
-        "--type=merge -p '{{\"spec\": {{\"suspend\": true}}}}'",
-    ])
+  def suspend_jobset(jobset_name: str, namespace: str) -> str:
+    patch_content = '{"spec": {"suspend": true}}'
+    return (
+        f"kubectl patch jobset {jobset_name} -n {namespace} "
+        f"--type=merge -p '{patch_content}'"
+    )
 
   class K8sGetPodsOutput(enum.Enum):
     DEFAULT = "json"

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -191,6 +191,7 @@ _TEMPLATE = string.Template(
 )
 # pylint: enable=line-too-long
 
+
 @dataclasses.dataclass
 class JobSet(dict):
   """
@@ -553,7 +554,7 @@ def build_jobset_from_gcs_yaml(
 @task
 def run_workload(
     node_pool: node_pool_info,
-    jobset_config: JobSet ,
+    jobset_config: JobSet,
     workload_type: Workload,
 ) -> TimeUtil:
   """

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -508,6 +508,24 @@ def build_jobset_from_gcs_yaml(
 
 
 @task
+def generate_jobset_name(dag_id: str) -> str:
+  """
+  Generates a jobset name.
+
+  Args:
+    dag_id: The DAG ID to use as a prefix for the jobset name.
+    (should be shorter than 40 characters to fit k8s naming 63 characters limit)
+  Returns:
+    A string representing the generated jobset name.
+  """
+  now_utc = datetime.datetime.now(datetime.timezone.utc)
+  timestamp = now_utc.strftime("%Y%m%d%H%M%S")
+  dag_id_prefix = dag_id.replace("_", "-").lower()
+
+  return f"{dag_id_prefix}-workload-{timestamp}"
+
+
+@task
 def run_workload(
     node_pool: node_pool_info, jobset_config: JobSet, workload_type: Workload
 ) -> TimeUtil:

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -343,8 +343,7 @@ class Command:
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
         f"--type=merge -p '"
-        '{{"spec": {{"suspend": true}}}}\''
-        ""
+        f"--type=merge -p '{json.dumps({'spec': {'suspend': True}})}'"
     )
 
   class K8sGetPodsOutput(enum.Enum):

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -372,7 +372,7 @@ class Command:
     return Command.k8s_get_pods(jobset_name, namespace, output)
 
 
-class ReplicaType(enum.Enum):
+class ReplicaStatus(enum.Enum):
   """Defines replica types."""
 
   READY = "ready"
@@ -383,7 +383,7 @@ class ReplicaType(enum.Enum):
 
 
 def get_replica_num(
-    replica_type: ReplicaType, job_name: str, node_pool: node_pool_info
+    replica_type: ReplicaStatus, job_name: str, node_pool: node_pool_info
 ) -> int:
   """
   Get the number of a certain type of replicas from a running jobset.
@@ -997,7 +997,7 @@ def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
 def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet,
-    replica_type: ReplicaType,
+    replica_type: ReplicaStatus,
     expected_replica_number: int,
 ):
   """
@@ -1006,7 +1006,7 @@ def wait_for_jobset_replica_number(
   Args:
     node_pool: Configuration object with cluster details.
     jobset_config: Configuration of JobSet which is being run.
-    replica_type(ReplicaType): The type of status being checked for.
+    replica_type(ReplicaStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
   """
   logging.info(

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -262,7 +262,10 @@ class JobSet(BaseModel, MutableMapping):
 
   def __getattr__(self, key: str) -> Any:
     """Allows attribute-style access."""
-    return self[key]
+    try:
+      return self[key]
+    except KeyError as e:
+      raise AttributeError(f"'JobSet' object has no attribute '{key}'") from e
 
   def __setattr__(self, key: str, value: Any) -> None:
     """Allows attribute-style access."""
@@ -1091,7 +1094,7 @@ def wait_for_jobset_replica_number(
   logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
-      job_name=jobset_config["replicated_job_name"],
+      job_name=jobset_config.replicated_job_name,
       node_pool=node_pool,
   )
   return suspended_replica_number == expected_replica_number

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -943,6 +943,8 @@ def ensure_no_jobset_uptime_data(
     logging.info("Stability period passed with no data detected.")
     return True
   return False
+
+
 @task
 def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
   """

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -342,7 +342,9 @@ class Command:
     return (
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
-        f"--type=merge -p '{{\"spec\": {{\"suspend\": true}}}}'"
+        f"--type=merge -p '"
+        '{{"spec": {{"suspend": true}}}}\''
+        ""
     )
 
   class K8sGetPodsOutput(enum.Enum):

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -327,12 +327,17 @@ class Command:
     ])
 
   @staticmethod
-  def k8s_delete_pod_command(
-      kubeconfig: str, pod_name: str, namespace: str
-  ) -> str:
+  def k8s_get_pod_name_command(kubeconfig: str, namespace: str) -> str:
     return " ".join([
-        f"kubectl --kubeconfig={kubeconfig} delete pod {pod_name}",
-        f"-n {namespace} --wait=false",
+        f"kubectl --kubeconfig={kubeconfig} get pods",
+        f"-n {namespace} -o jsonpath={{.items[*].metadata.name}}",
+    ])
+
+  @staticmethod
+  def suspend_jobset(jobset_name: str) -> str:
+    return " ".join([
+        f"kubectl patch jobset {jobset_name}",
+        "--type=merge -p '{{\"spec\": {{\"suspend\": true}}}}'",
     ])
 
   class K8sGetPodsOutput(enum.Enum):
@@ -670,7 +675,7 @@ def delete_one_random_pod(
 
   Raises:
     AirflowFailException: If no running pods are found in the specified
-      namespace.
+    namespace.
   """
   running_pods = get_running_pods(
       node_pool=node_pool,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -24,7 +24,8 @@ import random
 import string
 import tempfile
 import textwrap
-from typing import Final, Optional
+from typing import Final
+from typing_extensions import override
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
@@ -192,7 +193,7 @@ _TEMPLATE = string.Template(
 
 
 @dataclasses.dataclass
-class JobSet:
+class JobSet(dict):
   """
   Generates YAML configurations for Kubernetes JobSets.
 
@@ -232,6 +233,20 @@ class JobSet:
   image: str
   tpu_cores_per_pod: int
   node_pool_selector: str
+
+  @override
+  def __getitem__(self, key):
+    try:
+      return getattr(self, key)
+    except AttributeError:
+      return super().__getitem__(key)
+
+  @override
+  def __setitem__(self, key, value):
+    if hasattr(self, key):
+      setattr(self, key, value)
+    else:
+      super().__setitem__(key, value)
 
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.
@@ -489,24 +504,24 @@ def _generate_jobset_name(dag_id_prefix: str) -> str:
   return f"{dag_id_prefix}-{timestamp}"
 
 
-def _build_jobset_config_dict(
-    gcs_path: str, dag_name: str, **overrides
+@task.python(multiple_outputs=True)
+def build_jobset_from_gcs_yaml(
+    gcs_path: str,
+    dag_name: str,
+    **overrides,
 ) -> dict:
   """
-  Builds a dictionary of JobSet configuration by loading from GCS and applying
-  overrides.
+  Builds a JobSet instance by merging YAML defaults and generating
+  a timestamped name based on dag_id_prefix.
 
   Args:
     gcs_path: The GCS path to the YAML configuration file.
     dag_name: The name of the DAG to extract specific configurations.
     **overrides: Additional parameters to override default configurations.
-  Returns:
-    A dictionary containing the config_dict JobSet configuration.
   """
-
   config = gcs.load_yaml_from_gcs(gcs_path)
   known_fields = {f.name for f in dataclasses.fields(JobSet)}
-  config_dict = {
+  merged = {
       k: v
       for k, v in config.get("jobset_defaults", {}).items()
       if k in known_fields
@@ -516,64 +531,15 @@ def _build_jobset_config_dict(
 
   for k, v in dag_cfg.items():
     if k in known_fields and v is not None:
-      config_dict[k] = v
+      merged[k] = v
 
-  config_dict.update({k: v for k, v in overrides.items() if k in known_fields})
-  config_dict["jobset_name"] = _generate_jobset_name(dag_id_prefix)
+  merged.update({k: v for k, v in overrides.items() if k in known_fields})
+  merged["jobset_name"] = _generate_jobset_name(dag_id_prefix)
 
   logging.info(
-      f"Final jobset dictionary '{config_dict['jobset_name']}' "
-      f"created for DAG '{dag_name}'"
+      f"Final JobSet '{merged['jobset_name']}' created for DAG '{dag_name}'"
   )
-  return config_dict
-
-
-@task
-def build_jobset_dict_from_gcs_yaml(
-    gcs_path: str,
-    dag_name: str,
-    **overrides,
-) -> dict:
-  """
-  Builds a JobSet configuration dictionary from a GCS YAML file.
-
-  Args:
-    gcs_path: The GCS path to the YAML configuration file.
-    dag_name: The name of the DAG to extract specific configurations.
-    **overrides: Additional parameters to override default configurations.
-
-  Returns:
-    A dictionary containing the JobSet configuration.
-  """
-
-  return _build_jobset_config_dict(
-      gcs_path=gcs_path, dag_name=dag_name, **overrides
-  )
-
-
-@task
-def build_jobset_from_gcs_yaml(
-    gcs_path: str,
-    dag_name: str,
-    **overrides,
-) -> JobSet:
-  """
-  Builds a JobSet instance by merging YAML defaults and generating
-  a timestamped name based on dag_id_prefix.
-
-  Args:
-    gcs_path: The GCS path to the YAML configuration file.
-    dag_name: The name of the DAG to extract specific configurations.
-    **overrides: Additional parameters to override default configurations.
-
-  Returns:
-    A JobSet instance with the final configuration ready for use in the DAG.
-  """
-
-  jobset_dict = _build_jobset_config_dict(
-      gcs_path=gcs_path, dag_name=dag_name, **overrides
-  )
-  return JobSet(**jobset_dict)
+  return JobSet(**merged)
 
 
 @task
@@ -1059,8 +1025,7 @@ def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet | dict,
     job_status: ReplicatedJobStatus,
-    expected_replica_number: Optional[int] = None,
-    xcom_argument: Optional[dict] = None,
+    expected_replica_number: int,
 ):
   """
   A sensor which checks if the correct number jobset replicas in a status type.
@@ -1073,15 +1038,6 @@ def wait_for_jobset_replica_number(
     xcom_argument(dict): An optional argument to pull the expected replica number
       from an XCom push. Should be in the format {"replicas": int}.
   """
-
-  if (expected_replica_number is None) == (xcom_argument is None):
-    raise ValueError(
-        "Exactly one of expected_replica_number or xcom_argument must be "
-        "provided."
-    )
-
-  if xcom_argument is not None:
-    expected_replica_number = xcom_argument.get("replicas")
 
   if isinstance(jobset_config, dict):
     jobset_config = JobSet(**jobset_config)

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -327,10 +327,13 @@ class Command:
     ])
 
   @staticmethod
-  def k8s_suspend_jobset_command(jobset_name: str, namespace: str) -> str:
+  def k8s_suspend_jobset_command(
+      kubeconfig: str, jobset_name: str, namespace: str
+  ) -> str:
     patch_content = '{"spec": {"suspend": true}}'
     return (
-        f"kubectl patch jobset {jobset_name} -n {namespace} "
+        f"kubectl --kubeconfig={kubeconfig} "
+        f"patch jobset {jobset_name} -n {namespace} "
         f"--type=merge -p '{patch_content}'"
     )
 
@@ -958,3 +961,54 @@ def ensure_no_jobset_uptime_data(
     logging.info("Stability period passed with no data detected.")
     return True
   return False
+@task
+def suspended_jobset(node_pool: node_pool_info, jobset_config: JobSet):
+  """
+  Suspend a jobset from the GKE cluster.
+
+  This task executes a bash script to:
+  1. Authenticate `gcloud` with the specified GKE cluster.
+  2. Suspend a JobSet.
+
+  Args:
+    node_pool: Configuration object with cluster details.
+    jobset_name: The name of the JobSet to delete.
+  """
+  with tempfile.NamedTemporaryFile() as temp_config_file:
+    env = os.environ.copy()
+    env["KUBECONFIG"] = temp_config_file.name
+
+    cmd = " && ".join([
+        Command.get_credentials_command(node_pool),
+        Command.k8s_suspend_jobset_command(
+            temp_config_file.name,
+            jobset_config.jobset_name,
+            jobset_config.namespace,
+        ),
+    ])
+
+    subprocess.run_exec(cmd, env=env)
+
+@task.sensor(poke_interval=30, timeout=900, mode="poke")
+def wait_for_jobset_replica_number(
+    node_pool: node_pool_info,
+    jobset_config: JobSet,
+    replica_type: str,
+    correct_replica_num: int,
+):
+  """
+  A sensor which checks if the correct number jobset replicas in a status type.
+
+  Args:
+    node_pool: Configuration object with cluster details.
+    jobset_config: Configuration of JobSet which is being run.
+    replica_type(str): The name of the type of status being checked for.
+    correct_replica_num(int): The expected number of replicas to be found.
+  """
+  logging.info("Checking for number of replicas of type: %s", replica_type)
+  ready_replicas = get_replica_num(
+      replica_type=replica_type,
+      job_name=jobset_config.replicated_job_name,
+      node_pool=node_pool,
+  )
+  return ready_replicas == correct_replica_num

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -24,7 +24,7 @@ import random
 import string
 import tempfile
 import textwrap
-from typing import Final
+from typing import Final, Optional
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
@@ -1059,7 +1059,8 @@ def wait_for_jobset_replica_number(
     node_pool: node_pool_info,
     jobset_config: JobSet | dict,
     job_status: ReplicatedJobStatus,
-    expected_replica_number: int,
+    expected_replica_number: Optional[int] = None,
+    xcom_argument: Optional[dict] = None,
 ):
   """
   A sensor which checks if the correct number jobset replicas in a status type.
@@ -1070,6 +1071,15 @@ def wait_for_jobset_replica_number(
     job_status(ReplicatedJobStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
   """
+
+  if (expected_replica_number is None) == (xcom_argument is None):
+    raise ValueError(
+        "Exactly one of expected_replica_number or xcom_argument must be "
+        "provided."
+    )
+
+  if xcom_argument is not None:
+    expected_replica_number = xcom_argument.get("replicas")
 
   if isinstance(jobset_config, dict):
     jobset_config = JobSet(**jobset_config)

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -566,9 +566,7 @@ def build_jobset_from_gcs_yaml(
 
 @task
 def run_workload(
-    node_pool: node_pool_info,
-    jobset_config: JobSet,
-    workload_type: Workload,
+    node_pool: node_pool_info, jobset_config: JobSet, workload_type: Workload
 ) -> TimeUtil:
   """
   Applies the specified YAML file to the GKE cluster.

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -1070,6 +1070,8 @@ def wait_for_jobset_replica_number(
     jobset_config: Configuration of JobSet which is being run.
     job_status(ReplicatedJobStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
+    xcom_argument(dict): An optional argument to pull the expected replica number
+      from an XCom push. Should be in the format {"replicas": int}.
   """
 
   if (expected_replica_number is None) == (xcom_argument is None):

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -342,7 +342,7 @@ class Command:
     return (
         f"kubectl --kubeconfig={kubeconfig} "
         f"patch jobset {jobset_name} -n {namespace} "
-        "--type=merge -p '{\"spec\": {\"suspend\": true}}'"
+        '--type=merge -p \'{"spec": {"suspend": true}}\''
     )
 
   class K8sGetPodsOutput(enum.Enum):
@@ -1008,9 +1008,7 @@ def wait_for_jobset_replica_number(
     job_status(ReplicatedJobStatus): The type of status being checked for.
     expected_replica_number(int): The expected number of replicas to be found.
   """
-  logging.info(
-      "Checking for number of replicas of type: %s", job_status.value
-  )
+  logging.info("Checking for number of replicas of type: %s", job_status.value)
   suspended_replica_number = get_replica_num(
       job_status=job_status,
       job_name=jobset_config.replicated_job_name,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -15,7 +15,6 @@
 """Utilities for managing JobSets in GKE clusters for TPU observability."""
 
 import enum
-import dataclasses
 from datetime import timedelta
 import json
 import logging
@@ -236,7 +235,7 @@ class JobSet(dict):
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
     for k, v in self.items():
-        setattr(self, k, v)
+      setattr(self, k, v)
 
   @override
   def __getitem__(self, key):
@@ -262,7 +261,7 @@ class JobSet(dict):
     Returns:
         A string containing the complete JobSet YAML.
     """
-    params = dataclasses.asdict(self)
+    params = dict(self)
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""
@@ -524,7 +523,7 @@ def build_jobset_from_gcs_yaml(
     **overrides: Additional parameters to override default configurations.
   """
   config = gcs.load_yaml_from_gcs(gcs_path)
-  known_fields = {f.name for f in dataclasses.fields(JobSet)}
+  known_fields = set(JobSet.__annotations__.keys())
   merged = {
       k: v
       for k, v in config.get("jobset_defaults", {}).items()

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -194,20 +194,18 @@ _TEMPLATE = string.Template(
 
 
 class JobSet(BaseModel, MutableMapping):
-  """
-  Generates YAML configurations for Kubernetes JobSets and serves as a
+  """Generates YAML configurations for Kubernetes JobSets and serves as a
   data transfer object specifically for Airflow XCom, 'multiple_outputs', etc.
 
-  BaseModel:
-    BaseModel is advanced version of @dataclass. we can do dynamic attribute
-      assignment, validation. More suitable in this case.
+  Note:
+    Extends Pydantic's BaseModel (rather than a plain dataclass) to leverage
+    runtime type validation, field coercion, and dynamic attribute assignment.
 
-  MutableMapping:
-    We avoid to use dict here. Since airflow will adapt default serialization
-      and deserialization process on dict, we might lose BaseModel's
-      features. Instead, we implement MutableMapping, so airflow would just
-      call customized serialize() and deserialize() methods defined by
-      ourselves.
+    Implements MutableMapping instead of inheriting from dict to prevent
+    Airflow from invoking its default dict serialization/deserialization
+    logic, which would bypass BaseModel's field handling. By satisfying the
+    MutableMapping interface, Airflow delegates to the custom serialize() and
+    deserialize() methods defined on this class.
 
   Attributes:
     jobset_name: The name of the JobSet.

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -290,7 +290,7 @@ class JobSet(BaseModel, MutableMapping):
     return {k: v for k, v in self.model_dump().items() if v is not None}
 
   @staticmethod
-  def deserialize(data: dict) -> "JobSet":
+  def deserialize(data: dict, version: int) -> "JobSet":
     """
     Deserializes a dict retrieved from Airflow XCom back into a JobSet.
 

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -327,13 +327,6 @@ class Command:
     ])
 
   @staticmethod
-  def k8s_get_pod_name_command(kubeconfig: str, namespace: str) -> str:
-    return " ".join([
-        f"kubectl --kubeconfig={kubeconfig} get pods",
-        f"-n {namespace} -o jsonpath={{.items[*].metadata.name}}",
-    ])
-
-  @staticmethod
   def suspend_jobset(jobset_name: str, namespace: str) -> str:
     patch_content = '{"spec": {"suspend": true}}'
     return (


### PR DESCRIPTION
 # Description

Implemented the `jobset_healthiness_suspended `DAG to validate TPU v6e resource behavior when a v6e training workload JobSet are suspended. This ensures GKE infrastructure correctly handles resource release/re-acquisition while maintaining observability.

# Technical Implementation

- **Create Suspended status:** Using `kubectl patch jobset <jobset name> -n <namespace> --type=merge -p '{"spec": {"suspend": true}}'` to interrupt a running jobset. 
- **Status Validation:** Verifies the number of "suspended" matchs with expectation. 

# Airflow/Composer

- GCP Composer name: kim-test (under GCP project: cienet-cmcs)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5
- Test results: https://b827a8074a3e45609878ed3189e81f27-dot-us-central1.composer.googleusercontent.com/dags/jobset_healthiness_suspended/grid
# Required Variables 

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to jobset-sdk-monitoring-v6e)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.