### PR TITLE
update pw_mcjax_dag, with imagee, kpo and pass workload_id

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/maxtext_pathways/configs/parameters.py
+++ b/dags/maxtext_pathways/configs/parameters.py
@@ -17,6 +17,7 @@
 from airflow.models.param import Param
 from dags.maxtext_pathways.configs import model_configs as model_cfg
 from dags.common.vm_resource import TpuVersion
+from dags.common.vm_resource import DockerImage
 
 MODEL_FRAMEWORK = ["mcjax", "pathways"]
 
@@ -31,6 +32,8 @@ MODEL_NAME.extend(V5P_MODEL_NAME)
 MODEL_NAME.extend(V6E_MODEL_NAME)
 
 DEVICE_VERSION = ["v" + version.value for version in TpuVersion]
+
+IMAGE = DockerImage.MAXTEXT_TPU_JAX_STABLE
 
 PARAMETERS = {
     "user": Param(
@@ -92,22 +95,21 @@ PARAMETERS = {
         description="Number of slices",
     ),
     "server_image": Param(
-        # TODO(b/451750407): Replace this temporary image with a formal one.
-        "gcr.io/cienet-cmcs/lidanny/unsanitized_server:latest",
+        # Reference to https://g3doc.corp.google.com/cloud/tpu/g3doc/fas/pathways-on-cloud/index.md?cl=head
+        "us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:20260102-jax_0.8.1",
         type="string",
         title="Server Image",
         description="Server image for pathways.",
     ),
     "proxy_image": Param(
-        # TODO(b/451750407): Replace this temporary image with a formal one.
-        "gcr.io/cienet-cmcs/lidanny/unsanitized_proxy_server:latest",
+        # Reference to https://g3doc.corp.google.com/cloud/tpu/g3doc/fas/pathways-on-cloud/index.md?cl=head
+        "us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:20260102-jax_0.8.1",
         type="string",
         title="Proxy Image",
         description="Proxy image for pathways.",
     ),
     "runner": Param(
-        # TODO(b/451750407): Replace this temporary image with a formal one.
-        "gcr.io/cienet-cmcs/lidanny_latest:latest",
+        IMAGE.value,
         type="string",
         title="Runner Image",
         description="Runner image for the cluster.",

--- a/dags/maxtext_pathways/configs/recipe_config.py
+++ b/dags/maxtext_pathways/configs/recipe_config.py
@@ -53,6 +53,6 @@ RECIPE_FLAG = [
     "bq_enable",
     "bq_db_project",
     "bq_db_dataset",
-    "temp_key",
+    "workload_id",
     "device_type",
 ]

--- a/dags/maxtext_pathways/pw_mcjax_dags.py
+++ b/dags/maxtext_pathways/pw_mcjax_dags.py
@@ -24,18 +24,12 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.subprocess import SubprocessHook
 from airflow.utils.trigger_rule import TriggerRule
 
-from airflow.providers.google.cloud.operators.kubernetes_engine import GKEStartPodOperator
-from kubernetes.client import models as k8s
-
 from dags import composer_env
 from dags.common import test_owner
 from dags.maxtext_pathways.configs import commands as cmds
 from dags.maxtext_pathways.configs import parameters as ui_params
 from dags.maxtext_pathways.configs import recipe_config as recipe_cfg
-from xlml.utils import xpk, gke
-
-# based on maxtext_dependencies.Dockerfile, and apply PR2715 in addition
-IMAGE = "gcr.io/cienet-cmcs/cnt_pathway:latest"
+from xlml.utils import kpo, xpk, gke
 
 
 @task.python(multiple_outputs=True)
@@ -58,7 +52,7 @@ def generate_derived_parameters(dag_params: dict) -> dict:
   # Generate recipe workload_id and temp_key.
   name, temp_post_fix = generate_recipe_workload_id(dag_params)
   derived_params["temp_key"] = temp_post_fix
-  derived_params["recipe_workload_id"] = name
+  derived_params["workload_id"] = name
 
   # Generate region by zone
   derived_params["region"] = gke.zone_to_region(dag_params["zone"])
@@ -312,42 +306,19 @@ with models.DAG(
   derived_params = generate_derived_parameters(dag_params)
   commands = generate_commands(dag_params, derived_params, RECIPE_INSTANCE)
 
-  start_recipe = GKEStartPodOperator(
-      task_id="start_recipe",
-      name=RECIPE_NAME.replace("_", "-"),
-      project_id=dag_params["project"],
-      cluster_name=dag_params["cluster_name"],
-      location=derived_params["region"],
-      namespace="default",
-      # This is required for `namespace="default"` under cienet-cmcs
-      node_selector={"cloud.google.com/gke-nodepool": "cpu-np"},
-      image=IMAGE,
-      # TODO(b/452777428): Apply this once the "apache-airflow-providers-google" in
-      # prod composer is upgraded to "16.0.0".
-      # on_finish_action=OnFinishAction.DELETE_POD.value,
-      get_logs=True,
-      cmds=["/bin/bash", "-cxue", commands],
-      labels={"airflow-runtime": recipe_runtime},
-      owner=test_owner.DORA_H,
-  )
-
-  # TODO(b/452777428): Remove this once the "apache-airflow-providers-google" in prod
-  # composer is upgraded to "16.0.0".
-  # Explicitly clean up the pod since the `on_finish_action` of
-  # `GKEStartPodOperator` is not functioning.
-  clean_up_start_recipe_pod = clean_up_pod.override(
-      trigger_rule=TriggerRule.ALL_DONE
-  )(
-      cluster_name=dag_params["cluster_name"],
-      region=derived_params["region"],
-      project=dag_params["project"],
-      airflow_runtime=recipe_runtime,
+  start_recipe = kpo.run_command_in_kpo(
+      start_cli_command=commands,
+      workload_id="start_recipe",
+      task_owner=test_owner.DORA_H,
+      provisioning_timeout=datetime.timedelta(minutes=5),
+      workload_run_timeout=datetime.timedelta(minutes=15),
+      image_full_url=dag_params["runner"],
   )
 
   check_recipe_log = wait_workload_complete.override(
       task_id="check_recipe_log",
   )(
-      workload_id=derived_params["recipe_workload_id"],
+      workload_id=derived_params["workload_id"],
       project_id=dag_params["project"],
       region=derived_params["region"],
       cluster_name=dag_params["cluster_name"],
@@ -359,7 +330,7 @@ with models.DAG(
   clean_up_recipe = xpk.clean_up_workload.override(
       task_id="clean_up_recipe", trigger_rule=TriggerRule.ALL_DONE
   )(
-      workload_id=derived_params["recipe_workload_id"],
+      workload_id=derived_params["workload_id"],
       project_id=dag_params["project"],
       zone=dag_params["zone"],
       cluster_name=dag_params["cluster_name"],
@@ -375,4 +346,4 @@ with models.DAG(
       >> check_recipe_log
       >> clean_up_recipe
   )
-  start_recipe >> clean_up_start_recipe_pod
+  start_recipe >> check_recipe_log

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -28,7 +28,7 @@ from airflow.decorators import task
 from airflow.operators.empty import EmptyOperator
 
 from dags.common.quarantined_tests import QuarantineTests
-from xlml.utils import gpu, metric, name_format, ssh, tpu, xpk, axlearn, gke
+from xlml.utils import gpu, metric, name_format, ssh, tpu, xpk, axlearn, gke, kpo
 from xlml.apis import gcp_config, metric_config, test_config, gcs
 
 
@@ -254,8 +254,8 @@ class AXLearnTask(BaseTask):
           label=self.label,
       )
 
-      run_workload = axlearn.start_cli_in_kpo(
-          start_axlearn_cli_command=gen_cmds,
+      run_workload = kpo.run_command_in_kpo(
+          start_cli_command=gen_cmds,
           workload_id=workload_id,
           task_owner=self.test_cfg.task_owner,
           provisioning_timeout=self.workload_provision_timeout,

--- a/xlml/utils/axlearn.py
+++ b/xlml/utils/axlearn.py
@@ -14,62 +14,14 @@
 """Utilities to run workloads with AXLearn."""
 
 import datetime as dt
-import os
-from absl import logging
 import textwrap
 
 from airflow.decorators import task
 from airflow.hooks.subprocess import SubprocessHook
-from airflow.models.taskmixin import DAGNode
-from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
-from airflow.utils.task_group import TaskGroup
 
 from dags import composer_env
 from xlml.utils import gke
 from xlml.utils import composer
-
-
-_KPO_LABEL = {"axlearn-kpo-label": "axlearn_cli_kpo_worker"}
-
-# pylint: disable=line-too-long
-_KPO_NAMESPACE = "composer-user-workloads"
-"""
-**MUST** use this fixed namespace for Cloud Composer 2.
-See: https://cloud.google.com/composer/docs/composer-2/use-kubernetes-pod-operator#composer-2-kpo-access-project-resources
-"""
-# pylint: enable=line-too-long
-
-_COMPOSER_KUBECONFIG_PATH = "/home/airflow/composer_kube_config"
-
-
-@task(
-    retry_delay=dt.timedelta(seconds=15),
-    retries=4,
-)
-def reset_kube_config() -> None:
-  """Get credential for in-cluster to setup CLI AXLearn command."""
-
-  cluster_name = os.environ["COMPOSER_GKE_NAME"]
-  project_id = os.environ["GCP_PROJECT"]
-  region = os.environ["COMPOSER_LOCATION"]
-
-  logging.info(f"{' LOGGING AIRFLOW CLUSTER ':=^80}")
-  logging.info("CLUSTER_NAME: %s", cluster_name)
-  logging.info("PROJECT_ID: %s", project_id)
-  logging.info("REGION: %s", region)
-
-  hook = SubprocessHook()
-  result = hook.run_command([
-      "bash",
-      "-c",
-      f"sudo chown -R airflow:airflow {_COMPOSER_KUBECONFIG_PATH} && "
-      f"gcloud container clusters get-credentials {cluster_name} "
-      f"--region {region} --project {project_id}",
-  ])
-
-  assert (
-      result.exit_code == 0
-  ), f"XPK clean-up failed with code {result.exit_code}"
 
 
 @task(
@@ -99,77 +51,6 @@ def update_image_tag_cmd(image_name: str, workload_id: str):
   assert (
       result.exit_code == 0
   ), f"Failed to update image tag; exit code {result.exit_code}"
-
-
-def start_cli_in_kpo(
-    start_axlearn_cli_command: str,
-    workload_id: str,
-    task_owner: str,
-    provisioning_timeout: dt.timedelta,
-    workload_run_timeout: dt.timedelta,
-    image_full_url: str,
-) -> DAGNode:
-  """
-  Launch AXLearn CLI in an isolated Kubernetes Pod (via @task.kubernetes) and
-  wait until the workload's Pods become Ready (or the wait times out).
-
-  Airflow injects this function as a temporary Python script into the Pod and
-  executes it there. Because only the Python standard library is guaranteed to
-  be available at runtime (unless baked into the image), this function avoids
-  third-party imports.
-
-  Args:
-    start_axlearn_cli_command: Full shell command that starts AXLearn (the CLI
-      will submit the workload to GKE).
-    workload_id: Workload/JobSet identifier used to discover Pods (e.g., via a
-      label selector).
-    task_owner: The owner of the task, used for Airflow metadata and
-      pod labeling.
-    provisioning_timeout: Timedelta object representing the time reserved for
-      resource provisioning.
-    workload_run_timeout: Timedelta object representing the maximum allowed
-      execution time for the Airflow task.
-    image_full_url: The full URL of the Docker image.
-
-  Returns:
-    None. The task completes when readiness is observed.
-
-  Raises:
-    AirflowFailException: If the AXLearn CLI command fails, or if Pods do not
-      become Ready before the timeout.
-  """
-
-  airflow_task_timeout = workload_run_timeout.total_seconds()
-  k8s_timeout = airflow_task_timeout - provisioning_timeout.total_seconds()
-
-  with TaskGroup(group_id="start_cli_in_kpo") as group:
-    # The default worker pod's kube_config may contain leftover
-    # contexts/configs from other tasks (e.g., after `gcloud container clusters
-    # get-credentials`) that point to a different GKE cluster.
-    # Reset it so kubectl/gcloud—and the KPO we launch—target the Composer
-    # cluster and use the correct Workload Identity–backed SA.
-    reset_kube_config_task = reset_kube_config.override(owner=task_owner)()
-
-    kpo = KubernetesPodOperator(
-        task_id="run_axlearn-cli",
-        name="axlearn-cli-kpo",
-        namespace=_KPO_NAMESPACE,
-        config_file=_COMPOSER_KUBECONFIG_PATH,
-        image=image_full_url,
-        cmds=["bash", "-cx", start_axlearn_cli_command],
-        labels={
-            **_KPO_LABEL,
-            "workload_id": workload_id,
-            "owner": task_owner,
-        },
-        active_deadline_seconds=int(k8s_timeout),
-        execution_timeout=workload_run_timeout,
-        retries=0,
-    )
-
-    _ = reset_kube_config_task >> kpo
-
-  return group
 
 
 @task(retries=0)

--- a/xlml/utils/kpo.py
+++ b/xlml/utils/kpo.py
@@ -1,0 +1,137 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0 #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to run workloads with KubernetesPodOperator"""
+
+import datetime as dt
+import os
+from absl import logging
+
+from airflow.decorators import task
+from airflow.hooks.subprocess import SubprocessHook
+from airflow.models.taskmixin import DAGNode
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+from airflow.utils.task_group import TaskGroup
+
+_KPO_LABEL = {"kpo-label": "cli_kpo_worker"}
+
+# pylint: disable=line-too-long
+_KPO_NAMESPACE = "composer-user-workloads"
+"""
+**MUST** use this fixed namespace for Cloud Composer 2.
+See: https://cloud.google.com/composer/docs/composer-2/use-kubernetes-pod-operator#composer-2-kpo-access-project-resources
+"""
+# pylint: enable=line-too-long
+
+_COMPOSER_KUBECONFIG_PATH = "/home/airflow/composer_kube_config"
+
+
+@task(
+    retry_delay=dt.timedelta(seconds=15),
+    retries=4,
+)
+def reset_kube_config() -> None:
+  """Get credential for in-cluster to setup CLI command."""
+
+  cluster_name = os.environ["COMPOSER_GKE_NAME"]
+  project_id = os.environ["GCP_PROJECT"]
+  region = os.environ["COMPOSER_LOCATION"]
+
+  logging.info(f"{' LOGGING AIRFLOW CLUSTER ':=^80}")
+  logging.info("CLUSTER_NAME: %s", cluster_name)
+  logging.info("PROJECT_ID: %s", project_id)
+  logging.info("REGION: %s", region)
+
+  hook = SubprocessHook()
+  result = hook.run_command([
+      "bash",
+      "-c",
+      f"sudo chown -R airflow:airflow {_COMPOSER_KUBECONFIG_PATH} && "
+      f"gcloud container clusters get-credentials {cluster_name} "
+      f"--region {region} --project {project_id}",
+  ])
+
+  assert (
+      result.exit_code == 0
+  ), f"XPK clean-up failed with code {result.exit_code}"
+
+
+def run_command_in_kpo(
+    start_cli_command: str,
+    workload_id: str,
+    task_owner: str,
+    provisioning_timeout: dt.timedelta,
+    workload_run_timeout: dt.timedelta,
+    image_full_url: str,
+) -> DAGNode:
+  """
+  Launch an isolated Kubernetes Pod (via @task.kubernetes) and
+  wait until the workload's Pods become Ready (or the wait times out).
+
+  Airflow injects this function as a temporary Python script into the Pod and
+  executes it there. Because only the Python standard library is guaranteed to
+  be available at runtime (unless baked into the image), this function avoids
+  third-party imports.
+
+  Args:
+    start_cli_command: Full shell command that starts the CLI ( will
+      submit the workload to GKE).
+    workload_id: Workload/JobSet identifier used to discover Pods (e.g., via a
+      label selector).
+    task_owner: The owner of the task, used for Airflow metadata and
+      pod labeling.
+    provisioning_timeout: Timedelta object representing the time reserved for
+      resource provisioning.
+    workload_run_timeout: Timedelta object representing the maximum allowed
+      execution time for the Airflow task.
+    image_full_url: The full URL of the Docker image.
+
+  Returns:
+    None. The task completes when readiness is observed.
+
+  Raises:
+    AirflowFailException: If the CLI command fails, or if Pods do not
+      become Ready before the timeout.
+  """
+
+  airflow_task_timeout = workload_run_timeout.total_seconds()
+  k8s_timeout = airflow_task_timeout - provisioning_timeout.total_seconds()
+
+  with TaskGroup(group_id="run_command_in_kpo") as group:
+    # The default worker pod's kube_config may contain leftover
+    # contexts/configs from other tasks (e.g., after `gcloud container clusters
+    # get-credentials`) that point to a different GKE cluster.
+    # Reset it so kubectl/gcloud—and the KPO we launch—target the Composer
+    # cluster and use the correct Workload Identity–backed SA.
+    reset_kube_config_task = reset_kube_config.override(owner=task_owner)()
+
+    kpo = KubernetesPodOperator(
+        task_id="run_kpo-cli",
+        name="cli-kpo",
+        namespace=_KPO_NAMESPACE,
+        config_file=_COMPOSER_KUBECONFIG_PATH,
+        image=image_full_url,
+        cmds=["bash", "-cx", start_cli_command],
+        labels={
+            **_KPO_LABEL,
+            "workload_id": workload_id,
+            "owner": task_owner,
+        },
+        active_deadline_seconds=int(k8s_timeout),
+        execution_timeout=workload_run_timeout,
+        retries=0,
+    )
+
+    _ = reset_kube_config_task >> kpo
+
+  return group


### PR DESCRIPTION
# Description

This PR updates the DAG `pw_mcjax_benchmark_recipe` with the following changes:
 - Replace `GKEStartPodOperator` with `KubernetesPodOperator`.
 - Update the `runner`, `proxy` and `sever` image with **Maxtext daily build image** and the **official proxy server & server images**.
 - Specify the name of the workload and passing it as the `workload_id` for checking the workload logs.

# Tests

Tested in [dev composer](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pw_mcjax_benchmark_recipe/grid?dag_run_id=manual__2026-03-30T08%3A01%3A54%2B00%3A00&task_id=check_recipe_log&tab=logs)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.