### PR TITLE
fix: Rearrange tests in `maxtext_end_to_end`

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -116,18 +116,6 @@ with models.DAG(
     stable_tpu >> nightly_tpu
 
   multicluster_test_models = {
-      "gemma-7b": [
-          {
-              "script_name": "tpu/gemma/7b/1_test_gemma",
-              "cluster": XpkClusters.CPU_N2_STANDARD_64_CLUSTER,
-              "time_out_in_min": 60,
-          },
-          {
-              "script_name": "tpu/gemma/7b/2_test_gemma",
-              "cluster": XpkClusters.TPU_V5P_8_CLUSTER,
-              "time_out_in_min": 60,
-          },
-      ],
       "llama2-70b": [
           {
               "script_name": "tpu/llama2/70b/1_test_llama2_70b",
@@ -137,6 +125,18 @@ with models.DAG(
           {
               "script_name": "tpu/llama2/70b/2_test_llama2_70b",
               "cluster": XpkClusters.TPU_V5P_128_CLUSTER,
+              "time_out_in_min": 60,
+          },
+      ],
+      "gemma-7b": [
+          {
+              "script_name": "tpu/gemma/7b/1_test_gemma",
+              "cluster": XpkClusters.CPU_N2_STANDARD_64_CLUSTER,
+              "time_out_in_min": 60,
+          },
+          {
+              "script_name": "tpu/gemma/7b/2_test_gemma",
+              "cluster": XpkClusters.TPU_V5P_8_CLUSTER,
               "time_out_in_min": 60,
           },
       ],

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
# Description

Move `chained_tests_llama2-70b_stable`, `chained_tests_llama2-70b_nightly` before `chained_tests_gemma-7b_stable` and `chained_tests_gemma-7b_nightly` in `maxtext_end_to_end`.

# Tests

<img width="911" height="108" alt="image" src="https://github.com/user-attachments/assets/351b1a33-1908-4298-92ab-fbf5e718f3ed" />


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.