### PR TITLE
fix: Fix `test_checkpoiting.sh`

### DIFF
--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -58,7 +58,7 @@ with models.DAG(
       command = (
           "bash tests/end_to_end/test_checkpointing.sh "
           f" {run_name} {base_output_directory} {dataset_path}"
-          f" true tfds autoselected {async_checkpointing}",
+          f" tfds autoselected {async_checkpointing}",
       )
       maxtext_v4_configs_test = gke_config.get_gke_config(
           num_slices=1,


### PR DESCRIPTION
# Description

Update maxtext_checkpointing since [PR#3940](https://github.com/AI-Hypercomputer/maxtext/pull/3940) in Maxtext removed the `COLLECT_STACK_TRACE=${4}` in `tests/end_to_end/test_checkpointing.sh`

# Tests

[Tested in Dev composer.](http://08398f98ca104983a06a424b851a390d-dot-us-central1.composer.googleusercontent.com/dags/maxtext_checkpointing/grid?dag_run_id=manual__2026-05-26T04%3A57%3A36.530086%2B00%3A00&task_id=maxtext-checkpointing-nightly-sync-v5p-8.run_model.wait_for_workload_completion&tab=logs)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.