### PR TITLE
fix: Simplify `pw_mcjax_benchmark_recipe`

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/maxtext_pathways/configs/parameters.py
+++ b/dags/maxtext_pathways/configs/parameters.py
@@ -152,25 +152,6 @@ PARAMETERS = {
         title="Max Restarts",
         description="Max restarts for the workload",
     ),
-    "bq_enable": Param(
-        False,
-        type="boolean",
-        title="BigQuery Enable",
-        description="Enable BigQuery to store metrics data",
-    ),
-    "bq_db_project": Param(
-        "cloud-tpu-multipod-dev",
-        type="string",
-        title="BigQuery Database Project",
-        description="The Project of BigQuery Database",
-    ),
-    "bq_db_dataset": Param(
-        # TODO(b/451750407): Replace this temporary image with a formal one.
-        "chzheng_test_100steps",
-        type="string",
-        title="BigQuery Database Dataset",
-        description="The Dataset of BigQuery Database",
-    ),
     "override_timeout_in_min": Param(
         None,
         type=["null", "integer"],

--- a/dags/maxtext_pathways/configs/parameters.py
+++ b/dags/maxtext_pathways/configs/parameters.py
@@ -76,12 +76,6 @@ PARAMETERS = {
         title="Core Count",
         description='Device core count for the cluster. ex: v6e-"64"',
     ),
-    "benchmark_steps": Param(
-        20,
-        type="integer",
-        title="Benchmark Steps",
-        description="Number of benchmark steps.",
-    ),
     "num_slices_list": Param(
         1,
         type="integer",
@@ -151,16 +145,5 @@ PARAMETERS = {
         type="integer",
         title="Max Restarts",
         description="Max restarts for the workload",
-    ),
-    "override_timeout_in_min": Param(
-        None,
-        type=["null", "integer"],
-        title="Override Timeout In Minutes",
-        description=(
-            "Timeout in minutes for the workload task. Adjust it when you "
-            "meet (airflow.exceptions.AirflowException: Timed out after ...) "
-            "issue. The default value `None` means automatic calculation "
-            "of timeout."
-        ),
     ),
 }

--- a/dags/maxtext_pathways/configs/recipe_config.py
+++ b/dags/maxtext_pathways/configs/recipe_config.py
@@ -41,7 +41,6 @@ RECIPE_FLAG = [
     "cluster_name",
     "project",
     "zone",
-    "benchmark_steps",
     "num_slices_list",
     "server_image",
     "proxy_image",

--- a/dags/maxtext_pathways/configs/recipe_config.py
+++ b/dags/maxtext_pathways/configs/recipe_config.py
@@ -50,9 +50,6 @@ RECIPE_FLAG = [
     "selected_model_names",
     "priority",
     "max_restarts",
-    "bq_enable",
-    "bq_db_project",
-    "bq_db_dataset",
     "workload_id",
     "device_type",
 ]

--- a/dags/maxtext_pathways/pw_mcjax_dags.py
+++ b/dags/maxtext_pathways/pw_mcjax_dags.py
@@ -247,7 +247,6 @@ with models.DAG(
 
     ### Prerequisites
     - This test requires an existing cluster.
-    - This test requires that a dataset with the same name as the UI parameter "[BigQuery Database Dataset]".
     - If you're using a service account to pull an image from a different project, you need to grant the service account the `Artifact Registry Reader` role in that project.
 
     ### Procedures

--- a/dags/maxtext_pathways/pw_mcjax_dags.py
+++ b/dags/maxtext_pathways/pw_mcjax_dags.py
@@ -162,60 +162,6 @@ def clean_up_pod(
   ), f"kubectl clean-up failed with code {result.exit_code}"
 
 
-@task
-def wait_workload_complete(
-    workload_id: str,
-    project_id: str,
-    region: str,
-    cluster_name: str,
-    benchmark_steps: int,
-    override_timeout_in_min: int = 10,
-    poke_interval_in_second: int = 60,
-) -> bool:
-  """
-  Checks for the completion of an workload by repeatedly executing its core logic.
-  The core logic uses workload logs to report the detailed status of successful or failed completion.
-  """
-  # Extract and reuse the logic in the` xpk` module to wait for a workload to be completed.
-  impl = getattr(
-      xpk.wait_for_workload_completion, "python_callable", None
-  ) or getattr(xpk.wait_for_workload_completion, "__wrapped__", None)
-
-  if impl is None:
-    raise AirflowException(
-        f"Cannot extract core callable from {xpk.wait_for_workload_completion}."
-        "It might not be a valid task/sensor or is wrapped too deeply."
-    )
-
-  # Dynamically sets the Airflow task timeout based on a custom flag or calculates it using a benchmark step count.
-  if override_timeout_in_min:
-    timeout_in_min = override_timeout_in_min
-  else:
-    max_step_min = 5  # Average time required for each step in lama3-1-405b.
-    timeout_in_min = benchmark_steps * max_step_min
-
-  timeout_in_sec = timeout_in_min * 60
-
-  logging.info(
-      f"The timeout for this task is {timeout_in_min} minutes ({timeout_in_sec} seconds).\n"
-      f"Check if completed every {poke_interval_in_second} seconds."
-  )
-
-  deadline = datetime.datetime.now() + datetime.timedelta(
-      seconds=timeout_in_sec
-  )
-  while datetime.datetime.now() < deadline:
-    # Call the core function to check if the workload is complete.
-    if impl(workload_id, project_id, region, cluster_name):
-      return True
-
-    time.sleep(poke_interval_in_second)
-
-  raise AirflowException(
-      f"Timed out after {timeout_in_min}min({timeout_in_sec}s). Please adjust `Override Timeout In Minutes` in UI input."
-  )
-
-
 RECIPE_INSTANCE = recipe_cfg.Recipe.PW_MCJAX_BENCHMARK_RECIPE
 RECIPE_NAME = RECIPE_INSTANCE.value.lower()
 
@@ -275,16 +221,13 @@ with models.DAG(
       image_full_url=dag_params["runner"],
   )
 
-  check_recipe_log = wait_workload_complete.override(
-      task_id="check_recipe_log",
+  wait_for_workload_complete = xpk.wait_for_workload_completion.override(
+      task_id="wait_for_workload_complete",
   )(
       workload_id=derived_params["workload_id"],
       project_id=dag_params["project"],
       region=derived_params["region"],
       cluster_name=dag_params["cluster_name"],
-      benchmark_steps=dag_params["benchmark_steps"],
-      override_timeout_in_min=dag_params["override_timeout_in_min"],
-      poke_interval_in_second=30,
   )
 
   clean_up_recipe = xpk.clean_up_workload.override(
@@ -301,7 +244,7 @@ with models.DAG(
       >> derived_params
       >> commands
       >> start_recipe
-      >> check_recipe_log
+      >> wait_for_workload_complete
       >> clean_up_recipe
   )
-  start_recipe >> check_recipe_log
+  start_recipe >> wait_for_workload_complete

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
# Description

This change simplifies the `pw_mcjax_benchmark_recipe` DAG by removing the unused BigQuery integration and replacing the customized `wait_workload_complete` with the existing library.

# Tests

[Tested in Dev composer](https://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/pw_mcjax_benchmark_recipe/grid?dag_run_id=manual__2026-04-29T03%3A16%3A17%2B00%3A00&task_id=wait_for_workload_complete&tab=logs)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.