### PR TITLE
Refactor: refactor class JobSet to fit `multiple_outputs` decorator

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -16,6 +16,7 @@
 
 import enum
 import dataclasses
+from collections.abc import MutableMapping
 from datetime import timedelta
 import json
 import logging
@@ -24,7 +25,9 @@ import random
 import string
 import tempfile
 import textwrap
-from typing import Final
+from typing import Final, Any, Optional
+
+from pydantic import BaseModel
 
 from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
@@ -191,14 +194,19 @@ _TEMPLATE = string.Template(
 # pylint: enable=line-too-long
 
 
-@dataclasses.dataclass
-class JobSet:
+class JobSet(BaseModel, MutableMapping):
   """
-  Generates YAML configurations for Kubernetes JobSets.
+  Generates YAML configurations for Kubernetes JobSets and serves as a
+  data transfer object specifically for Airflow XCom, 'multiple_outputs', etc.
 
-  This class helps in creating JobSet YAMLs by providing a template and allowing
-  customization of various parameters like jobset name, replicas, TPU
-  configuration, and the workload script to be executed.
+  Extends Pydantic's BaseModel (rather than a plain dataclass) to leverage
+  runtime type validation, field coercion, and dynamic attribute assignment.
+
+  Implements MutableMapping instead of inheriting from dict to prevent
+  Airflow from invoking its default dict serialization/deserialization
+  logic, which would bypass BaseModel's field handling. By satisfying the
+  MutableMapping interface, Airflow delegates to the custom serialize() and
+  deserialize() methods defined on this class.
 
   Attributes:
     jobset_name: The name of the JobSet.
@@ -218,20 +226,95 @@ class JobSet:
     tpu_cores_per_pod: The number of TPU cores requested per pod.
   """
 
-  jobset_name: str
-  namespace: str
-  max_restarts: int
-  replicated_job_name: str
-  replicas: int
-  backoff_limit: int
-  completions: int
-  parallelism: int
-  tpu_accelerator_type: str
-  tpu_topology: str
-  container_name: str
-  image: str
-  tpu_cores_per_pod: int
-  node_pool_selector: str
+  jobset_name: Optional[str] = None
+  namespace: Optional[str] = None
+  max_restarts: Optional[int] = None
+  replicated_job_name: Optional[str] = None
+  replicas: Optional[int] = None
+  backoff_limit: Optional[int] = None
+  completions: Optional[int] = None
+  parallelism: Optional[int] = None
+  tpu_accelerator_type: Optional[str] = None
+  tpu_topology: Optional[str] = None
+  container_name: Optional[str] = None
+  image: Optional[str] = None
+  tpu_cores_per_pod: Optional[int] = None
+  node_pool_selector: Optional[str] = None
+
+  def __getitem__(self, key: str) -> Any:
+    """Necessary MutableMapping method: allows dict-like field access."""
+
+    if key not in JobSet.model_fields:
+      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+    return object.__getattribute__(self, key)
+
+  def __setitem__(self, key: str, value: Any) -> None:
+    """Necessary MutableMapping method: allows setting field values."""
+    if key not in JobSet.model_fields:
+      raise KeyError(f"Key '{key}' is not a valid JobSet parameter.")
+    if value is None:
+      raise ValueError(f"Value for '{key}' cannot be None.")
+    object.__setattr__(self, key, value)
+
+  def __delitem__(self, key: str) -> None:
+    """Necessary MutableMapping method: allows deletion of fields."""
+    raise NotImplementedError("JobSet does not support field deletion.")
+
+  def __getattr__(self, key: str) -> Any:
+    """Allows attribute-style access."""
+    try:
+      return self[key]
+    except KeyError as e:
+      raise AttributeError(f"'JobSet' object has no attribute '{key}'") from e
+
+  def __setattr__(self, key: str, value: Any) -> None:
+    """Allows attribute-style access."""
+    self[key] = value
+
+  def to_dict(self) -> dict:
+    """Converts the JobSet to a dict, excluding None values."""
+    return {k: v for k, v in self.model_dump().items() if v is not None}
+
+  def __iter__(self) -> iter:
+    """Necessary MutableMapping method: iterates over non-None field keys."""
+    return iter(self.to_dict())
+
+  def __len__(self) -> int:
+    """Necessary MutableMapping method: counts non-None fields."""
+    return len(self.to_dict())
+
+  def serialize(self) -> dict:
+    """
+    Serializes this JobSet to a dict for Airflow XCom storage.
+
+    Because JobSet is a MutableMapping rather than a plain dict, Airflow
+    skips its default dict serialization and delegates to this method
+    instead. Only non-None fields are included to keep the payload minimal.
+
+    Returns:
+      A dict representation of this JobSet, excluding unset fields.
+    """
+    return self.to_dict()
+
+  @staticmethod
+  def deserialize(data: dict, version: int) -> "JobSet":
+    """
+    Deserializes a dict retrieved from Airflow XCom back into a JobSet.
+
+    Because JobSet is a MutableMapping rather than a plain dict, Airflow
+    skips its default dict deserialization and delegates to this method
+    instead.
+
+    Args:
+      data: A dict previously produced by serialize().
+      version: The version of the serialized data format (not used in
+        this implementation, but a required signature for Airflow
+        deserialization).
+
+    Returns:
+      A JobSet instance populated with the fields from data.
+    """
+    return JobSet(**data)
 
   def generate_yaml(self, workload_script: Workload) -> str:
     """Generates the final JobSet YAML content.
@@ -243,7 +326,7 @@ class JobSet:
     Returns:
         A string containing the complete JobSet YAML.
     """
-    params = dataclasses.asdict(self)
+    params = self.to_dict()
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = self.node_pool_selector or ""
@@ -361,8 +444,18 @@ class Command:
     return Command.k8s_get_pods(jobset_name, namespace, output)
 
 
+class ReplicatedJobStatus(enum.Enum):
+  """Defines status of a replicated job."""
+
+  READY = "ready"
+  SUSPENDED = "suspended"
+  ACTIVE = "active"
+  FAILED = "failed"
+  SUCCEEDED = "succeeded"
+
+
 def get_replica_num(
-    replica_type: str, job_name: str, node_pool: node_pool_info
+    job_status: ReplicatedJobStatus, job_name: str, node_pool: node_pool_info
 ) -> int:
   """
   Get the number of a certain type of replicas from a running jobset.
@@ -371,12 +464,12 @@ def get_replica_num(
   the number of replicas in a certain status.
 
   Args:
-    replica_type: The type of replica being searched for.
+    job_status: The status of the replicated job being searched for.
     job_name: The name of the job replica which is run from the jobset.
     node_pool: The Info object containing the cluster information needed for
     the kubernetes API to connect to it.
   Returns:
-    The number of replicas of the specific type in the jobset.
+    The number of replicas of the specific status in the jobset.
   """
   api_client = gke.get_authenticated_client(
       node_pool.project_id,
@@ -396,7 +489,7 @@ def get_replica_num(
   try:
     replica_job_status = jobsets["items"][0]["status"]["replicatedJobsStatus"]
     name = replica_job_status[0]["name"]
-    replicas = replica_job_status[0][replica_type]
+    replicas = replica_job_status[0][job_status.value]
     logging.info("Found %s replicas", replicas)
 
   except (KeyError, IndexError, TypeError) as e:
@@ -469,7 +562,7 @@ def _generate_jobset_name(dag_id_prefix: str) -> str:
   return f"{dag_id_prefix}-{timestamp}"
 
 
-@task
+@task.python(multiple_outputs=True)
 def build_jobset_from_gcs_yaml(
     gcs_path: str,
     dag_name: str,
@@ -479,32 +572,32 @@ def build_jobset_from_gcs_yaml(
   Builds a JobSet instance by merging YAML defaults and generating
   a timestamped name based on dag_id_prefix.
 
+  update priority: jobset_defaults > dag-specific config > overrides
+
   Args:
     gcs_path: The GCS path to the YAML configuration file.
     dag_name: The name of the DAG to extract specific configurations.
     **overrides: Additional parameters to override default configurations.
   """
   config = gcs.load_yaml_from_gcs(gcs_path)
-  known_fields = {f.name for f in dataclasses.fields(JobSet)}
-  merged = {
-      k: v
-      for k, v in config.get("jobset_defaults", {}).items()
-      if k in known_fields
-  }
+  known_fields = JobSet.model_fields.keys()
+  jobset = JobSet()
+
+  cfg_defaults = config.get("jobset_defaults", {})
   dag_cfg = config.get("dag", {}).get(dag_name, {})
   dag_id_prefix = dag_cfg.get("dag_id_prefix")
 
-  for k, v in dag_cfg.items():
-    if k in known_fields and v is not None:
-      merged[k] = v
+  jobset["jobset_name"] = _generate_jobset_name(dag_id_prefix)
 
-  merged.update({k: v for k, v in overrides.items() if k in known_fields})
-  merged["jobset_name"] = _generate_jobset_name(dag_id_prefix)
+  jobset.update({k: v for k, v in cfg_defaults.items() if k in known_fields})
+  jobset.update({k: v for k, v in dag_cfg.items() if k in known_fields})
+  jobset.update({k: v for k, v in overrides.items() if k in known_fields})
 
   logging.info(
-      f"Final JobSet '{merged['jobset_name']}' created for DAG '{dag_name}'"
+      f"Final JobSet '{jobset['jobset_name']}' created for DAG '{dag_name}'"
   )
-  return JobSet(**merged)
+
+  return jobset
 
 
 @task

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
 # Description

Refactor class JobSet to fit decorator `@task.python(multiple_outputs=True)`. 

# Example
```python
#  XXX_dag.py

with models.DAG( dag_id=DAG_ID) as dag:
        jobset_config = jobset.build_jobset_from_gcs_yaml(
          gcs_path=GCS_JOBSET_CONFIG_PATH,
          dag_name="jobset_healthiness_suspended",
       )

      validate_suspended_replicas =jobset.wait_for_jobset_replica_number(
          node_pool=node_pool_info,
          jobset_config=jobset_config,
          job_status=ReplicatedJobStatus.SUSPENDED,
          expected_replica_number=jobset_config["replicas"],
     )
```
```python
# jobset_util.py

@task.python(multiple_outputs=True)
def build_jobset_from_gcs_yaml(
    gcs_path: str,
    dag_name: str,
    **overrides,
) -> JobSet:
 # ...
```
In general condition, `jobset_config["replicas"]` cause compiler error, since `jobset_config` is a Xcom argument, it doesn't have actual value until runtime. 

But in this case, it works. `build_jobset_from_gcs_yaml` return a dict-like item `JobSet`(it means it's a key-value pair object) and can be manipulated by parentheses `jobset["feature"]`. This is effect of `task.python(multiple_outputs=True)`, which stores each key-value pair **separately** in airflow database. 

# Changes

In the original `JobSet` design, it is a plain `@dataclasses.dataclass`. This works for runtime usage but breaks XCom key access at DAG definition time — `jobset_config["replicas"]` raises an error because `jobset_config` is an
`XComArg`, not a real dict.

The fix is to annotate `build_jobset_from_gcs_yaml` with `@task.python(multiple_outputs=True)`. Airflow then stores each key-value pair separately in the XCom database and wraps the result in an `XComArg` that supports `[]` subscript access, making `jobset_config["replicas"]` valid at DAG definition time.

To satisfy this requirement, `JobSet` is refactored to extend both `pydantic.BaseModel` and `collections.abc.MutableMapping`:

- **Pydantic `BaseModel`**: provides runtime type validation and field coercion, replacing the plain `dataclass`.
- **`MutableMapping`**: MutableMapping prevents Airflow from treating JobSet as a plain dict — if it did, Airflow's default dict serialization would discard all custom methods and non-dict attributes, bypassing BaseModel field handling entirely. By implementing MutableMapping instead, Airflow delegates serialization/deserialization to the custom serialize() and deserialize() methods.

All fields are changed to `Optional[...] = None` to allow incremental construction before all values are known.

`ReplicatedJobStatus` enum is also introduced to replace the raw `replica_type: str` parameter in `get_replica_num()`, improving type safety.

------------------------


Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.