### PR TITLE
Feat: add jobset_ttr_pod_oom DAG for v6e recovery validation

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -64,6 +64,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "jobset_uptime_validation": dt.timedelta(minutes=90),
         "jobset_ttr_drain_restart": DefaultTimeout,
         "tpu_info_metrics_verification": DefaultTimeout,
+        "jobset_ttr_pod_oom": dt.timedelta(minutes=90),
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {
         "validate_interruption_count_gce_bare_metal_preemption": DefaultTimeout,

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -46,8 +46,8 @@ def trigger_oom_failure(info, pod_name: str):
   A connection error is expected and caught when the pod is killed.
 
   Args:
-      info: Node pool and cluster information.
-      pod_name (str): The name of the target pod to be OOMKilled.
+    info: Node pool and cluster information.
+    pod_name (str): The name of the target pod to be OOMKilled.
   """
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
@@ -75,10 +75,10 @@ def pick_random_pod(active_pods: List[str]) -> str:
   JobSet controller handles partial failures within a replica.
 
   Args:
-      pod_names (List[str]): List of active pod names in the JobSet.
+    pod_names (List[str]): List of active pod names in the JobSet.
 
   Returns:
-      str: The name of the randomly selected pod.
+    str: The name of the randomly selected pod.
   """
   if not active_pods:
     raise ValueError("No pods found to attack!")

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A DAG to validate the `tpumonitoring` SDK, ensuring help() and
-list_supported_metrics() are functional inside TPU worker pods."""
+"""A DAG to validate JobSet Time-to-Recover (TTR) metrics
+by injecting Out-of-Memory (OOM) faults into TPU worker pods."""
 
 import datetime
 import tempfile

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -219,14 +219,13 @@ with models.DAG(
     )
 
     chain(
-      create_node_pool,
-      start_workload,
-      ensure_all_pods_running,
-      found_pods,
-      select_random_pod,
-      trigger_oom_killed,
-      wait_for_metric_upload,
-      cleanup_workload,
-      cleanup_node_pool,
+        create_node_pool,
+        start_workload,
+        ensure_all_pods_running,
+        found_pods,
+        select_random_pod,
+        trigger_oom_killed,
+        wait_for_metric_upload,
+        cleanup_workload,
+        cleanup_node_pool,
     )
-

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -219,6 +219,7 @@ with models.DAG(
     )
 
     chain(
+        cluster_info,
         create_node_pool,
         start_workload,
         ensure_all_pods_running,

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -1,0 +1,234 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A DAG to validate the `tpumonitoring` SDK, ensuring help() and
+list_supported_metrics() are functional inside TPU worker pods."""
+
+import datetime
+import tempfile
+import os
+import random
+from typing import List
+
+from airflow import models
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
+from airflow.decorators import task
+
+from dags import composer_env
+from dags.tpu_observability.utils import jobset_util as jobset
+from dags.tpu_observability.utils import node_pool_util as node_pool
+from dags.tpu_observability.utils import subprocess_util as subprocess
+from dags.tpu_observability.utils.jobset_util import JobSet, Workload
+from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+
+
+@task
+def trigger_oom_failure(info, pod_name: str):
+    """
+    Triggers an OOM (Out-of-Memory) event on a specified TPU pod.
+
+    This task connects to the specified pod via kubectl exec and runs a
+    memory-intensive Python script (oomkill.py). The script is designed
+    to exhaust the container's memory limit, forcing a SIGKILL (Exit Code 137).
+    A connection error is expected and caught when the pod is killed.
+
+    Args:
+        info: Node pool and cluster information.
+        pod_name (str): The name of the target pod to be OOMKilled.
+    """
+    with tempfile.NamedTemporaryFile() as temp_config_file:
+        env = os.environ.copy()
+        env["KUBECONFIG"] = temp_config_file.name
+
+        cmd = " && ".join([
+            jobset.Command.get_credentials_command(info),
+            f"kubectl exec {pod_name} -n default -- python3 oomkill.py",
+        ])
+
+        try:
+            print(f"Executing OOM script in {pod_name}...")
+            subprocess.run_exec(cmd, env=env)
+        except Exception as e:
+            print(f"Expectation: Connection closed due to OOMKilled. Info: {e}")
+
+@task
+def pick_random_pod(pod_names: List[str]) -> str:
+    """
+    Randomly selects one pod from a list of available JobSet pods.
+
+    This ensures that the fault injection is performed on a single
+    unit of the TPU slice, allowing the test to validate how the
+    JobSet controller handles partial failures within a replica.
+
+    Args:
+        pod_names (List[str]): List of active pod names in the JobSet.
+
+    Returns:
+        str: The name of the randomly selected pod.
+    """
+    if not pod_names:
+        raise ValueError("No pods found to attack!")
+    chosen_pod = random.choice(pod_names)
+    print(f"Randomly selected pod for OOM test: {chosen_pod}")
+    return chosen_pod
+
+with models.DAG(
+    dag_id="jobset_ttr_pod_oom",
+    start_date=datetime.datetime(2026, 1, 15),
+    schedule="0 18 * * *" if composer_env.is_prod_env() else None,
+    catchup=False,
+    tags=[
+        "cloud-ml-auto-solutions",
+        "jobset",
+        "tpu-observability",
+        "pod_oom",
+        "TPU",
+        "v6e-16",
+        "SDK",
+        "Validation",
+    ],
+    description=(
+        "This DAG tests the JobSet time-to-recover metric by injecting an OOM event "
+        "into a random pod to trigger a recovery, then polls Cloud Monitoring to "
+        "verify the metric is updated."
+    ),
+    doc_md="""
+        ### JobSet Time-To-Recover (TTR) Test Using Random Pod OOM Injection
+        ### Description
+        This DAG verifies that JobSet can recover from a single pod failure caused by
+        an Out-Of-Memory (OOM) event. It launches a JobSet with memory limits,
+        injects a memory-intensive workload into a running pod, and uses a sensor
+        to confirm that the JobSet controller triggers a recovery and reports the
+        recovery duration.
+        ### Prerequisites
+        This test requires an existing cluster and a container image containing
+        the `oomkill.py` script to run.
+        ### Procedures
+        First, the node pool is created. A JobSet YAML with specific memory constraints
+        is then launched on the cluster and given time for all pods to reach a
+        `Running` state. After this, a random pod is selected and an OOM event is
+        triggered via `kubectl exec` to interrupt the JobSet (expecting Exit Code 137).
+        A sensor is finally run which will poll Cloud Monitoring to detect that the
+        JobSet Time-To-Recover (TTR) metric has been updated, resulting in a success,
+        or timeout, and fail.
+      """,
+) as dag:
+  for machine in MachineConfigMap:
+    config = machine.value
+
+    jobset_config = JobSet(
+        jobset_name="jobset-ttr-pod-oom-v6e-workload",
+        namespace="default",
+        max_restarts=5,
+        replicated_job_name="tpu-job-slice",
+        replicas=1,
+        backoff_limit=0,
+        completions=4,
+        parallelism=4,
+        tpu_accelerator_type="tpu-v6e-slice",
+        tpu_topology="4x4",
+        container_name="jax-tpu-worker",
+        image="us-docker.pkg.dev/cienet-cmcs/emma-tpu-test-repo/oom-test:v1",
+        tpu_cores_per_pod=4,
+    )
+    raw_yaml = jobset_config.generate_yaml(workload_script="sleep infinity")
+    custom_yaml = raw_yaml.replace(
+        "google.com/tpu: 4",
+        "google.com/tpu: 4\n                  memory: \"4Gi\""
+    )
+  # Keyword arguments are generated dynamically at runtime (pylint does not
+  # know this signature).
+  with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+      group_id=f"v{config.tpu_version.value}"
+  ):
+    cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+        task_id="build_node_pool_info_from_gcs_yaml"
+    )(
+        gcs_path=GCS_CONFIG_PATH,
+        dag_name="jobset_ttr_pod_oom",
+        is_prod=composer_env.is_prod_env(),
+        machine_type=config.machine_version.value,
+        tpu_topology=config.tpu_topology,
+    )
+
+    create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+        node_pool=cluster_info,
+    )
+
+    start_workload = jobset.run_workload.override(task_id="start_workload")(
+        node_pool=cluster_info,
+        yaml_config=custom_yaml,
+        namespace=jobset_config.namespace,
+    )
+
+    ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
+        task_id="ensure_all_pods_running"
+    )(
+        num_pods=(jobset_config.replicas * jobset_config.parallelism),
+        node_pool=cluster_info,
+    )
+
+    pod_names = jobset.list_pod_names.override(task_id="list_pod_names")(
+        node_pool=cluster_info,
+        namespace=jobset_config.namespace,
+    )
+
+    select_random_pod = pick_random_pod.override(task_id='select_random_pod')(
+       pod_names=pod_names
+    )
+
+    trigger_oom_killed = trigger_oom_failure.override(task_id='trigger_oom_killed')(
+        info=cluster_info,
+        pod_name=select_random_pod
+    )
+
+    wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+          task_id="wait_for_jobset_ttr_to_be_found"
+      )(
+          node_pool=cluster_info,
+          jobset_name=jobset_config.jobset_name,
+      )
+
+    cleanup_workload = jobset.end_workload.override(
+        task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+    )(
+        node_pool=cluster_info,
+        jobset_name=jobset_config.jobset_name,
+        namespace=jobset_config.namespace,
+    ).as_teardown(
+        setups=start_workload
+    )
+
+    cleanup_node_pool = node_pool.delete.override(
+        task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+    )(node_pool=cluster_info).as_teardown(
+        setups=create_node_pool,
+    )
+
+    # Airflow uses >> for task chaining, which is pointless for pylint.
+    # pylint: disable=pointless-statement
+    (
+        cluster_info
+        >> create_node_pool
+        >> start_workload
+        >> ensure_all_pods_running
+        >> pod_names
+        >> select_random_pod
+        >> trigger_oom_killed
+        >> wait_for_metric_upload
+        >> cleanup_workload
+        >> cleanup_node_pool
+    )
+    # pylint: enable=pointless-statement

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -19,7 +19,7 @@ import datetime
 import tempfile
 import os
 import random
-import time
+import logging
 from typing import List
 
 from airflow import models
@@ -66,11 +66,7 @@ def trigger_oom_failure(info, pod_name: str, namespace: str):
     the expected connection loss during an OOM event.
   """
 
-  wait_time = 60
-  print(
-      f"Waiting {wait_time}s for Pod {pod_name} to stabilize before OOM Test..."
-  )
-  time.sleep(wait_time)
+  logging.info(f"Checking status for Pod {pod_name}...")
 
   python_logic = (
       "import time\n"
@@ -87,19 +83,26 @@ def trigger_oom_failure(info, pod_name: str, namespace: str):
     env["KUBECONFIG"] = temp_config_file.name
 
     credentials_cmd = jobset.Command.get_credentials_command(info)
+
+    wait_cmd = (
+        f"kubectl wait --for=condition=Ready pod/{pod_name} "
+        f"-n {namespace} --timeout=60s"
+    )
+
     exec_cmd = (
         f'kubectl exec {pod_name} -n {namespace} -- python3 -c "{python_logic}"'
     )
 
-    full_command = f"{credentials_cmd} && {exec_cmd}"
+    full_command = f"{credentials_cmd} && {wait_cmd} && {exec_cmd}"
 
     try:
-      print(f"Blasting {pod_name} memory now...")
+      logging.info(f"Blasting {pod_name} memory now...")
       subprocess.run_exec(full_command, env=env)
     except subprocess.ProcessKilledException:
-      print(f"Success: Pod {pod_name} was OOMKilled.")
+      logging.info(f"Success: Pod {pod_name} was OOMKilled.")
     except Exception as e:
-      print(f"Connection lost or other error: {e}")
+      logging.error(f"Connection lost or other error: {e}")
+      raise e
 
 
 @task
@@ -120,7 +123,7 @@ def pick_random_pod(active_pods: List[str]) -> str:
   if not active_pods:
     raise ValueError("No pods found to attack!")
   chosen_pod = random.choice(active_pods)
-  print(f"Randomly selected pod for OOM test: {chosen_pod}")
+  logging.info(f"Randomly selected pod for OOM test: {chosen_pod}")
   return chosen_pod
 
 

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -19,6 +19,7 @@ import datetime
 import tempfile
 import os
 import random
+import time
 from typing import List
 
 from airflow import models
@@ -31,38 +32,75 @@ from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils import subprocess_util as subprocess
-from dags.tpu_observability.utils.jobset_util import JobSet
-from dags.tpu_observability.configs.common import MachineConfigMap, GCS_CONFIG_PATH
+from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.configs.common import (
+    MachineConfigMap,
+    GCS_CONFIG_PATH,
+    GCS_JOBSET_CONFIG_PATH,
+)
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+
+DAG_ID = "jobset_ttr_pod_oom"
+DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
+SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 
 @task
-def trigger_oom_failure(info, pod_name: str):
+def trigger_oom_failure(info, pod_name: str, namespace: str):
   """
-  Triggers an OOM (Out-of-Memory) event on a specified TPU pod.
+  Injects an OOM fault by running a memory-intensive loop inside a pod.
 
-  This task connects to the specified pod via kubectl exec and runs a
-  memory-intensive Python script (oomkill.py). The script is designed
-  to exhaust the container's memory limit, forcing a SIGKILL (Exit Code 137).
-  A connection error is expected and caught when the pod is killed.
+  This task waits for the target pod to stabilize, then executes a Python
+    one-liner via 'kubectl exec' that rapidly allocates memory. The script
+    uses bytearray allocation combined with an immediate write operation
+    (a[-1][0] = 1) to ensure physical RAM is committed by the OS, effectively
+    triggering a SIGKILL from the OOM Killer (Exit Code 137).
 
   Args:
-    info: Node pool and cluster information.
-    pod_name (str): The name of the target pod to be OOMKilled.
+    info: An object containing cluster and node pool credentials/metadata.
+    pod_name: The name of the target TPU worker pod to inject the fault.
+    namespace: The Kubernetes namespace where the pod is running.
+
+  Raises:
+    Exception: If the subprocess execution fails for reasons other than
+    the expected connection loss during an OOM event.
   """
+
+  wait_time = 60
+  print(
+      f"Waiting {wait_time}s for Pod {pod_name} to stabilize before OOM Test..."
+  )
+  time.sleep(wait_time)
+
+  python_logic = (
+      "import time\n"
+      "a = []\n"
+      "print('Starting memory stress test...')\n"
+      "while True:\n"
+      "    a.append(bytearray(1024**3))\n"
+      "    a[-1][0] = 1\n"
+      "    time.sleep(0.01)"
+  )
+
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
 
-    cmd = " && ".join([
-        jobset.Command.get_credentials_command(info),
-        f"kubectl exec {pod_name} -n default -- python3 oomkill.py",
-    ])
+    credentials_cmd = jobset.Command.get_credentials_command(info)
+    exec_cmd = (
+        f'kubectl exec {pod_name} -n {namespace} -- python3 -c "{python_logic}"'
+    )
+
+    full_command = f"{credentials_cmd} && {exec_cmd}"
 
     try:
-      print(f"Executing OOM script in {pod_name}...")
-      subprocess.run_exec(cmd, env=env)
-    except RuntimeError as e:
-      print(f"Expectation: Connection closed due to OOMKilled. Info: {e}")
+      print(f"Blasting {pod_name} memory now...")
+      subprocess.run_exec(full_command, env=env)
+    except Exception as e:
+      if "137" in str(e):
+        print(f"Success: Pod {pod_name} was OOMKilled (Exit Code 137).")
+      else:
+        print(f"Connection lost (Possible OOM): {e}")
 
 
 @task
@@ -88,9 +126,10 @@ def pick_random_pod(active_pods: List[str]) -> str:
 
 
 with models.DAG(
-    dag_id="jobset_ttr_pod_oom",
+    dag_id=DAG_ID,
     start_date=datetime.datetime(2026, 1, 15),
-    schedule="0 18 * * *" if composer_env.is_prod_env() else None,
+    schedule=SCHEDULE if composer_env.is_prod_env() else None,
+    dagrun_timeout=DAGRUN_TIMEOUT,
     catchup=False,
     tags=[
         "cloud-ml-auto-solutions",
@@ -130,103 +169,82 @@ with models.DAG(
   for machine in MachineConfigMap:
     config = machine.value
 
-    jobset_config = JobSet(
-        jobset_name="jobset-ttr-pod-oom-v6e-workload",
-        namespace="default",
-        max_restarts=5,
-        replicated_job_name="tpu-job-slice",
-        replicas=1,
-        backoff_limit=0,
-        completions=4,
-        parallelism=4,
-        tpu_accelerator_type="tpu-v6e-slice",
-        tpu_topology="4x4",
-        container_name="jax-tpu-worker",
-        image="us-docker.pkg.dev/cienet-cmcs/emma-tpu-test-repo/oom-test:v1",
-        tpu_cores_per_pod=4,
-    )
-    raw_yaml = jobset_config.generate_yaml(workload_script="sleep infinity")
-    custom_yaml = raw_yaml.replace(
-        "google.com/tpu: 4",
-        'google.com/tpu: 4\n                  memory: "4Gi"',
-    )
-  # Keyword arguments are generated dynamically at runtime (pylint does not
-  # know this signature).
-  with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-      group_id=f"v{config.tpu_version.value}"
-  ):
-    cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
-        task_id="build_node_pool_info_from_gcs_yaml"
-    )(
-        gcs_path=GCS_CONFIG_PATH,
-        dag_name="jobset_ttr_pod_oom",
-        is_prod=composer_env.is_prod_env(),
-        machine_type=config.machine_version.value,
-        tpu_topology=config.tpu_topology,
-    )
+    # Keyword arguments are generated dynamically at runtime (pylint does not
+    # know this signature).
+    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}"
+    ):
+      selector = jobset.generate_node_pool_selector("jobset-ttr-pod-oom")
 
-    create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-        node_pool=cluster_info,
-    )
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+          node_pool_selector=selector,
+      )
 
-    start_workload = jobset.run_workload.override(task_id="start_workload")(
-        node_pool=cluster_info,
-        yaml_config=custom_yaml,
-        namespace=jobset_config.namespace,
-    )
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml.override(
+          task_id="build_node_pool_info_from_gcs_yaml"
+      )(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name=DAG_ID,
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+          node_pool_selector=selector,
+      )
 
-    ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
-        task_id="ensure_all_pods_running"
-    )(
-        num_pods=(jobset_config.replicas * jobset_config.parallelism),
-        node_pool=cluster_info,
-    )
+      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+          node_pool=cluster_info,
+      )
 
-    found_pods = jobset.list_pod_names.override(task_id="list_pod_names")(
-        node_pool=cluster_info,
-        namespace=jobset_config.namespace,
-    )
+      start_workload = jobset.run_workload.override(task_id="start_workload")(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
+      )
 
-    select_random_pod = pick_random_pod.override(task_id="select_random_pod")(
-        active_pods=found_pods
-    )
+      ensure_all_pods_running = jobset.wait_for_all_pods_running.override(
+          task_id="ensure_all_pods_running"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      )
 
-    trigger_oom_killed = trigger_oom_failure.override(
-        task_id="trigger_oom_killed"
-    )(info=cluster_info, pod_name=select_random_pod)
+      select_random_pod = pick_random_pod.override(task_id="select_random_pod")(
+          active_pods=ensure_all_pods_running
+      )
 
-    wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-        task_id="wait_for_jobset_ttr_to_be_found"
-    )(
-        node_pool=cluster_info,
-        jobset_name=jobset_config.jobset_name,
-    )
+      trigger_oom_killed = trigger_oom_failure.override(
+          task_id="trigger_oom_killed"
+      )(info=cluster_info, pod_name=select_random_pod, namespace="default")
 
-    cleanup_workload = jobset.end_workload.override(
-        task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-    )(
-        node_pool=cluster_info,
-        jobset_name=jobset_config.jobset_name,
-        namespace=jobset_config.namespace,
-    ).as_teardown(
-        setups=start_workload
-    )
+      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+          task_id="wait_for_jobset_ttr_to_be_found"
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+      )
 
-    cleanup_node_pool = node_pool.delete.override(
-        task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-    )(node_pool=cluster_info).as_teardown(
-        setups=create_node_pool,
-    )
+      cleanup_workload = jobset.end_workload.override(
+          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=cluster_info, jobset_config=jobset_config).as_teardown(
+          setups=start_workload
+      )
 
-    chain(
-        cluster_info,
-        create_node_pool,
-        start_workload,
-        ensure_all_pods_running,
-        found_pods,
-        select_random_pod,
-        trigger_oom_killed,
-        wait_for_metric_upload,
-        cleanup_workload,
-        cleanup_node_pool,
-    )
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=cluster_info).as_teardown(
+          setups=create_node_pool,
+      )
+
+      chain(
+          cluster_info,
+          create_node_pool,
+          start_workload,
+          ensure_all_pods_running,
+          select_random_pod,
+          trigger_oom_killed,
+          wait_for_metric_upload,
+          cleanup_workload,
+          cleanup_node_pool,
+      )

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -149,20 +149,20 @@ with models.DAG(
         ### JobSet Time-To-Recover (TTR) Test Using Random Pod OOM Injection
         ### Description
         This DAG verifies that JobSet can recover from a single pod failure caused by
-        an Out-Of-Memory (OOM) event. It launches a JobSet with memory limits,
-        injects a memory-intensive workload into a running pod, and uses a sensor
-        to confirm that the JobSet controller triggers a recovery and reports the
-        recovery duration.
+        an Out-Of-Memory (OOM) event. It launches a JobSet, injects a memory-intensive
+        Python stressor into a running pod, and uses a sensor to confirm that the
+        JobSet controller triggers a recovery and reports the recovery duration (TTR).
         ### Prerequisites
-        This test requires an existing cluster and a container image containing
-        the `oomkill.py` script to run.
+        This test requires an existing cluster and the ability to execute commands
+        within the pod via `kubectl exec`.
         ### Procedures
-        First, the node pool is created. A JobSet YAML with specific memory constraints
-        is then launched on the cluster and given time for all pods to reach a
-        `Running` state. After this, a random pod is selected and an OOM event is
-        triggered via `kubectl exec` to interrupt the JobSet (expecting Exit Code 137).
-        A sensor is finally run which will poll Cloud Monitoring to detect that the
-        JobSet Time-To-Recover (TTR) metric has been updated, resulting in a success,
+        First, the node pool is created. A JobSet YAML is then launched on the cluster
+        and given time for all pods to reach a `Running` state. After stabilization,
+        a random pod is selected and an OOM event is triggered via `kubectl exec`
+        using a Python-based memory allocator that forces physical RAM commitment
+        until the process is terminated (expecting Exit Code 137). A sensor is
+        finally run which will poll Cloud Monitoring to detect that the JobSet
+        Time-To-Recover (TTR) metric has been updated, resulting in a success,
         or timeout, and fail.
       """,
 ) as dag:

--- a/dags/tpu_observability/jobset_ttr_pod_oom.py
+++ b/dags/tpu_observability/jobset_ttr_pod_oom.py
@@ -96,11 +96,10 @@ def trigger_oom_failure(info, pod_name: str, namespace: str):
     try:
       print(f"Blasting {pod_name} memory now...")
       subprocess.run_exec(full_command, env=env)
+    except subprocess.ProcessKilledException:
+      print(f"Success: Pod {pod_name} was OOMKilled.")
     except Exception as e:
-      if "137" in str(e):
-        print(f"Success: Pod {pod_name} was OOMKilled (Exit Code 137).")
-      else:
-        print(f"Connection lost (Possible OOM): {e}")
+      print(f"Connection lost or other error: {e}")
 
 
 @task

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -749,7 +749,7 @@ def wait_for_jobset_started(
   return all(p > threshold_value for p in last_n_data_points)
 
 
-@task.sensor(poke_interval=60, timeout=3600, mode="reschedule")
+@task.sensor(poke_interval=60, timeout=3600, mode="poke")
 def wait_for_jobset_ttr_to_be_found(
     node_pool: node_pool_info,
     jobset_config: JobSet,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -749,7 +749,7 @@ def wait_for_jobset_started(
   return all(p > threshold_value for p in last_n_data_points)
 
 
-@task.sensor(poke_interval=60, timeout=3600, mode="poke")
+@task.sensor(poke_interval=60, timeout=3600, mode="reschedule")
 def wait_for_jobset_ttr_to_be_found(
     node_pool: node_pool_info,
     jobset_config: JobSet,

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
 # Description

The primary goal of this PR is to implement the `jobset_ttr_pod_oom` DAG, designed to validate the self-healing capability of TPU JobSets under memory pressure. Unlike simple pod deletion, this DAG automates **OOM (Out-Of-Memory) fault injection** to ensure JAX workloads and the JobSet controller correctly handle and recover from container-level failures.

# Technical Implementation

- **Dynamic Provisioning:** Builds node pool info from GCS configurations and provisions TPU resources based on `MachineConfigMap` (e.g., v6e-16).
- **Resource Constraints:** Dynamically injects memory limits (e.g., 4Gi) into the JobSet YAML to facilitate rapid OOM triggering.
- **Fault Injection:** Implements `@task` `trigger_oom_killed` which executes `oomkill.py` inside a random pod via kubectl exec. 
- **Detection Phase:** Monitors the JobSet's reaction. It expects the JobSet to detect the missing pod and trigger a full-slice restart (Killing event) to maintain JAX synchronization.
- **Performance Metric:** Measures the Time To Recovery (TTR). 

# Airflow/Composer

- GCP Composer name: emmalien-test (under GCP project: cienet-cmcs)
- GCP Composer version: 2.13.1
- GCP Airflow version: 2.10.5
- Test results: https://35b13c750f364c56b55b9367bb681dee-dot-us-central1.composer.googleusercontent.com/dags/jobset_ttr_pod_oom/grid
# Required Variables 

- Cluster Information (This DAG requires an existing cluster)
  - PROJECT_ID: The GCP project ID where the cluster resides. (Default to cienet-cmcs)
  - CLUSTER_NAME: The name of the target GKE cluster. (Default to tpu-observability-automation-dev)
  - LOCATION: The region of the GKE cluster. (Default to us-central1)

- Node Pool Configurations
  - NODE_POOL_NAME: The base name for the new node pool. (Default to jobset-ttr-pod-oom-v6e)
  - NODE_LOCATIONS: The zone for the nodes in the normal test path. (Default to us-central1-b)
  - NUM_NODES: The number of nodes to create in the pool. (Default to 4)
  - MACHINE_TYPE: The machine type for the GKE nodes. (Default to ct6e-standard-4t)
  - TPU_TOPOLOGY: The TPU topology for the node pool. (Default to 4x4)


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.