### PR TITLE
Fix resource allocation for post-training notebook DAGs

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/post_training/maxtext_rl_notebook.py
+++ b/dags/post_training/maxtext_rl_notebook.py
@@ -76,15 +76,16 @@ with models.DAG(
   current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
   # Load configurations from GCS
-  config = notebook_util.load_notebook_config_from_gcs_yaml(
+  config_arg = notebook_util.load_notebook_config_from_gcs_yaml(
       gcs_path=notebook_util.NOTEBOOK_CONFIG_GCS_PATH,
       dag_name=DAG_TEST_NAME,
   )
+  config = notebook_util.NotebookConfig(config_arg)
 
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
 
-  previous_algo_last_tasks = [config]
+  previous_algo_last_tasks = [config_arg]
   for loss_algo in loss_algos:
     previous_algo_last_tasks = notebook_util.create_branched_notebook_tasks(
         dag_name=DAG_TEST_NAME,

--- a/dags/post_training/maxtext_rl_notebook.py
+++ b/dags/post_training/maxtext_rl_notebook.py
@@ -8,7 +8,6 @@ training on single-host TPU VMs.
 import datetime
 
 from airflow import models
-from airflow.models.baseoperator import chain
 
 from dags import composer_env
 from dags.common import test_owner
@@ -76,23 +75,25 @@ with models.DAG(
   test_run_name = "llama31_rl_notebook"
   current_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
+  # Load configurations from GCS
+  config = notebook_util.load_notebook_config_from_gcs_yaml(
+      gcs_path=notebook_util.NOTEBOOK_CONFIG_GCS_PATH,
+      dag_name=DAG_TEST_NAME,
+  )
+
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
 
-  notebook_rl_tests = []
-  # Test both GRPO and GSPO algorithms
+  previous_algo_last_tasks = []
   for loss_algo in loss_algos:
-    rl_notebook_test = notebook_util.initialize_notebook_test(
-        test_name=f"{DAG_TEST_NAME}_rl_{loss_algo.value}",
+    previous_algo_last_tasks = notebook_util.create_branched_notebook_tasks(
         dag_name=DAG_TEST_NAME,
+        task_id_prefix=f"rl_{loss_algo.value}",
         notebook_path="src/maxtext/examples/rl_llama3_demo.ipynb",
         set_up_script=setup_script,
         parameters={"LOSS_ALGO": loss_algo.loss_name},
         task_owner=test_owner.DEPP_L,
+        hf_token=HF_TOKEN_LLAMA31,
+        config=config,
+        previous_tasks=previous_algo_last_tasks,
     )
-
-    notebook_rl_tests.append(
-        notebook_util.run_training(rl_notebook_test, HF_TOKEN_LLAMA31)
-    )
-
-  chain(*notebook_rl_tests)

--- a/dags/post_training/maxtext_rl_notebook.py
+++ b/dags/post_training/maxtext_rl_notebook.py
@@ -85,9 +85,9 @@ with models.DAG(
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
 
-  previous_algo_last_tasks = [config_arg]
+  previous_task = config_arg
   for loss_algo in loss_algos:
-    previous_algo_last_tasks = notebook_util.create_branched_notebook_tasks(
+    previous_task = notebook_util.run_notebook_tests(
         dag_name=DAG_TEST_NAME,
         task_id_prefix=f"rl_{loss_algo.value}",
         notebook_path="src/maxtext/examples/rl_llama3_demo.ipynb",
@@ -96,5 +96,5 @@ with models.DAG(
         task_owner=test_owner.DEPP_L,
         hf_token=HF_TOKEN_LLAMA31,
         config=config,
-        previous_tasks=previous_algo_last_tasks,
+        previous_task=previous_task,
     )

--- a/dags/post_training/maxtext_rl_notebook.py
+++ b/dags/post_training/maxtext_rl_notebook.py
@@ -84,7 +84,7 @@ with models.DAG(
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
 
-  previous_algo_last_tasks = []
+  previous_algo_last_tasks = [config]
   for loss_algo in loss_algos:
     previous_algo_last_tasks = notebook_util.create_branched_notebook_tasks(
         dag_name=DAG_TEST_NAME,

--- a/dags/post_training/maxtext_sft_notebook.py
+++ b/dags/post_training/maxtext_sft_notebook.py
@@ -73,10 +73,11 @@ with models.DAG(
   )
 
   # Load configurations from GCS
-  config = notebook_util.load_notebook_config_from_gcs_yaml(
+  config_arg = notebook_util.load_notebook_config_from_gcs_yaml(
       gcs_path=notebook_util.NOTEBOOK_CONFIG_GCS_PATH,
       dag_name=DAG_TEST_NAME,
   )
+  config = notebook_util.NotebookConfig(config_arg)
 
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
@@ -90,5 +91,5 @@ with models.DAG(
       task_owner=test_owner.DEPP_L,
       hf_token=HF_TOKEN_LLAMA31,
       config=config,
-      previous_tasks=[config],
+      previous_tasks=[config_arg],
   )

--- a/dags/post_training/maxtext_sft_notebook.py
+++ b/dags/post_training/maxtext_sft_notebook.py
@@ -90,4 +90,5 @@ with models.DAG(
       task_owner=test_owner.DEPP_L,
       hf_token=HF_TOKEN_LLAMA31,
       config=config,
+      previous_tasks=[config],
   )

--- a/dags/post_training/maxtext_sft_notebook.py
+++ b/dags/post_training/maxtext_sft_notebook.py
@@ -72,17 +72,22 @@ with models.DAG(
       f"{gcs_bucket.ORBAX_AUTOMATION_BUCKET_EUROPE_WEST4}/post-training/sft/"
   )
 
+  # Load configurations from GCS
+  config = notebook_util.load_notebook_config_from_gcs_yaml(
+      gcs_path=notebook_util.NOTEBOOK_CONFIG_GCS_PATH,
+      dag_name=DAG_TEST_NAME,
+  )
+
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
 
-  # Test SFT training
-  sft_notebook_test = notebook_util.initialize_notebook_test(
-      test_name=f"{DAG_TEST_NAME}_sft",
+  notebook_util.create_branched_notebook_tasks(
       dag_name=DAG_TEST_NAME,
+      task_id_prefix="sft",
       notebook_path="src/maxtext/examples/sft_llama3_demo_tpu.ipynb",
       set_up_script=setup_script,
       parameters={"BASE_OUTPUT_DIRECTORY": BASE_OUTPUT_DIRECTORY},
       task_owner=test_owner.DEPP_L,
+      hf_token=HF_TOKEN_LLAMA31,
+      config=config,
   )
-
-  notebook_util.run_training(sft_notebook_test, HF_TOKEN_LLAMA31)

--- a/dags/post_training/maxtext_sft_notebook.py
+++ b/dags/post_training/maxtext_sft_notebook.py
@@ -82,7 +82,7 @@ with models.DAG(
   # Setup commands for MaxText environment
   setup_script = notebook_util.build_maxtext_setup_script()
 
-  notebook_util.create_branched_notebook_tasks(
+  notebook_util.run_notebook_tests(
       dag_name=DAG_TEST_NAME,
       task_id_prefix="sft",
       notebook_path="src/maxtext/examples/sft_llama3_demo_tpu.ipynb",
@@ -91,5 +91,5 @@ with models.DAG(
       task_owner=test_owner.DEPP_L,
       hf_token=HF_TOKEN_LLAMA31,
       config=config,
-      previous_tasks=[config_arg],
+      previous_task=config_arg,
   )

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -12,6 +12,7 @@ from airflow.models.taskmixin import DAGNode
 from airflow.models.baseoperator import chain
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.task_group import TaskGroup
 
 from dags.common.vm_resource import (
     Project,
@@ -292,7 +293,7 @@ def initialize_notebook_test(
 class NotebookConfig:
   """A simple container holding dynamic XComArg fields."""
 
-  def __init__(self, config_arg: dict[str, airflow.XComArg]) -> None:
+  def __init__(self, config_arg: airflow.XComArg) -> None:
     self.zone = config_arg["zone"]
     self.tpu_version = config_arg["tpu_version"]
 
@@ -340,7 +341,7 @@ def run_training(
   )
 
 
-def create_branched_notebook_tasks(
+def run_notebook_tests(
     dag_name: str,
     task_id_prefix: str,
     notebook_path: str,
@@ -349,9 +350,9 @@ def create_branched_notebook_tasks(
     task_owner: str,
     hf_token: str,
     config: NotebookConfig,
-    previous_tasks: list[DAGNode] = None,
-) -> list[DAGNode]:
-  """Creates and chains branched notebook tasks for all TPU versions.
+    previous_task: DAGNode | None = None,
+) -> TaskGroup:
+  """Creates and chains branched notebook tests for all TPU versions.
 
   Args:
       dag_name: Name of the DAG.
@@ -362,67 +363,70 @@ def create_branched_notebook_tasks(
       task_owner: Owner of the task.
       hf_token: HuggingFace access token.
       config: A `NotebookConfig` wrapper containing zone and tpu_version.
-      previous_tasks: Optional list of tasks/DAGNodes to chain *before* the branches.
+      previous_task: Optional task/DAGNode to chain *before* the branches.
 
   Returns:
-      A list of terminal DAGNode tasks ([run_task, skipped_task]) from the end
-      of this branch loop, which can be chained into subsequent tasks.
+      A TaskGroup representing the entire branched notebook test workflow.
   """
-  # 1. Initialize and create the V5E test and task group
-  notebook_test_v5e = initialize_notebook_test(
-      test_name=f"{dag_name}_{task_id_prefix}",
-      dag_name=dag_name,
-      notebook_path=notebook_path,
-      set_up_script=set_up_script,
-      parameters=parameters,
-      task_owner=task_owner,
-      tpu_version=TpuVersion.V5E,
-  )
-  run_task_v5e = run_training(notebook_test_v5e, hf_token, zone=config.zone)
+  with TaskGroup(
+      group_id=f"{task_id_prefix}_tests", prefix_group_id=False
+  ) as group:
+    # 1. Initialize and create the V5E test and task group
+    notebook_test_v5e = initialize_notebook_test(
+        test_name=f"{dag_name}_{task_id_prefix}",
+        dag_name=dag_name,
+        notebook_path=notebook_path,
+        set_up_script=set_up_script,
+        parameters=parameters,
+        task_owner=task_owner,
+        tpu_version=TpuVersion.V5E,
+    )
+    run_task_v5e = run_training(notebook_test_v5e, hf_token, zone=config.zone)
 
-  # 2. Initialize and create the TRILLIUM/V6E test and task group
-  notebook_test_v6e = initialize_notebook_test(
-      test_name=f"{dag_name}_{task_id_prefix}",
-      dag_name=dag_name,
-      notebook_path=notebook_path,
-      set_up_script=set_up_script,
-      parameters=parameters,
-      task_owner=task_owner,
-      tpu_version=TpuVersion.TRILLIUM,
-  )
-  run_task_v6e = run_training(notebook_test_v6e, hf_token, zone=config.zone)
+    # 2. Initialize and create the TRILLIUM/V6E test and task group
+    notebook_test_v6e = initialize_notebook_test(
+        test_name=f"{dag_name}_{task_id_prefix}",
+        dag_name=dag_name,
+        notebook_path=notebook_path,
+        set_up_script=set_up_script,
+        parameters=parameters,
+        task_owner=task_owner,
+        tpu_version=TpuVersion.TRILLIUM,
+    )
+    run_task_v6e = run_training(notebook_test_v6e, hf_token, zone=config.zone)
 
-  # 3. Create skipped fallback empty operator task
-  skipped = EmptyOperator(task_id=f"skipped_{task_id_prefix}")
+    # 3. Create skipped fallback empty operator task
+    skipped = EmptyOperator(task_id=f"skipped_{task_id_prefix}")
 
-  # 4. Define central Task-decorated Branch Operator accepting dynamic parameters
-  @airflow_task.branch(
-      task_id=f"task_path_decider_{task_id_prefix}",
-      trigger_rule=TriggerRule.ALL_DONE,
-  )
-  def task_path_decider(tpu_version: str) -> str:
-    logging.info(f"Configured active TPU version: '{tpu_version}'")
-    active_tpu_version = TpuVersion(tpu_version)
+    # 4. Define central Task-decorated Branch Operator accepting dynamic parameters
+    @airflow_task.branch(
+        task_id=f"task_path_decider_{task_id_prefix}",
+        trigger_rule=TriggerRule.ALL_DONE,
+        retries=0,
+    )
+    def task_path_decider(tpu_version: str) -> str:
+      logging.info(f"Configured active TPU version: '{tpu_version}'")
+      active_tpu_version = TpuVersion(tpu_version)
 
-    match active_tpu_version:
-      case TpuVersion.V5E:
-        decided_task_id = run_task_v5e.group_id
-      case TpuVersion.TRILLIUM:
-        decided_task_id = run_task_v6e.group_id
-      case _:
-        decided_task_id = skipped.task_id
+      match active_tpu_version:
+        case TpuVersion.V5E:
+          decided_task_id = run_task_v5e.group_id
+        case TpuVersion.TRILLIUM:
+          decided_task_id = run_task_v6e.group_id
+        case _:
+          decided_task_id = skipped.task_id
 
-    logging.info(f"running task_id: {decided_task_id}")
-    return decided_task_id
+      logging.info(f"running task_id: {decided_task_id}")
+      return decided_task_id
 
-  # 5. Instantiate branch decider task, passing XComArg directly for Airflow auto-resolution
-  task_decider = task_path_decider(tpu_version=config.tpu_version)
+    # 5. Instantiate branch decider task, passing XComArg directly for Airflow auto-resolution
+    task_decider = task_path_decider(tpu_version=config.tpu_version)
 
-  # 6. Chain previous tasks to the decider if exist
-  if previous_tasks:
-    chain(previous_tasks, task_decider)
+    # 6. Chain previous tasks to the decider if exist
+    if previous_task:
+      chain(previous_task, task_decider)
 
-  # 7. Connect branch decider to target branches
-  task_decider >> [run_task_v5e, run_task_v6e, skipped]
+    # 7. Connect branch decider to target branches
+    chain(task_decider, [run_task_v5e, run_task_v6e, skipped])
 
-  return [run_task_v5e, run_task_v6e, skipped]
+  return group

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -7,6 +7,7 @@ import textwrap
 import airflow
 import json
 import re
+
 from airflow.decorators import task as airflow_task
 from airflow.models.taskmixin import DAGNode
 from airflow.models.baseoperator import chain

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -356,18 +356,18 @@ def run_notebook_tests(
   """Creates and chains branched notebook tests for all TPU versions.
 
   Args:
-      dag_name: Name of the DAG.
-      task_id_prefix: Prefix for task and operator IDs (e.g. "rl_grpo" or "sft").
-      notebook_path: Path to the notebook to run.
-      set_up_script: Setup script for MaxText environment.
-      parameters: Dict of parameters to inject in the notebook.
-      task_owner: Owner of the task.
-      hf_token: HuggingFace access token.
-      config: A `NotebookConfig` wrapper containing zone and tpu_version.
-      previous_task: Optional task/DAGNode to chain *before* the branches.
+    dag_name: Name of the DAG.
+    task_id_prefix: Prefix for task and operator IDs (e.g. "rl_grpo" or "sft").
+    notebook_path: Path to the notebook to run.
+    set_up_script: Setup script for MaxText environment.
+    parameters: Dict of parameters to inject in the notebook.
+    task_owner: Owner of the task.
+    hf_token: HuggingFace access token.
+    config: A `NotebookConfig` wrapper containing zone and tpu_version.
+    previous_task: Optional task/DAGNode to chain *before* the branches.
 
   Returns:
-      A TaskGroup representing the entire branched notebook test workflow.
+    A TaskGroup representing the entire branched notebook test workflow.
   """
   with TaskGroup(
       group_id=f"{task_id_prefix}_tests", prefix_group_id=False

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -1,14 +1,18 @@
 """Utility functions for automating Jupyter notebooks in Airflow."""
 
-import dataclasses
 import datetime
 import inspect
 import logging
 import textwrap
+import airflow
+import json
+import re
+from airflow.exceptions import AirflowException
+from airflow.decorators import task as airflow_task
+from airflow.operators.python import get_current_context
 from airflow.models.taskmixin import DAGNode
 from airflow.models.baseoperator import chain
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import BranchPythonOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags.common.vm_resource import (
@@ -88,9 +92,6 @@ def _run_parameter_injection(
       parameters: Dict of {key: value} for literal injection.
       env_params: List of keys to be injected as `os.getenv("KEY")`.
   """
-  import json
-  import re
-
   with open(notebook_path, encoding="utf-8") as f:
     nb = json.load(f)
 
@@ -290,34 +291,88 @@ def initialize_notebook_test(
   )
 
 
-@dataclasses.dataclass
-class NotebookConfig:
-  tpu_version: str
-  zone: str
-
-
+@airflow_task
 def load_notebook_config_from_gcs_yaml(
     gcs_path: str, dag_name: str
-) -> NotebookConfig:
+) -> dict[str, str]:
   """Loads and parses TPU version and zone configs from GCS yaml config."""
+  logging.info(
+      "[Load Config] Attempting to load YAML configuration"
+      f"from GCS path: '{gcs_path}' for DAG: '{dag_name}'."
+  )
   config = gcs.load_yaml_from_gcs(gcs_path)
+  logging.info(
+      "[Load Config] Raw YAML configuration successfully parsed "
+      f"from GCS: {config}"
+  )
   dag_cfg = config.get("dag", {}).get(dag_name, {})
+  logging.info(
+      "[Load Config] Extracted configuration block "
+      f"for DAG '{dag_name}': {dag_cfg}"
+  )
 
   tpu_version = dag_cfg.get("tpu_version")
   zone = dag_cfg.get("zone")
 
-  return NotebookConfig(tpu_version=tpu_version, zone=zone)
+  logging.info(
+      f"[Load Config] Parsed active configuration: "
+      f"tpu_version='{tpu_version}', zone='{zone}'."
+  )
+
+  return {"tpu_version": tpu_version, "zone": zone}
+
+
+class DynamicNotebookConfig:
+  """Wraps a lazy config XComArg and exposes properties that resolve to Zone/TpuVersion Enums at runtime."""
+
+  def __init__(self, config_arg: airflow.XComArg):
+    self._config_arg = config_arg
+
+  @property
+  def tpu_version(self) -> TpuVersion:
+    val = self._config_arg["tpu_version"]
+    try:
+      resolved = val.resolve(get_current_context())
+      return TpuVersion(resolved)
+    except AirflowException:
+      return val
+
+  @property
+  def zone(self) -> Zone:
+    val = self._config_arg["zone"]
+    try:
+      resolved = val.resolve(get_current_context())
+      return Zone(resolved)
+    except AirflowException:
+      return val
+
+
+class DynamicGCPConfig(gcp_config.GCPConfig):
+  """GCPConfig subclass that dynamically resolves zone XComArgs/Enums at runtime."""
+
+  @property
+  def zone(self) -> str:
+    val = self._zone
+    if isinstance(val, airflow.XComArg):
+      try:
+        val = val.resolve(get_current_context())
+      except AirflowException:
+        return val
+    return str(val.value) if hasattr(val, "value") else str(val)
+
+  @zone.setter
+  def zone(self, value):
+    self._zone = value
 
 
 def run_training(
-    config: test_config.TpuVmTest, hf_token: str, zone: str | None = None
+    config: test_config.TpuVmTest, hf_token: str, zone: str
 ) -> DAGNode:
-  target_zone = zone if zone is not None else Zone.EUROPE_WEST4_B.value
   return task.run_queued_resource_test(
       task_test_config=config,
-      task_gcp_config=gcp_config.GCPConfig(
+      task_gcp_config=DynamicGCPConfig(
           project_name=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          zone=target_zone,
+          zone=zone,
           dataset_name=metric_config.DatasetOption.XLML_DATASET,
       ),
       skip_post_process=True,
@@ -333,7 +388,7 @@ def create_branched_notebook_tasks(
     parameters: dict[str, any],
     task_owner: str,
     hf_token: str,
-    config: NotebookConfig,
+    config: airflow.XComArg,
     previous_tasks: list[DAGNode] | None = None,
 ) -> list[DAGNode]:
   """Creates and chains branched notebook tasks for all TPU versions.
@@ -346,74 +401,78 @@ def create_branched_notebook_tasks(
       parameters: Dict of parameters to inject in the notebook.
       task_owner: Owner of the task.
       hf_token: HuggingFace access token.
-      config: Loaded NotebookConfig holding active tpu_version and zone.
+      config: An `airflow.XComArg` task output that resolves at runtime to a
+        dictionary `dict[str, str]` containing 'tpu_version' and 'zone' keys.
       previous_tasks: Optional list of tasks/DAGNodes to chain *before* the branches.
 
   Returns:
       A list of terminal DAGNode tasks ([run_task, skipped_task]) from the end
       of this branch loop, which can be chained into subsequent tasks.
   """
+  if isinstance(config, airflow.XComArg):
+    config = DynamicNotebookConfig(config)
 
-  tpu_versions = [TpuVersion.V5E, TpuVersion.TRILLIUM]
+  # 1. Initialize and create the V5E test and task group
+  notebook_test_v5e = initialize_notebook_test(
+      test_name=f"{dag_name}_{task_id_prefix}",
+      dag_name=dag_name,
+      notebook_path=notebook_path,
+      set_up_script=set_up_script,
+      parameters=parameters,
+      task_owner=task_owner,
+      tpu_version=TpuVersion.V5E,
+  )
+  run_task_v5e = run_training(notebook_test_v5e, hf_token, zone=config.zone)
 
-  def choose_tpu_branch(
-      tpu_version_value: str, task_group_id: str, skipped_task_id: str
-  ):
-    selected = config.tpu_version
+  # 2. Initialize and create the TRILLIUM/V6E test and task group
+  notebook_test_v6e = initialize_notebook_test(
+      test_name=f"{dag_name}_{task_id_prefix}",
+      dag_name=dag_name,
+      notebook_path=notebook_path,
+      set_up_script=set_up_script,
+      parameters=parameters,
+      task_owner=task_owner,
+      tpu_version=TpuVersion.TRILLIUM,
+  )
+  run_task_v6e = run_training(notebook_test_v6e, hf_token, zone=config.zone)
+
+  # 3. Create skipped fallback empty operator task
+  skipped = EmptyOperator(task_id=f"skipped_{task_id_prefix}")
+
+  # 4. Define central Task-decorated Branch Operator
+  @airflow_task.branch(
+      task_id=f"task_path_decider_{task_id_prefix}",
+      trigger_rule=TriggerRule.ALL_DONE,
+  )
+  def task_path_decider() -> str:
+    active_tpu = config.tpu_version
     logging.info(
-        f"[Branch tpu_version Decision] DAG: {dag_name}, "
-        f"Task ID Prefix: {task_id_prefix}. "
-        f"Configured active TPU version: '{selected}', "
-        f"Current loop TPU version: '{tpu_version_value}'."
+        f"[Branch Decision] Configured active TPU version: '{active_tpu}'"
     )
-    if selected == "all" or selected == tpu_version_value:
+    if active_tpu == TpuVersion.V5E:
       logging.info(
-          f"[Branch tpu_version Decision] MATCH! Routing"
-          f"execution to active task group: '{task_group_id}'."
+          "[Branch Decision] MATCH! Routing execution to active V5E task group."
       )
-      return task_group_id
+      return run_task_v5e.group_id
+    elif active_tpu == TpuVersion.TRILLIUM:
+      logging.info(
+          "[Branch Decision] MATCH! Routing execution to active TRILLIUM task group."
+      )
+      return run_task_v6e.group_id
+
     logging.info(
-        f"[Branch tpu_version Decision] MISMATCH! Routing"
-        f"execution to skipped placeholder task: '{skipped_task_id}'."
+        "[Branch Decision] MISMATCH/INVALID! Routing execution to skipped fallback task."
     )
-    return skipped_task_id
+    return skipped.task_id
 
-  previous_version_tasks = previous_tasks or []
-  for tpu_version in tpu_versions:
-    # 1. Initialize the test config
-    notebook_test = initialize_notebook_test(
-        test_name=f"{dag_name}_{task_id_prefix}",
-        dag_name=dag_name,
-        notebook_path=notebook_path,
-        set_up_script=set_up_script,
-        parameters=parameters,
-        task_owner=task_owner,
-        tpu_version=tpu_version,
-    )
+  # 5. Instantiate branch decider task
+  task_decider = task_path_decider()
 
-    # 2. Create run training task group/task
-    run_task = run_training(notebook_test, hf_token, zone=config.zone)
+  # 6. Chain previous tasks to the decider if exist
+  if previous_tasks:
+    chain(previous_tasks, task_decider)
 
-    # 3. Create skipped empty operator task
-    skipped = EmptyOperator(
-        task_id=f"skipped_{task_id_prefix}_{tpu_version.value}"
-    )
+  # 7. Connect branch decider to target branches
+  task_decider >> [run_task_v5e, run_task_v6e, skipped]
 
-    # 4. Create BranchPythonOperator
-    branch = BranchPythonOperator(
-        task_id=f"branch_{task_id_prefix}_{tpu_version.value}",
-        python_callable=choose_tpu_branch,
-        op_args=[tpu_version.value, run_task.group_id, skipped.task_id],
-    )
-
-    # 5. Chain previous tasks to the branch operator if exist
-    if previous_version_tasks:
-      chain(previous_version_tasks, branch)
-      branch.trigger_rule = TriggerRule.ALL_DONE
-
-    # 6. Connect branch to the run task and skipped empty operator
-    branch >> [run_task, skipped]
-
-    previous_version_tasks = [run_task, skipped]
-
-  return previous_version_tasks
+  return [run_task_v5e, run_task_v6e, skipped]

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -1,9 +1,15 @@
 """Utility functions for automating Jupyter notebooks in Airflow."""
 
+import dataclasses
 import datetime
 import inspect
+import logging
 import textwrap
 from airflow.models.taskmixin import DAGNode
+from airflow.models.baseoperator import chain
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import BranchPythonOperator
+from airflow.utils.trigger_rule import TriggerRule
 
 from dags.common.vm_resource import (
     Project,
@@ -14,7 +20,11 @@ from dags.common.vm_resource import (
     Zone,
 )
 from dags.post_training.util import test_config_util
-from xlml.apis import gcp_config, metric_config, task, test_config
+from xlml.apis import gcp_config, gcs, metric_config, task, test_config
+
+NOTEBOOK_CONFIG_GCS_PATH = (
+    "gs://ml-auto-solutions-dag-configs/post-training/notebook_dag_configs.yaml"
+)
 
 
 def build_maxtext_setup_script() -> str:
@@ -252,6 +262,7 @@ def initialize_notebook_test(
     set_up_script: str,
     parameters: dict[str, any],
     task_owner: str,
+    tpu_version: TpuVersion,
 ) -> test_config.TpuVmTest:
   """Creates a TpuVmTest configuration for notebook execution."""
   notebook_execution = build_notebook_execution_command(
@@ -262,7 +273,7 @@ def initialize_notebook_test(
   )
   return test_config.TpuVmTest(
       test_config.Tpu(
-          version=TpuVersion.V5E,
+          version=tpu_version,
           cores=8,
           runtime_version=RuntimeVersion.V2_ALPHA_TPUV6.value,
           reserved=False,
@@ -279,14 +290,130 @@ def initialize_notebook_test(
   )
 
 
-def run_training(config: test_config.TpuVmTest, hf_token: str) -> DAGNode:
+@dataclasses.dataclass
+class NotebookConfig:
+  tpu_version: str
+  zone: str
+
+
+def load_notebook_config_from_gcs_yaml(
+    gcs_path: str, dag_name: str
+) -> NotebookConfig:
+  """Loads and parses TPU version and zone configs from GCS yaml config."""
+  config = gcs.load_yaml_from_gcs(gcs_path)
+  dag_cfg = config.get("dag", {}).get(dag_name, {})
+
+  tpu_version = dag_cfg.get("tpu_version")
+  zone = dag_cfg.get("zone")
+
+  return NotebookConfig(tpu_version=tpu_version, zone=zone)
+
+
+def run_training(
+    config: test_config.TpuVmTest, hf_token: str, zone: str | None = None
+) -> DAGNode:
+  target_zone = zone if zone is not None else Zone.EUROPE_WEST4_B.value
   return task.run_queued_resource_test(
       task_test_config=config,
       task_gcp_config=gcp_config.GCPConfig(
           project_name=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          zone=Zone.EUROPE_WEST4_B.value,
+          zone=target_zone,
           dataset_name=metric_config.DatasetOption.XLML_DATASET,
       ),
       skip_post_process=True,
       custom_env={"HF_TOKEN": hf_token},
   )
+
+
+def create_branched_notebook_tasks(
+    dag_name: str,
+    task_id_prefix: str,
+    notebook_path: str,
+    set_up_script: str,
+    parameters: dict[str, any],
+    task_owner: str,
+    hf_token: str,
+    config: NotebookConfig,
+    previous_tasks: list[DAGNode] | None = None,
+) -> list[DAGNode]:
+  """Creates and chains branched notebook tasks for all TPU versions.
+
+  Args:
+      dag_name: Name of the DAG.
+      task_id_prefix: Prefix for task and operator IDs (e.g. "rl_grpo" or "sft").
+      notebook_path: Path to the notebook to run.
+      set_up_script: Setup script for MaxText environment.
+      parameters: Dict of parameters to inject in the notebook.
+      task_owner: Owner of the task.
+      hf_token: HuggingFace access token.
+      config: Loaded NotebookConfig holding active tpu_version and zone.
+      previous_tasks: Optional list of tasks/DAGNodes to chain *before* the branches.
+
+  Returns:
+      A list of terminal DAGNode tasks ([run_task, skipped_task]) from the end
+      of this branch loop, which can be chained into subsequent tasks.
+  """
+
+  tpu_versions = [TpuVersion.V5E, TpuVersion.TRILLIUM]
+
+  def choose_tpu_branch(
+      tpu_version_value: str, task_group_id: str, skipped_task_id: str
+  ):
+    selected = config.tpu_version
+    logging.info(
+        f"[Branch tpu_version Decision] DAG: {dag_name}, "
+        f"Task ID Prefix: {task_id_prefix}. "
+        f"Configured active TPU version: '{selected}', "
+        f"Current loop TPU version: '{tpu_version_value}'."
+    )
+    if selected == "all" or selected == tpu_version_value:
+      logging.info(
+          f"[Branch tpu_version Decision] MATCH! Routing"
+          f"execution to active task group: '{task_group_id}'."
+      )
+      return task_group_id
+    logging.info(
+        f"[Branch tpu_version Decision] MISMATCH! Routing"
+        f"execution to skipped placeholder task: '{skipped_task_id}'."
+    )
+    return skipped_task_id
+
+  previous_version_tasks = previous_tasks or []
+  for tpu_version in tpu_versions:
+    # 1. Initialize the test config
+    notebook_test = initialize_notebook_test(
+        test_name=f"{dag_name}_{task_id_prefix}",
+        dag_name=dag_name,
+        notebook_path=notebook_path,
+        set_up_script=set_up_script,
+        parameters=parameters,
+        task_owner=task_owner,
+        tpu_version=tpu_version,
+    )
+
+    # 2. Create run training task group/task
+    run_task = run_training(notebook_test, hf_token, zone=config.zone)
+
+    # 3. Create skipped empty operator task
+    skipped = EmptyOperator(
+        task_id=f"skipped_{task_id_prefix}_{tpu_version.value}"
+    )
+
+    # 4. Create BranchPythonOperator
+    branch = BranchPythonOperator(
+        task_id=f"branch_{task_id_prefix}_{tpu_version.value}",
+        python_callable=choose_tpu_branch,
+        op_args=[tpu_version.value, run_task.group_id, skipped.task_id],
+    )
+
+    # 5. Chain previous tasks to the branch operator if exist
+    if previous_version_tasks:
+      chain(previous_version_tasks, branch)
+      branch.trigger_rule = TriggerRule.ALL_DONE
+
+    # 6. Connect branch to the run task and skipped empty operator
+    branch >> [run_task, skipped]
+
+    previous_version_tasks = [run_task, skipped]
+
+  return previous_version_tasks

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -291,6 +291,52 @@ def initialize_notebook_test(
   )
 
 
+class XComValueWrapper:
+  """A wrapper that dynamically resolves a native Airflow XComArg at execution time."""
+
+  def __init__(
+      self, xcom_arg: airflow.XComArg, cast_type=str, default=None
+  ) -> None:
+    self.xcom_arg = xcom_arg
+    self.cast_type = cast_type
+    self.default = default
+
+  def resolve(self):
+    try:
+      context = get_current_context()
+      resolved = self.xcom_arg.resolve(context)
+      if resolved is not None:
+        return self.cast_type(resolved)
+    except Exception:
+      pass
+    return self.default
+
+  def __str__(self) -> str:
+    val = self.resolve()
+    if hasattr(val, "value"):
+      return str(val.value)
+    return str(val) if val is not None else ""
+
+  def __repr__(self) -> str:
+    return self.__str__()
+
+  def __eq__(self, other) -> bool:
+    val = self.resolve()
+    val_compare = val.value if hasattr(val, "value") else val
+    other_compare = other.value if hasattr(other, "value") else other
+    return val_compare == other_compare
+
+
+class NotebookConfig:
+  """A simple container holding dynamic XComValueWrapper fields."""
+
+  def __init__(self, config_arg: airflow.XComArg) -> None:
+    self.zone = XComValueWrapper(config_arg["zone"], cast_type=str)
+    self.tpu_version = XComValueWrapper(
+        config_arg["tpu_version"], cast_type=TpuVersion
+    )
+
+
 @airflow_task
 def load_notebook_config_from_gcs_yaml(
     gcs_path: str, dag_name: str
@@ -309,55 +355,12 @@ def load_notebook_config_from_gcs_yaml(
   return {"tpu_version": tpu_version, "zone": zone}
 
 
-class DynamicNotebookConfig:
-  """Wraps a lazy config XComArg and exposes properties that resolve to Zone/TpuVersion Enums at runtime."""
-
-  def __init__(self, config_arg: airflow.XComArg):
-    self._config_arg = config_arg
-
-  @property
-  def tpu_version(self) -> TpuVersion:
-    val = self._config_arg["tpu_version"]
-    try:
-      resolved = val.resolve(get_current_context())
-      return TpuVersion(resolved)
-    except AirflowException:
-      return val
-
-  @property
-  def zone(self) -> Zone:
-    val = self._config_arg["zone"]
-    try:
-      resolved = val.resolve(get_current_context())
-      return Zone(resolved)
-    except AirflowException:
-      return val
-
-
-class DynamicGCPConfig(gcp_config.GCPConfig):
-  """GCPConfig subclass that dynamically resolves zone XComArgs/Enums at runtime."""
-
-  @property
-  def zone(self) -> str:
-    val = self._zone
-    if isinstance(val, airflow.XComArg):
-      try:
-        val = val.resolve(get_current_context())
-      except AirflowException:
-        return val
-    return str(val.value) if hasattr(val, "value") else str(val)
-
-  @zone.setter
-  def zone(self, value):
-    self._zone = value
-
-
 def run_training(
     config: test_config.TpuVmTest, hf_token: str, zone: str
 ) -> DAGNode:
   return task.run_queued_resource_test(
       task_test_config=config,
-      task_gcp_config=DynamicGCPConfig(
+      task_gcp_config=gcp_config.GCPConfig(
           project_name=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
           zone=zone,
           dataset_name=metric_config.DatasetOption.XLML_DATASET,
@@ -375,7 +378,7 @@ def create_branched_notebook_tasks(
     parameters: dict[str, any],
     task_owner: str,
     hf_token: str,
-    config: airflow.XComArg,
+    config: NotebookConfig,
     previous_tasks: list[DAGNode] = None,
 ) -> list[DAGNode]:
   """Creates and chains branched notebook tasks for all TPU versions.
@@ -388,17 +391,13 @@ def create_branched_notebook_tasks(
       parameters: Dict of parameters to inject in the notebook.
       task_owner: Owner of the task.
       hf_token: HuggingFace access token.
-      config: An `airflow.XComArg` task output that resolves at runtime to a
-        dictionary `dict[str, str]` containing 'tpu_version' and 'zone' keys.
+      config: A `NotebookConfig` wrapper containing zone and tpu_version.
       previous_tasks: Optional list of tasks/DAGNodes to chain *before* the branches.
 
   Returns:
       A list of terminal DAGNode tasks ([run_task, skipped_task]) from the end
       of this branch loop, which can be chained into subsequent tasks.
   """
-  if isinstance(config, airflow.XComArg):
-    config = DynamicNotebookConfig(config)
-
   # 1. Initialize and create the V5E test and task group
   notebook_test_v5e = initialize_notebook_test(
       test_name=f"{dag_name}_{task_id_prefix}",
@@ -432,9 +431,8 @@ def create_branched_notebook_tasks(
       trigger_rule=TriggerRule.ALL_DONE,
   )
   def task_path_decider() -> str:
-    active_tpu = config.tpu_version
-    logging.info(f"Configured active TPU version: '{active_tpu}'")
-    match active_tpu:
+    logging.info(f"Configured active TPU version: '{config.tpu_version}'")
+    match config.tpu_version:
       case TpuVersion.V5E:
         decided_task_id = run_task_v5e.group_id
       case TpuVersion.TRILLIUM:

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -7,9 +7,7 @@ import textwrap
 import airflow
 import json
 import re
-from airflow.exceptions import AirflowException
 from airflow.decorators import task as airflow_task
-from airflow.operators.python import get_current_context
 from airflow.models.taskmixin import DAGNode
 from airflow.models.baseoperator import chain
 from airflow.operators.empty import EmptyOperator
@@ -291,53 +289,15 @@ def initialize_notebook_test(
   )
 
 
-class XComValueWrapper:
-  """A wrapper that dynamically resolves a native Airflow XComArg at execution time."""
-
-  def __init__(
-      self, xcom_arg: airflow.XComArg, cast_type=str, default=None
-  ) -> None:
-    self.xcom_arg = xcom_arg
-    self.cast_type = cast_type
-    self.default = default
-
-  def resolve(self):
-    try:
-      context = get_current_context()
-      resolved = self.xcom_arg.resolve(context)
-      if resolved is not None:
-        return self.cast_type(resolved)
-    except Exception:
-      pass
-    return self.default
-
-  def __str__(self) -> str:
-    val = self.resolve()
-    if hasattr(val, "value"):
-      return str(val.value)
-    return str(val) if val is not None else ""
-
-  def __repr__(self) -> str:
-    return self.__str__()
-
-  def __eq__(self, other) -> bool:
-    val = self.resolve()
-    val_compare = val.value if hasattr(val, "value") else val
-    other_compare = other.value if hasattr(other, "value") else other
-    return val_compare == other_compare
-
-
 class NotebookConfig:
-  """A simple container holding dynamic XComValueWrapper fields."""
+  """A simple container holding dynamic XComArg fields."""
 
-  def __init__(self, config_arg: airflow.XComArg) -> None:
-    self.zone = XComValueWrapper(config_arg["zone"], cast_type=str)
-    self.tpu_version = XComValueWrapper(
-        config_arg["tpu_version"], cast_type=TpuVersion
-    )
+  def __init__(self, config_arg: dict[str, airflow.XComArg]) -> None:
+    self.zone = config_arg["zone"]
+    self.tpu_version = config_arg["tpu_version"]
 
 
-@airflow_task
+@airflow_task(multiple_outputs=True)
 def load_notebook_config_from_gcs_yaml(
     gcs_path: str, dag_name: str
 ) -> dict[str, str]:
@@ -348,6 +308,16 @@ def load_notebook_config_from_gcs_yaml(
   tpu_version = dag_cfg.get("tpu_version")
   zone = dag_cfg.get("zone")
 
+  # Validate that GCS config values correspond to valid Enum values
+  def assert_is_valid_enum(value: str, enum_class) -> None:
+    try:
+      enum_class(value)
+    except ValueError as e:
+      raise ValueError(f"Config Validation Error: {e}") from e
+
+  assert_is_valid_enum(zone, Zone)
+  assert_is_valid_enum(tpu_version, TpuVersion)
+
   logging.info(
       f"Loaded configuration: tpu_version='{tpu_version}', zone='{zone}'."
   )
@@ -356,7 +326,7 @@ def load_notebook_config_from_gcs_yaml(
 
 
 def run_training(
-    config: test_config.TpuVmTest, hf_token: str, zone: str
+    config: test_config.TpuVmTest, hf_token: str, zone: str | airflow.XComArg
 ) -> DAGNode:
   return task.run_queued_resource_test(
       task_test_config=config,
@@ -425,14 +395,16 @@ def create_branched_notebook_tasks(
   # 3. Create skipped fallback empty operator task
   skipped = EmptyOperator(task_id=f"skipped_{task_id_prefix}")
 
-  # 4. Define central Task-decorated Branch Operator
+  # 4. Define central Task-decorated Branch Operator accepting dynamic parameters
   @airflow_task.branch(
       task_id=f"task_path_decider_{task_id_prefix}",
       trigger_rule=TriggerRule.ALL_DONE,
   )
-  def task_path_decider() -> str:
-    logging.info(f"Configured active TPU version: '{config.tpu_version}'")
-    match config.tpu_version:
+  def task_path_decider(tpu_version: str) -> str:
+    logging.info(f"Configured active TPU version: '{tpu_version}'")
+    active_tpu_version = TpuVersion(tpu_version)
+
+    match active_tpu_version:
       case TpuVersion.V5E:
         decided_task_id = run_task_v5e.group_id
       case TpuVersion.TRILLIUM:
@@ -443,8 +415,8 @@ def create_branched_notebook_tasks(
     logging.info(f"running task_id: {decided_task_id}")
     return decided_task_id
 
-  # 5. Instantiate branch decider task
-  task_decider = task_path_decider()
+  # 5. Instantiate branch decider task, passing XComArg directly for Airflow auto-resolution
+  task_decider = task_path_decider(tpu_version=config.tpu_version)
 
   # 6. Chain previous tasks to the decider if exist
   if previous_tasks:

--- a/dags/post_training/util/notebook_util.py
+++ b/dags/post_training/util/notebook_util.py
@@ -296,27 +296,14 @@ def load_notebook_config_from_gcs_yaml(
     gcs_path: str, dag_name: str
 ) -> dict[str, str]:
   """Loads and parses TPU version and zone configs from GCS yaml config."""
-  logging.info(
-      "[Load Config] Attempting to load YAML configuration"
-      f"from GCS path: '{gcs_path}' for DAG: '{dag_name}'."
-  )
   config = gcs.load_yaml_from_gcs(gcs_path)
-  logging.info(
-      "[Load Config] Raw YAML configuration successfully parsed "
-      f"from GCS: {config}"
-  )
   dag_cfg = config.get("dag", {}).get(dag_name, {})
-  logging.info(
-      "[Load Config] Extracted configuration block "
-      f"for DAG '{dag_name}': {dag_cfg}"
-  )
 
   tpu_version = dag_cfg.get("tpu_version")
   zone = dag_cfg.get("zone")
 
   logging.info(
-      f"[Load Config] Parsed active configuration: "
-      f"tpu_version='{tpu_version}', zone='{zone}'."
+      f"Loaded configuration: tpu_version='{tpu_version}', zone='{zone}'."
   )
 
   return {"tpu_version": tpu_version, "zone": zone}
@@ -389,7 +376,7 @@ def create_branched_notebook_tasks(
     task_owner: str,
     hf_token: str,
     config: airflow.XComArg,
-    previous_tasks: list[DAGNode] | None = None,
+    previous_tasks: list[DAGNode] = None,
 ) -> list[DAGNode]:
   """Creates and chains branched notebook tasks for all TPU versions.
 
@@ -446,24 +433,17 @@ def create_branched_notebook_tasks(
   )
   def task_path_decider() -> str:
     active_tpu = config.tpu_version
-    logging.info(
-        f"[Branch Decision] Configured active TPU version: '{active_tpu}'"
-    )
-    if active_tpu == TpuVersion.V5E:
-      logging.info(
-          "[Branch Decision] MATCH! Routing execution to active V5E task group."
-      )
-      return run_task_v5e.group_id
-    elif active_tpu == TpuVersion.TRILLIUM:
-      logging.info(
-          "[Branch Decision] MATCH! Routing execution to active TRILLIUM task group."
-      )
-      return run_task_v6e.group_id
+    logging.info(f"Configured active TPU version: '{active_tpu}'")
+    match active_tpu:
+      case TpuVersion.V5E:
+        decided_task_id = run_task_v5e.group_id
+      case TpuVersion.TRILLIUM:
+        decided_task_id = run_task_v6e.group_id
+      case _:
+        decided_task_id = skipped.task_id
 
-    logging.info(
-        "[Branch Decision] MISMATCH/INVALID! Routing execution to skipped fallback task."
-    )
-    return skipped.task_id
+    logging.info(f"running task_id: {decided_task_id}")
+    return decided_task_id
 
   # 5. Instantiate branch decider task
   task_decider = task_path_decider()

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -19,14 +19,37 @@ set -e
 
 FOLDERS_TO_FORMAT=("dags" "xlml")
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."

--- a/xlml/apis/gcp_config.py
+++ b/xlml/apis/gcp_config.py
@@ -15,7 +15,10 @@
 """Config file for Google Cloud Project (GCP)."""
 
 import dataclasses
-
+from typing import Any
+from airflow.exceptions import AirflowException
+from airflow.models.xcom_arg import XComArg
+from airflow.operators.python import get_current_context
 from dags.common.vm_resource import Project
 from xlml.apis import metric_config
 
@@ -37,3 +40,28 @@ class GCPConfig:
   dataset_name: metric_config.DatasetOption
   dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value
   composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value
+
+  def __getattribute__(self, name: str) -> Any:
+    # First obtain the underlying value of the attribute.
+    value = super().__getattribute__(name)
+
+    # Actively resolve an XComArg under execution phase.
+    match value:
+      case XComArg():
+        try:
+          context = get_current_context()
+        except AirflowException:
+          # AirflowException means we are not in execution phase yet,
+          # return the XComArg as-is
+          return value
+
+        resolved_value = value.resolve(context)
+
+        # Store the resolved result back so that
+        # further references won't have to resolve again.
+        super().__setattr__(name, resolved_value)
+
+        return resolved_value
+
+      case _:
+        return value

--- a/xlml/apis/gcp_config.py
+++ b/xlml/apis/gcp_config.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 from typing import Any
+
 from airflow.exceptions import AirflowException
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.python import get_current_context
@@ -36,7 +37,7 @@ class GCPConfig:
   """
 
   project_name: str
-  zone: str
+  zone: str | XComArg
   dataset_name: metric_config.DatasetOption
   dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value
   composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -147,9 +147,9 @@ def run_queued_resource_test(
         },
     )
 
-    clean_up = tpu.delete_queued_resource.override(group_id="clean_up")(
-        queued_resource_name
-    )
+    with TaskGroup(group_id="clean_up") as clean_up:
+      clean_up_task = tpu.delete_queued_resource(queued_resource_name)
+    clean_up_task.as_teardown(setups=queued_resource_name.operator)
 
     if skip_post_process:
       _ = provision >> run_model >> clean_up

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -147,9 +147,9 @@ def run_queued_resource_test(
         },
     )
 
-    with TaskGroup(group_id="clean_up") as clean_up:
-      clean_up_task = tpu.delete_queued_resource(queued_resource_name)
-    clean_up_task.as_teardown(setups=queued_resource_name.operator)
+    clean_up = tpu.delete_queued_resource.override(group_id="clean_up")(
+        queued_resource_name
+    )
 
     if skip_post_process:
       _ = provision >> run_model >> clean_up

--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -23,6 +23,7 @@ import uuid
 
 from absl import logging
 import airflow
+
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.decorators import task, task_group
 from airflow.utils.task_group import TaskGroup

--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -23,6 +23,7 @@ import uuid
 
 from absl import logging
 import airflow
+from airflow.utils.trigger_rule import TriggerRule
 from airflow.decorators import task, task_group
 from airflow.utils.task_group import TaskGroup
 from airflow.operators.python import get_current_context
@@ -244,6 +245,7 @@ def create_queued_resource(
   return tg, qualified_name
 
 
+@task_group
 def delete_queued_resource(qualified_name: airflow.XComArg):
   """Implements cascading delete for a Queued Resource.
 
@@ -252,7 +254,7 @@ def delete_queued_resource(qualified_name: airflow.XComArg):
       resource.
   """
 
-  @task
+  @task(trigger_rule=TriggerRule.NONE_SKIPPED)
   def delete_tpu_nodes_request(qualified_name: str):
     # TODO(wcromar): Find a less repetitive way to manage the TPU client.
     creds, _ = google.auth.default()
@@ -298,7 +300,7 @@ def delete_queued_resource(qualified_name: airflow.XComArg):
     logging.info(f'TPU Nodes: {qr.tpu.node_spec}')
     return False
 
-  @task
+  @task(trigger_rule=TriggerRule.NONE_SKIPPED)
   def delete_queued_resource_request(qualified_name: str) -> Optional[str]:
     creds, _ = google.auth.default()
     client = tpu_api.TpuClient(credentials=creds)
@@ -330,7 +332,7 @@ def delete_queued_resource(qualified_name: airflow.XComArg):
   qr_op_name = delete_tpu_nodes >> delete_queued_resource_request(
       qualified_name
   )
-  return wait_for_queued_resource_deletion(qr_op_name)
+  wait_for_queued_resource_deletion(qr_op_name)
 
 
 def kill_process_by_pid() -> str:

--- a/xlml/utils/tpu.py
+++ b/xlml/utils/tpu.py
@@ -244,7 +244,6 @@ def create_queued_resource(
   return tg, qualified_name
 
 
-@task_group
 def delete_queued_resource(qualified_name: airflow.XComArg):
   """Implements cascading delete for a Queued Resource.
 
@@ -253,7 +252,7 @@ def delete_queued_resource(qualified_name: airflow.XComArg):
       resource.
   """
 
-  @task(trigger_rule='all_done')
+  @task
   def delete_tpu_nodes_request(qualified_name: str):
     # TODO(wcromar): Find a less repetitive way to manage the TPU client.
     creds, _ = google.auth.default()
@@ -299,7 +298,7 @@ def delete_queued_resource(qualified_name: airflow.XComArg):
     logging.info(f'TPU Nodes: {qr.tpu.node_spec}')
     return False
 
-  @task(trigger_rule='all_done')
+  @task
   def delete_queued_resource_request(qualified_name: str) -> Optional[str]:
     creds, _ = google.auth.default()
     client = tpu_api.TpuClient(credentials=creds)
@@ -331,7 +330,7 @@ def delete_queued_resource(qualified_name: airflow.XComArg):
   qr_op_name = delete_tpu_nodes >> delete_queued_resource_request(
       qualified_name
   )
-  wait_for_queued_resource_deletion(qr_op_name)
+  return wait_for_queued_resource_deletion(qr_op_name)
 
 
 def kill_process_by_pid() -> str:


### PR DESCRIPTION
# Description
 1. Support v5e and v6e TPU versions in the DAG.
 2. Read YAML configurations from a GCS bucket to set the TPU version and zone for the run.

# Tests
- Airflow Test Results: https://f5eac1c8d1684611864003492b988589-dot-us-east1.composer.googleusercontent.com/home?tags=post-training

#  Airflow/Composer
- GCP Composer name: `camilo-orbax-dev` (under GCP project: `cloud-ml-auto-solutions`)
- GCP Composer version: `2.13.1`

## Bucket  with HNS (Hierarchical Name Space)
- Bucket Name: gs://mtc-automation-bucket

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.