### PR TITLE
Refactor TPU Observability DAGs to Remove Dynamic Task Mapping

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -68,7 +68,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "multi_host_nodepool_rollback": DefaultTimeout,
         "node_pool_ttr_disk_size": dt.timedelta(minutes=90),
         "node_pool_ttr_update_label": dt.timedelta(minutes=90),
-        "tpu_info_format_validation_dag": DefaultTimeout,
+        "tpu_info_format_validation_dag": dt.timedelta(minutes=60),
         "tpu_sdk_monitoring_validation": DefaultTimeout,
         "jobset_ttr_kill_process": dt.timedelta(minutes=90),
         "jobset_uptime_validation": dt.timedelta(minutes=90),

--- a/dags/common/task_group_with_timeout/task_group_with_timeout.py
+++ b/dags/common/task_group_with_timeout/task_group_with_timeout.py
@@ -69,6 +69,7 @@ class TaskGroupWithTimeout(TaskGroup):
     super().__init__(group_id=group_id, **kwargs)
     self.group_name = f"{self.__class__.__name__}: '{group_id}'"
     self.timeout = timeout
+    self.is_teardown_group = is_teardown
     self.trigger_rule = (
         TriggerRule.ALL_DONE if is_teardown else TriggerRule.ALL_SUCCESS
     )
@@ -96,6 +97,9 @@ class TaskGroupWithTimeout(TaskGroup):
     """
     children_ids = set(self.children.keys())
     for child in self.children.values():
+      if self.is_teardown_group and isinstance(child, BaseOperator):
+        child.is_teardown = True
+
       if child is self._root_node:
         continue
       # If a sibling already chains into this child, the dependency on

--- a/dags/common/task_group_with_timeout/task_group_with_timeout.py
+++ b/dags/common/task_group_with_timeout/task_group_with_timeout.py
@@ -73,27 +73,29 @@ class TaskGroupWithTimeout(TaskGroup):
     self._root_node = None
 
   def __exit__(self, *args):
-    """Wire `_root_node` as upstream of in-group root children on context exit."""
+    """Wire `_root_node` as upstream of in-group root children on context
+    exit."""
     self.initialize_task_group_session()
     self.mark_teardown()
     return super().__exit__(*args)
 
   def initialize_task_group_session(self):
-    """Initializes the session root task and wires it to in-group root children."""
+    """Initializes the session root task and wires it to in-group root
+    children."""
     root_task = PythonOperator(
-      task_id=self.ROOT_TASK_ID,
-      python_callable=lambda: datetime.now(timezone.utc).isoformat(),
+        task_id=self.ROOT_TASK_ID,
+        python_callable=lambda: datetime.now(timezone.utc).isoformat(),
     )
 
     if self.setup_op is not None:
       setups = (
-        self.setup_op
-        if isinstance(self.setup_op, (list, tuple, TaskGroup))
-        else [self.setup_op]
+          self.setup_op
+          if isinstance(self.setup_op, (list, tuple, TaskGroup))
+          else [self.setup_op]
       )
       root_task.as_teardown(
-        setups=setups,
-        on_failure_fail_dagrun=False,
+          setups=setups,
+          on_failure_fail_dagrun=False,
       )
 
     self._root_node = root_task
@@ -103,7 +105,7 @@ class TaskGroupWithTimeout(TaskGroup):
         continue
 
       has_ingroup_upstream = any(
-        up in self.children.values() for up in child.upstream_list
+          up in self.children.values() for up in child.upstream_list
       )
       if not has_ingroup_upstream:
         child.set_upstream(self._root_node)
@@ -114,9 +116,9 @@ class TaskGroupWithTimeout(TaskGroup):
       return
 
     setups = (
-      self.setup_op
-      if isinstance(self.setup_op, (list, tuple, TaskGroup))
-      else [self.setup_op]
+        self.setup_op
+        if isinstance(self.setup_op, (list, tuple, TaskGroup))
+        else [self.setup_op]
     )
 
     for child in self.children.values():
@@ -129,8 +131,8 @@ class TaskGroupWithTimeout(TaskGroup):
             continue
 
           child.as_teardown(
-            setups=setups,
-            on_failure_fail_dagrun=True,
+              setups=setups,
+              on_failure_fail_dagrun=True,
           )
 
   def add(self, node: DAGNode):

--- a/dags/common/task_group_with_timeout/task_group_with_timeout.py
+++ b/dags/common/task_group_with_timeout/task_group_with_timeout.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, timezone
 
 from airflow.exceptions import AirflowFailException
 from airflow.models import BaseOperator
+from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskmixin import DAGNode
 from airflow.operators.python import PythonOperator
@@ -26,7 +27,6 @@ from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.context import Context
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.timeout import timeout as AirflowTimeout
-from airflow.utils.trigger_rule import TriggerRule
 
 
 class TaskGroupWithTimeout(TaskGroup):
@@ -63,51 +63,75 @@ class TaskGroupWithTimeout(TaskGroup):
       self,
       group_id,
       timeout: timedelta,
-      is_teardown: bool = False,
+      as_teardown_of: BaseOperator | None = None,
       **kwargs,
   ):
     super().__init__(group_id=group_id, **kwargs)
     self.group_name = f"{self.__class__.__name__}: '{group_id}'"
     self.timeout = timeout
-    self.is_teardown_group = is_teardown
-    self.trigger_rule = (
-        TriggerRule.ALL_DONE if is_teardown else TriggerRule.ALL_SUCCESS
-    )
+    self.setup_op = as_teardown_of
     self._root_node = None
 
-  def __enter__(self):
-    """Inject `_root_node` when entering the group context.
-
-    Overridden because this group's timeout mechanism needs a single anchor
-    task to record the start time; see class docstring for the full flow.
-    """
-    tg = super().__enter__()
-    self._root_node = PythonOperator(
-        task_id=self.ROOT_TASK_ID,
-        python_callable=lambda: datetime.now(timezone.utc).isoformat(),
-        trigger_rule=self.trigger_rule,
-    )
-    return tg
-
   def __exit__(self, *args):
-    """Wire `_root_node` as upstream of in-group root children on context exit.
+    """Wire `_root_node` as upstream of in-group root children on context exit."""
+    self.initialize_task_group_session()
+    self.mark_teardown()
+    return super().__exit__(*args)
 
-    Overridden to guarantee `_root_node` runs first. Only children with no
-    in-group sibling upstream get a direct edge; others inherit transitively.
-    """
-    children_ids = set(self.children.keys())
-    for child in self.children.values():
-      if self.is_teardown_group and isinstance(child, BaseOperator):
-        child.is_teardown = True
+  def initialize_task_group_session(self):
+    """Initializes the session root task and wires it to in-group root children."""
+    root_task = PythonOperator(
+      task_id=self.ROOT_TASK_ID,
+      python_callable=lambda: datetime.now(timezone.utc).isoformat(),
+    )
 
+    if self.setup_op is not None:
+      setups = (
+        self.setup_op
+        if isinstance(self.setup_op, (list, tuple, TaskGroup))
+        else [self.setup_op]
+      )
+      root_task.as_teardown(
+        setups=setups,
+        on_failure_fail_dagrun=False,
+      )
+
+    self._root_node = root_task
+
+    for child in list(self.children.values()):
       if child is self._root_node:
         continue
-      # If a sibling already chains into this child, the dependency on
-      # _root_node is satisfied transitively — no need to add a direct edge.
-      if child.upstream_task_ids & children_ids:
-        continue
-      child.set_upstream(self._root_node)
-    return super().__exit__(*args)
+
+      has_ingroup_upstream = any(
+        up in self.children.values() for up in child.upstream_list
+      )
+      if not has_ingroup_upstream:
+        child.set_upstream(self._root_node)
+
+  def mark_teardown(self):
+    """Marks all operators within this TaskGroup as teardown tasks."""
+    if self.setup_op is None:
+      return
+
+    setups = (
+      self.setup_op
+      if isinstance(self.setup_op, (list, tuple, TaskGroup))
+      else [self.setup_op]
+    )
+
+    for child in self.children.values():
+      match child:
+        case TaskGroup():
+          pass  # A TaskGroup does not have a teardown attribute.
+
+        case AbstractOperator():
+          if child is self._root_node:
+            continue
+
+          child.as_teardown(
+            setups=setups,
+            on_failure_fail_dagrun=True,
+          )
 
   def add(self, node: DAGNode):
     node = super().add(node)
@@ -145,12 +169,22 @@ class TaskGroupWithTimeout(TaskGroup):
 
         group_name = self.group_name
         timeout = self.timeout
-        root_node_id = self._root_node.task_id
+        root_node_id = self.ROOT_TASK_ID
 
         def wrapped_execute(context: Context):
           task_instance = context.get("task_instance")
 
-          start_time_str = task_instance.xcom_pull(task_ids=root_node_id)
+          current_task_id = task_instance.task_id
+          if "." in current_task_id:
+            group_prefix = current_task_id.rsplit(".", 1)[0]
+            full_root_node_id = f"{group_prefix}.{root_node_id}"
+          else:
+            full_root_node_id = root_node_id
+
+          start_time_str = task_instance.xcom_pull(task_ids=full_root_node_id)
+          if not start_time_str:
+            start_time_str = task_instance.xcom_pull(task_ids=root_node_id)
+
           if not start_time_str:
             raise AirflowFailException(
                 "Failed to overwrite timeout for task: "

--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -69,13 +69,14 @@ SHARON_Y = "Shuang-cnt"
 # MLCompass
 ORTI_B = "ortibazar"
 
-# Sparsity & Diffusion DevX
+# JAX Models and Performance
 RAN_R = "RissyRan"
 PARAM_B = "parambole"
 KUNJAN_P = "coolkp"
 MICHELLE_Y = "michelle-yooh"
 SHUNING_J = "shuningjin"
 ROHAN_B = "Rohan-Bierneni"
+SNEHAL_V = "snehalv2002"
 
 # Inference
 XIANG_S = "sixiang-google"

--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -272,6 +272,14 @@ class XpkClusters:
       project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
       zone=Zone.EUROPE_WEST4_B.value,
   )
+  TPU_V5P_MLPERF_CLUSTER = XpkClusterConfig(
+      name="mlperf-v5p",
+      device_version=TpuVersion.V5P,
+      core_count=8,
+      project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+      zone=Zone.EUROPE_WEST4_B.value,
+      namespace="automation-testing",
+  )
   TPU_V5E_256_CLUSTER = XpkClusterConfig(
       name="v5e-256-bodaborg-europe-west4",
       device_version=TpuVersion.V5E,

--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ Used upon library upgrades.
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -54,7 +54,11 @@ with models.DAG(
     for model_size in models:
       run_cmds = [
           "pip show aqtp",
-          f"bash src/maxtext/configs/tpu/{tpu}/{model_size}.sh EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} PLATFORM=gke",
+          (
+              f"bash src/maxtext/configs/tpu/{tpu}/{model_size}.sh "
+              f"EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} "
+              "PLATFORM=gke"
+          ),
       ]
 
       tests.extend(
@@ -98,4 +102,4 @@ with models.DAG(
 
   # Run jobs
   for test in tests:
-    test.run_with_run_name_generation()
+    test.run()

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-An example DAG to extract profile metrics from pretraining mixtral-8x7b model on 1xv4-128.
-Profile extraction can be easily integrated with gke_config + run_with_run_name_generation.
+"""An example DAG to extract profile metrics.
+
+Pretraining mixtral-8x7b model on 1xv4-128.
+Profile extraction can be easily integrated with gke_config
++ (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters
 from dags.multipod.configs import gke_config
 from xlml.apis import metric_config
 
@@ -28,36 +30,50 @@ SCHEDULED_TIME = None
 BASE_OUTPUT_PATH = "gs://runner-maxtext-logs"
 
 docker_image = {
-    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-20",
+    "stable": (
+        "gcr.io/tpu-prod-env-multipod/" "maxtext_jax_stable_stack:2025-05-20"
+    ),
 }
 
 base_command = (
     f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-    + "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+    "python3 -m maxtext.trainers.pre_train.train "
+    "src/maxtext/configs/base.yml "
+    "base_output_directory=gs://runner-maxtext-logs "
+    "run_name=${RUN_NAME} model_name=mixtral-8x7b "
+    "tokenizer_path=assets/tokenizer.mistral-v1 "
+    "dataset_path=gs://maxtext-dataset per_device_batch_size=4 "
+    "enable_checkpointing=false ici_fsdp_parallelism=-1 "
+    "max_target_length=1024 async_checkpointing=false "
+    "attention=flash dtype=bfloat16 weight_dtype=bfloat16"
 )
 
 test_models_tpu = {
     # use: upload single profile from the first host, extract profile
-    # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+    # add profiler config: ensure steps >
+    # skip_first_n_steps_for_profiler + profiler_steps
     "mixtral-8x7b_pretraining-megablox_config-true_upload-one": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+            base_command + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3",
         ],
     },
     # use: upload profiles from all hosts, extract one of the profiles
-    # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+    # add profiler config: ensure steps >
+    # skip_first_n_steps_for_profiler + profiler_steps
     "mixtral-8x7b_pretraining-megablox_config-true_upload-all": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 upload_all_profiler_results=True",
+            base_command + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            "upload_all_profiler_results=True",
         ],
     },
-    # testing: handle edge case, attempt to extract, find no match, proceed to post_process without error
+    # testing: handle edge case, attempt to extract, find no match,
+    # proceed to post_process without error
     "testing_config-true_upload-none": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
@@ -65,13 +81,14 @@ test_models_tpu = {
             base_command + " steps=10",
         ],
     },
-    # testing: not generate profile location, not extract profile in post_process
+    # testing: not generate profile location, not extract profile in
+    # post_process
     "testing_config-false_upload-one": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+            base_command + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3",
         ],
         "not_add_profile_config": True,
     },
@@ -87,8 +104,9 @@ with models.DAG(
     concurrency=2,
 ) as dag:
   for run_name, test_scripts_details in test_models_tpu.items():
-    for image in docker_image.keys():
-      # file_location: pass in base_output_directory, will be altered in `run_with_run_name_generation`
+    for image, img_val in docker_image.items():
+      # file_location: pass in base_output_directory, will be altered in
+      # XpkNameGenAndQuarantineTask.run_with_run_name_generation
       job_metric_config = metric_config.MetricConfig()
       # optionally, add tensorboard metrics
       job_metric_config.tensorboard_summary = metric_config.SummaryConfig(
@@ -105,13 +123,16 @@ with models.DAG(
       if "not_add_profile_config" in test_scripts_details:
         job_metric_config.profile = None
 
-      tpu_task = gke_config.get_gke_config(
+      tpu_task = gke_config.get_gke_config_with_name_gen_and_quarantine(
           num_slices=1,
           time_out_in_min=test_scripts_details["time_out_in_min"],
           test_name=f"maxtext_{image}_{run_name}",
           run_model_cmds=test_scripts_details["train_command"],
-          docker_image=docker_image[image],
+          docker_image=img_val,
           test_owner=test_owner.SHUNING_J,
           cluster=test_scripts_details["cluster"],
-          user_specified_job_metric_config=job_metric_config,  # customize config
-      ).run_with_run_name_generation(run_name_env="RUN_NAME")
+          user_specified_job_metric_config=(
+              job_metric_config
+          ),  # customize config
+          run_name_env="RUN_NAME",
+      ).run()

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-An example DAG to extract profile metrics from pretraining mixtral-8x7b model on v6-256.
-Profile extraction can be seamlessly integrated with maxtext_sweep_gke_config + run_with_name_gen_and_quarantine.
+"""An example DAG to extract profile metrics.
+
+Pretraining mixtral-8x7b model on v6-256.
+Profile extraction can be seamlessly integrated with
+maxtext_sweep_gke_config + (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime
 from airflow import models
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
-from dags.common.vm_resource import XpkClusters, DockerImage, Project
-from dags.multipod.configs import maxtext_sweep_gke_config
+from dags.common.vm_resource import XpkClusters, Project
+from dags.multipod.configs import maxtext_sweep_gke_config as sweep_config
 from xlml.apis import metric_config
 
 SCHEDULED_TIME = None
@@ -35,7 +37,9 @@ def dict_to_arg(param_dict):
 
 
 docker_image = {
-    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-20",
+    "stable": (
+        "gcr.io/tpu-prod-env-multipod/" "maxtext_jax_stable_stack:2025-05-20"
+    ),
 }
 
 # https://github.com/AI-Hypercomputer/maxtext/blob/main/benchmarks/maxtext_trillium_model_configs.py
@@ -45,9 +49,14 @@ test_models_tpu = {
         "cluster": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
         "train_command": [
             f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-            "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} model_name=mixtral-8x7b "
-            # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
-            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            "python3 -m maxtext.trainers.pre_train.train "
+            "src/maxtext/configs/base.yml "
+            "base_output_directory=${BASE_OUTPUT_PATH} "
+            "model_name=mixtral-8x7b "
+            # add profiler config: ensure steps >
+            # skip_first_n_steps_for_profiler + profiler_steps
+            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 "
+            "profiler_steps=3 "
             + dict_to_arg({
                 "per_device_batch_size": 12,
                 "ici_fsdp_parallelism": -1,
@@ -81,9 +90,14 @@ test_models_tpu = {
         "base_output_directory": "gs://runner-maxtext-logs",
         "train_command": [
             f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-            "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} model_name=mixtral-8x7b "
-            # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
-            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            "python3 -m maxtext.trainers.pre_train.train "
+            "src/maxtext/configs/base.yml "
+            "base_output_directory=${BASE_OUTPUT_PATH} "
+            "model_name=mixtral-8x7b "
+            # add profiler config: ensure steps >
+            # skip_first_n_steps_for_profiler + profiler_steps
+            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 "
+            "profiler_steps=3 "
             + dict_to_arg({
                 "per_device_batch_size": 12,
                 "ici_fsdp_parallelism": -1,
@@ -120,12 +134,12 @@ with models.DAG(
   )
 
   for run_name, test_scripts_details in test_models_tpu.items():
-    for image in docker_image.keys():
+    for image, img_val in docker_image.items():
       # sweep num_slices and other training params
       # generate run_name and tensorboard/profile location for extraction
       num_slices = [1]
       sweep_params = {}
-      maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+      maxtext_sweep_gke_test = sweep_config.get_maxtext_sweep_gke_config(
           test_owner=test_owner.SHUNING_J,
           dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
           composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
@@ -134,12 +148,13 @@ with models.DAG(
           time_out_in_min=test_scripts_details["time_out_in_min"],
           base_output_directory=BASE_OUTPUT_PATH,
           num_slices=num_slices,
-          docker_image=docker_image[image],
+          docker_image=img_val,
           run_name_prefix=f"maxtext_{image}_{run_name}",
           base_run_model_cmds=test_scripts_details["train_command"],
           sweep_params=sweep_params,
           enable_profile_config=True,  # add flag to enable profile extraction
+          quarantine_task_group=quarantine_task_group,
       )
 
       for test in maxtext_sweep_gke_test:
-        test.run_with_name_gen_and_quarantine(quarantine_task_group)
+        test.run()

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ on 1xv4-128.
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -37,7 +37,13 @@ with models.DAG(
   # MaxText set up and run commands
   base_output_directory = "gs://maxtext-experiments-multipod"
   base_run_model_cmds = [
-      f"python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory={base_output_directory} dataset_path=gs://max-datasets-rogue enable_checkpointing=false global_parameter_scale=16 steps=10",
+      (
+          "python3 -m maxtext.trainers.pre_train.train "
+          "src/maxtext/configs/base.yml "
+          f"base_output_directory={base_output_directory} "
+          "dataset_path=gs://max-datasets-rogue enable_checkpointing=false "
+          "global_parameter_scale=16 steps=10"
+      ),
   ]
 
   # Get list of MaxText GKE XPK jobs
@@ -57,4 +63,4 @@ with models.DAG(
 
   # Run jobs
   for test in maxtext_sweep_gke_test:
-    test.run_with_run_name_generation()
+    test.run()

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -14,13 +14,13 @@
 
 """Utilities to construct configs for maxtext DAG on GKE."""
 
-from dags.common import test_owner
+import datetime
+from typing import Any, Iterable
+
+from dags import gcs_bucket
+from dags.common.vm_resource import Project, XpkClusters
 from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
-from dags import gcs_bucket
-from dags.common.vm_resource import TpuVersion, Project, XpkClusters, GpuVersion, CpuVersion
-from typing import Iterable
-import datetime
 
 
 def get_gke_config(
@@ -31,7 +31,9 @@ def get_gke_config(
     run_model_cmds: Iterable[str],
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,
@@ -82,6 +84,140 @@ def get_gke_config(
   )
 
 
+def get_gke_config_with_interrupt(
+    time_out_in_min: int,
+    test_name: str,
+    docker_image: str,
+    test_owner: str,
+    run_model_cmds: Iterable[str],
+    expect_reach_to_step: int,
+    cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
+    num_slices: int = 1,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
+    dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    base_output_directory: str = None,
+    metric_aggregation_strategy: metric_config.AggregationStrategy = None,
+    user_specified_job_metric_config: metric_config.MetricConfig = None,
+    last_node: bool = False,
+    check_file_exists: bool = False,
+) -> task.XpkNodeInterruptionTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=cluster.project,
+      zone=cluster.zone,
+      dataset_name=dataset_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
+  )
+
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=cluster.device_version,
+          cores=cluster.core_count,
+      ),
+      test_name=test_name,
+      run_model_cmds=run_model_cmds,
+      set_up_cmds=None,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=test_owner,
+      num_slices=num_slices,
+      cluster_name=cluster.name,
+      docker_image=docker_image,
+      namespace=cluster.namespace,
+  )
+  job_metric_config = user_specified_job_metric_config
+  if job_metric_config is None:
+    job_metric_config = (
+        metric_config.MetricConfig(
+            tensorboard_summary=metric_config.SummaryConfig(
+                file_location=base_output_directory,
+                aggregation_strategy=metric_aggregation_strategy,
+                use_regex_file_location=True,
+            ),
+        )
+        if base_output_directory and metric_aggregation_strategy
+        else None
+    )
+
+  return task.XpkNodeInterruptionTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
+      expect_reach_to_step=expect_reach_to_step,
+      last_node=last_node,
+      check_file_exists=check_file_exists,
+  )
+
+
+def get_gke_config_with_name_gen_and_quarantine(
+    time_out_in_min: int,
+    test_name: str,
+    docker_image: str,
+    test_owner: str,
+    run_model_cmds: Iterable[str],
+    cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
+    num_slices: int = 1,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
+    dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    base_output_directory: str = None,
+    metric_aggregation_strategy: metric_config.AggregationStrategy = None,
+    user_specified_job_metric_config: metric_config.MetricConfig = None,
+    quarantine_task_group: Any = None,
+    run_name_env: str = "M_RUN_NAME",
+    nested_run_name_in_tb_file_location: bool = True,
+) -> task.XpkNameGenAndQuarantineTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=cluster.project,
+      zone=cluster.zone,
+      dataset_name=dataset_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
+  )
+
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=cluster.device_version,
+          cores=cluster.core_count,
+      ),
+      test_name=test_name,
+      run_model_cmds=run_model_cmds,
+      set_up_cmds=None,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=test_owner,
+      num_slices=num_slices,
+      cluster_name=cluster.name,
+      docker_image=docker_image,
+      namespace=cluster.namespace,
+  )
+  job_metric_config = user_specified_job_metric_config
+  if job_metric_config is None:
+    job_metric_config = (
+        metric_config.MetricConfig(
+            tensorboard_summary=metric_config.SummaryConfig(
+                file_location=base_output_directory,
+                aggregation_strategy=metric_aggregation_strategy,
+                use_regex_file_location=True,
+            ),
+        )
+        if base_output_directory and metric_aggregation_strategy
+        else None
+    )
+
+  return task.XpkNameGenAndQuarantineTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
+      quarantine_task_group=quarantine_task_group,
+      run_name_env=run_name_env,
+      nested_run_name_in_tb_file_location=nested_run_name_in_tb_file_location,
+  )
+
+
 def get_gke_maxtext_nightly_config(
     time_out_in_min: int,
     test_name: str,
@@ -89,7 +225,9 @@ def get_gke_maxtext_nightly_config(
     test_owner: str,
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
 ) -> task.XpkTask:
@@ -107,18 +245,25 @@ def get_gke_maxtext_nightly_config(
   base_output_directory = (
       f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
   )
-  run_name = f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}-maxtext-nightly-{current_datetime}"
+  run_name = (
+      f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}"
+      f"-maxtext-nightly-{current_datetime}"
+  )
 
   run_model_cmds = (
       "bash src/dependencies/scripts/preflight.sh PLATFORM=GKE",
       (
           "JAX_PLATFORM_NAME=TPU XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/'"
           " ENABLE_PJRT_COMPATIBILITY=true"
-          f" python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml run_name={run_name}"
-          f" base_output_directory={base_output_directory}"
+          " python3 -m maxtext.trainers.pre_train.train"
+          " src/maxtext/configs/base.yml"
+          f" run_name={run_name} base_output_directory={base_output_directory}"
           " dataset_path=gs://max-datasets-rogue dataset_type=synthetic"
-          " model_name=llama3-8b per_device_batch_size=12 reuse_example_batch=1 metrics_file='metrics.txt'"
-          " steps=50 enable_checkpointing=false profiler=xplane upload_all_profiler_results=true skip_first_n_steps_for_profiler=10 profiler_steps=10 gcs_metrics=true"
+          " model_name=llama3-8b per_device_batch_size=12 reuse_example_batch=1"
+          " metrics_file='metrics.txt' steps=50 enable_checkpointing=false"
+          " profiler=xplane upload_all_profiler_results=true"
+          " skip_first_n_steps_for_profiler=10 profiler_steps=10"
+          " gcs_metrics=true"
       ),
   )
 
@@ -189,7 +334,9 @@ def get_gke_gpt3_6b_nightly_config(
     test_owner: str,
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
 ) -> task.XpkTask:
@@ -207,18 +354,26 @@ def get_gke_gpt3_6b_nightly_config(
   base_output_directory = (
       f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
   )
-  run_name = f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}-gpt3-6b-nightly-{current_datetime}"
+  run_name = (
+      f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}"
+      f"-gpt3-6b-nightly-{current_datetime}"
+  )
 
   run_model_cmds = (
       "bash src/dependencies/scripts/preflight.sh PLATFORM=GKE",
       (
           "JAX_PLATFORM_NAME=TPU XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/'"
           " ENABLE_PJRT_COMPATIBILITY=true"
-          f" python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml run_name={run_name} model_name=gpt3-6b"
+          " python3 -m maxtext.trainers.pre_train.train"
+          " src/maxtext/configs/base.yml"
+          f" run_name={run_name} model_name=gpt3-6b"
           f" base_output_directory={base_output_directory}"
           " dataset_path=gs://max-datasets-rogue dataset_type=synthetic"
-          " per_device_batch_size=12 reuse_example_batch=1 global_parameter_scale=1 metrics_file='metrics.txt'"
-          " steps=50 enable_checkpointing=false profiler=xplane upload_all_profiler_results=true skip_first_n_steps_for_profiler=10 profiler_steps=10 gcs_metrics=true"
+          " per_device_batch_size=12 reuse_example_batch=1"
+          " global_parameter_scale=1 metrics_file='metrics.txt' steps=50"
+          " enable_checkpointing=false profiler=xplane"
+          " upload_all_profiler_results=true skip_first_n_steps_for_profiler=10"
+          " profiler_steps=10 gcs_metrics=true"
       ),
   )
 
@@ -252,7 +407,9 @@ def get_maxtext_cpu_end_to_end_gke_config(
     cluster: XpkClusterConfig = XpkClusters.CPU_N2_STANDARD_64_CLUSTER,
     machine_count: int = 1,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -59,6 +59,7 @@ def get_gke_config(
       num_slices=num_slices,
       cluster_name=cluster.name,
       docker_image=docker_image,
+      namespace=cluster.namespace,
   )
   job_metric_config = user_specified_job_metric_config
   if job_metric_config is None:

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -16,7 +16,7 @@
 
 import datetime
 from xlml.apis import gcp_config, metric_config, task, test_config
-from dags.common.vm_resource import TpuVersion, XpkClusterConfig
+from dags.common.vm_resource import XpkClusterConfig
 import itertools
 from typing import List, Iterable, Dict, Any
 
@@ -49,12 +49,17 @@ def get_maxtext_sweep_gke_config(
     docker_image: str,
     base_output_directory: str,
     base_run_model_cmds: Iterable[str],
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.BENCHMARK_DATASET,
-    metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.BENCHMARK_DATASET
+    ),
+    metric_aggregation_strategy: metric_config.AggregationStrategy = (
+        metric_config.AggregationStrategy.MEDIAN
+    ),
     dataset_project: str = None,
     composer_project: str = None,
     enable_profile_config: bool = False,
-) -> List[task.XpkTask]:
+    quarantine_task_group: Any = None,
+) -> List[task.XpkNameGenAndQuarantineTask]:
   if not dataset_project:
     dataset_project = cluster.project
   if not composer_project:
@@ -76,7 +81,8 @@ def get_maxtext_sweep_gke_config(
   for param, values in sweep_params.items():
     sweep_params_list.append([(param, val) for val in values])
 
-  # Generate all combinations of sweep param configurations and create a XpkTask for each one
+  # Generate all combinations of sweep param configurations
+  # and create a XpkTask for each one
   xpk_task_list = []
   for idx, config in enumerate(itertools.product(*sweep_params_list)):
     config_dict = {key: value for (key, value) in config}
@@ -122,10 +128,11 @@ def get_maxtext_sweep_gke_config(
           file_location=base_output_directory,
       )
 
-    xpk_task = task.XpkTask(
+    xpk_task = task.XpkNameGenAndQuarantineTask(
         task_test_config=job_test_config,
         task_gcp_config=job_gcp_config,
         task_metric_config=job_metric_config,
+        quarantine_task_group=quarantine_task_group,
     )
     xpk_task_list.append(xpk_task)
 

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -84,10 +84,11 @@ with models.DAG(
 
   sequential_tests = []
   for test_name, run_command in convergence_tests.items():
-    # The grain dataset takes longer to run, so we give it a longer timeout. The other tests are expected to complete within 5 hours.
+    # The grain dataset takes longer to run, so we give it a longer timeout.
+    # The other tests are expected to complete within 5 hours.
     timeout_in_min = 360 if test_name == "maxtext-convergence-grain" else 300
 
-    test_task = gke_config.get_gke_config(
+    test_task = gke_config.get_gke_config_with_name_gen_and_quarantine(
         cluster=XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
         time_out_in_min=timeout_in_min,
         test_name=test_name,
@@ -96,7 +97,7 @@ with models.DAG(
         test_owner=test_owner.MATT_D,
         base_output_directory=base_output_directory,
         metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
-    ).run_with_run_name_generation()
+    ).run()
     if test_name not in parallel_test_names:
       sequential_tests.append(test_task)
 

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -147,7 +147,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -173,7 +173,9 @@ with models.DAG(
             training_task = gke_config.get_gke_config(
                 time_out_in_min=60,
                 num_slices=1,
-                cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+                cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(
+                    core_count=128
+                ),
                 test_name=get_workload_name(model, mode),
                 run_model_cmds=training_cmd,
                 docker_image="{{ params.docker_image }}",
@@ -201,7 +203,7 @@ with models.DAG(
               test_name="convert-to-huggingface",
               run_model_cmds=convert_to_huggingface_cmd,
               docker_image="{{ params.docker_image }}",
-              cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+              cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
               test_owner=test_owner.SURBHI_J,
           ).run(skip_post_process=True, priority="very-high")
 

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -16,9 +16,7 @@
 A DAG to run MaxText E2E TPU Post-Training tests.
 """
 import datetime
-import hashlib
 
-from click import command
 from airflow import models
 from airflow.models.param import Param
 from airflow.utils.task_group import TaskGroup
@@ -29,11 +27,6 @@ from dags.multipod.configs import gke_config
 
 # HF token retrieved from Airflow Variables for secure credential management
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
-
-
-def get_workload_name(model, mode, length=6):
-  hex_code = f"{mode}-{hashlib.sha256(model.encode()).hexdigest()}"
-  return hex_code[:length]
 
 
 with models.DAG(
@@ -194,27 +187,27 @@ with models.DAG(
               "export ENABLE_PATHWAYS_PERSISTENCE='1'",
           ]
 
-          with TaskGroup(group_id=f"train-{mode}-{model}") as model_group:
-            command = mode_test_config["command"]
-            training_cmd = (
-                " && ".join(
-                    environment_variables + [f"{command} {run_name} true"]
-                ),
-            )
-            training_task = gke_config.get_gke_config(
-                time_out_in_min=60,
-                num_slices=1,
-                cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(
-                    core_count=128
-                ),
-                test_name=get_workload_name(model, mode),
-                run_model_cmds=training_cmd,
-                docker_image="{{ params.docker_image }}",
-                test_owner=test_owner.SURBHI_J,
-            ).run_model(
-                use_pathways=True,
-                priority="very-high",
-            )
+          command = mode_test_config["command"]
+          training_cmd = (
+              " && ".join(
+                  environment_variables + [f"{command} {run_name} true"]
+              ),
+          )
+          training_task = gke_config.get_gke_config(
+              time_out_in_min=60,
+              num_slices=1,
+              cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(
+                  core_count=128
+              ),
+              test_name=f"train-{mode}-{model}",
+              run_model_cmds=training_cmd,
+              docker_image="{{ params.docker_image }}",
+              test_owner=test_owner.SURBHI_J,
+          ).run(
+              use_pathways=True,
+              skip_post_process=True,
+              priority="very-high",
+          )
 
           to_hf_flags = mode_test_config.get("to_hf_flags", "false true")
 

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -126,7 +126,38 @@ with models.DAG(
               },
               "rl": {
                   "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3_rl.sh",
-                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/rl/{run_name}/checkpoints/actor/4/items",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/rl/{run_name}/checkpoints/actor/5/model_params",
+              },
+          },
+      },
+      "qwen3-vl-2b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_to_hf.sh",
+          },
+          "post_training": {
+              "multimodal_sft": {
+                  "command": "bash tests/end_to_end/tpu/qwen3/vl_2b/test_qwen3_multimodal_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-vl-2b/multimodal/sft/{run_name}/checkpoints/4/items",
+                  "to_hf_flags": "true false",
+              },
+          },
+      },
+      "gpt-oss-20b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/sft/{run_name}/checkpoints/5/model_params",
+                  "to_hf_flags": "true",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/rl/{run_name}/checkpoints/actor/5/model_params",
+                  "to_hf_flags": "true",
               },
           },
       },
@@ -199,7 +230,7 @@ with models.DAG(
               f"{run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(
-              time_out_in_min=60,
+              time_out_in_min=90,
               test_name="convert-to-huggingface",
               run_model_cmds=convert_to_huggingface_cmd,
               docker_image="{{ params.docker_image }}",

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -84,6 +84,18 @@ with models.DAG(
               "command": "bash tests/end_to_end/tpu/qwen3/30b/test_qwen3.sh",
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/qwen3-30b-a3b-base/train/{run_name}/checkpoints/4/items",
           },
+          "to_hf_flags": "false true",
+      },
+      "gpt-oss-20b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/gpt_oss/20b/test_gpt_oss.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/gpt-oss-20b/train/{run_name}/checkpoints/4/items",
+          },
+          "to_hf_flags": "true",
       },
   }
   # pylint: enable=line-too-long
@@ -121,16 +133,18 @@ with models.DAG(
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
       )
+      to_hf_flags = test_config.get("to_hf_flags", "")
+
       convert_to_huggingface_cmd = (
           f"export HF_TOKEN={HF_TOKEN}",
           'export HF_HOME="/dev/shm/hf_cache"',
           'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
       ) + (
           f"{test_config['checkpoint_conversion']['to_huggingface']} "
-          f"{run_name} {model_path}",
+          f"{run_name} {model_path} {to_hf_flags}",
       )
       convert_to_huggingface_task = gke_config.get_gke_config(
-          time_out_in_min=60,
+          time_out_in_min=90,
           test_name="convert-to-huggingface",
           run_model_cmds=convert_to_huggingface_cmd,
           docker_image="{{ params.docker_image }}",

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -102,7 +102,7 @@ with models.DAG(
           test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -114,7 +114,7 @@ with models.DAG(
           test_name="training",
           run_model_cmds=training_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER.override(core_count=128),
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 
@@ -134,7 +134,7 @@ with models.DAG(
           test_name="convert-to-huggingface",
           run_model_cmds=convert_to_huggingface_cmd,
           docker_image="{{ params.docker_image }}",
-          cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,
+          cluster=XpkClusters.TPU_V5P_MLPERF_CLUSTER,
           test_owner=test_owner.SURBHI_J,
       ).run(skip_post_process=True, priority="very-high")
 

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -120,7 +120,7 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
             num_slices=slice_num,
             cluster=test_config.cluster,
             time_out_in_min=60,
@@ -128,12 +128,12 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run_with_node_interruption(
+            expect_reach_to_step=step_to_interrupt,
+            last_node=True,
+        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
             skip_post_process=True,
-            last_node=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
         )
 

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -118,7 +118,7 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
             num_slices=slice_num,
             cluster=test_config.cluster,
             time_out_in_min=60,
@@ -126,11 +126,11 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run_with_node_interruption(
+            expect_reach_to_step=step_to_interrupt,
+        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
             skip_post_process=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
         )
 

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -121,7 +121,7 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
             num_slices=slice_num,
             cluster=test_config.cluster,
             time_out_in_min=60,
@@ -129,11 +129,11 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run_with_node_interruption(
+            expect_reach_to_step=step_to_interrupt,
+        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
             skip_post_process=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
         )
 

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -130,7 +130,7 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
             num_slices=slice_num,
             cluster=test_config.cluster,
             time_out_in_min=60,
@@ -138,13 +138,13 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.SHARON_Y,
-        ).run_with_node_interruption(
+            expect_reach_to_step=step_to_interrupt,
+            check_file_exists=True,
+        ).run(
             gcs_location=gcs_location,
             xpk_branch=MAIN_BRANCH,
             skip_post_process=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
-            check_file_exists=True,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxtext_moe_tpu_e2e.py
@@ -65,6 +65,12 @@ with models.DAG(
 
   # Unchained tests
   test_models_tpu = {
+      "deepseek4-284b": {
+          "script_name": "tpu/deepseek/v4-284b/2_test_deepseek",
+          "cluster": XpkClusters.TPU_V5P_128_CLUSTER,
+          "time_out_in_min": 180,
+          "owner": test_owner.SNEHAL_V,
+      },
       "deepseek32-671b": {
           "script_name": "tpu/deepseek/v3.2-671b/2_test_deepseek",
           "cluster": XpkClusters.TPU_V5P_128_CLUSTER,

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -226,15 +226,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info,
             jobset_config=jobset_config,
             jobset_name=jobset_name,
-        ).as_teardown(
-            setups=startup.jobset_start_time
         )
 
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
         chain(
             cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -21,17 +21,13 @@ from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.utils.task_group import TaskGroup
-from dags.common.task_group_with_timeout import TaskGroupWithTimeout
-
-
-from airflow.decorators import task
 
 from dags import composer_env
 from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     GCS_JOBSET_CONFIG_PATH,

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -158,7 +158,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
       with TaskGroupWithTimeout(
           group_id="test",
@@ -218,7 +218,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_workload = jobset.end_workload.override(
             task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -203,15 +203,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
           jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
           task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      )(node_pool=cluster_info)
 
       chain(
           selector,

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -31,6 +31,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
@@ -50,9 +51,13 @@ DAG_ID = "jobset_ttr_kill_process"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=20)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
+
 
 @task
-def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
+def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> TimeUtil:
   """
   Kills the python process on a list of pods.
 
@@ -60,8 +65,8 @@ def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
   python process inside each specified pod. It ignores errors if the pod
   has already been deleted to ensure pipeline continuity.
   """
-  target_pod = random.choice(running_pods)
 
+  operation_start_time = TimeUtil.now()
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
@@ -163,70 +168,75 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        ).as_setup()
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
+        chain(create_node_pool, *startup.tasks)
 
-      kill_tasks = kill_tpu_pod_workload.override(
-          task_id="kill_tpu_pod_workload"
-      )(
-          info=cluster_info,
-          pod_names=startup.running_pods,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        kill_tasks = kill_tpu_pod_workloads.override(
+            task_id="kill_tpu_pod_workloads"
+        )(
+            info=cluster_info,
+            pod_names=startup.running_pods,
+        )
 
-      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
-          task_id="wait_for_recovery"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+        wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+            task_id="wait_for_recovery"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      verify_duration = jobset.verify_recovery_duration.override(
-          task_id="verify_recovery_duration"
-      )(
-          start_time=kill_tasks,
-          end_time=wait_for_recovery,
-      )
+        verify_duration = jobset.verify_recovery_duration.override(
+            task_id="verify_recovery_duration"
+        )(
+            start_time=kill_tasks,
+            end_time=wait_for_recovery,
+        )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found",
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          start_time=kill_tasks,
-      )
+        wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+            task_id="wait_for_jobset_ttr_to_be_found",
+        )(
+            node_pool=cluster_info,
+            jobset_name=jobset_name,
+            start_time=kill_tasks,
+        )
+        chain(kill_tasks, wait_for_recovery, verify_duration, wait_for_metric_upload)
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          as_teardown_of=create_node_pool,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info)
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info)
+        chain(cleanup_workload, cleanup_node_pool)
 
-      chain(
-          selector,
-          jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          kill_tasks,
-          wait_for_recovery,
-          verify_duration,
-          wait_for_metric_upload,
-          cleanup_workload,
-          cleanup_node_pool,
-      )
+      chain(pre_test, test, post_test)

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -25,6 +25,7 @@ import tempfile
 
 from airflow import models
 from airflow.decorators import task
+from airflow.exceptions import AirflowFailException
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
@@ -65,6 +66,7 @@ def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
 
+    failed_pods = []
     for pod_name in pod_names:
       cmd = " && ".join([
           jobset.Command.get_credentials_command(info),
@@ -73,10 +75,20 @@ def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
 
       try:
         subprocess.run_exec(cmd, env=env)
+        logging.info("Execution succeeded for pod: %s", pod_name)
       except subprocess.ProcessKilledException:
         logging.info(f"Process in pod {pod_name} was terminated with SIGKILL")
+        logging.info("Execution succeeded for pod: %s", pod_name)
       except Exception as e:
-        raise e
+        logging.error("Execution failed for pod: %s. Error: %s", pod_name, e)
+        failed_pods.append((pod_name, e))
+
+    if failed_pods:
+      failed_pod_names = [name for name, _ in failed_pods]
+      logging.error("The following pods failed execution: %s", failed_pod_names)
+      raise AirflowFailException(
+          f"Task failed because execution failed on pods: {failed_pod_names}"
+      )
 
   return operation_start_time
 

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -78,7 +78,7 @@ def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
         logging.info("Execution succeeded for pod: %s", pod_name)
       except subprocess.ProcessKilledException:
         logging.info(f"Process in pod {pod_name} was terminated with SIGKILL")
-        logging.info("Execution succeeded for pod: %s", pod_name)
+        logging.info("Execution failed for pod: %s", pod_name)
       except Exception as e:
         logging.error("Execution failed for pod: %s. Error: %s", pod_name, e)
         failed_pods.append((pod_name, e))

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -51,12 +51,12 @@ SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 
 @task
-def kill_tpu_pod_workload(info: node_pool.Info, running_pods: list) -> None:
+def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> None:
   """
-  Kills the python process on a single pod.
+  Kills the python process on a list of pods.
 
   This task retrieves cluster credentials, then attempts to kill the JAX
-  python process inside the specified pod. It ignores errors if the pod
+  python process inside each specified pod. It ignores errors if the pod
   has already been deleted to ensure pipeline continuity.
   """
   target_pod = random.choice(running_pods)
@@ -65,21 +65,18 @@ def kill_tpu_pod_workload(info: node_pool.Info, running_pods: list) -> None:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
 
-    cmd = " && ".join([
-        jobset.Command.get_credentials_command(info),
-        f"kubectl exec {target_pod} -n default -- pkill -9 -f python",
-    ])
+    for pod_name in pod_names:
+      cmd = " && ".join([
+          jobset.Command.get_credentials_command(info),
+          f"kubectl exec {pod_name} -n default -- pkill -9 -f python",
+      ])
 
-    operation_start_time = TimeUtil.from_datetime(
-        datetime.datetime.now(datetime.timezone.utc)
-    )
-
-    try:
-      subprocess.run_exec(cmd, env=env)
-    except subprocess.ProcessKilledException:
-      logging.info("Process was terminated with SIGKILL")
-    except Exception as e:
-      raise e
+      try:
+        subprocess.run_exec(cmd, env=env)
+      except subprocess.ProcessKilledException:
+        logging.info(f"Process in pod {pod_name} was terminated with SIGKILL")
+      except Exception as e:
+        raise e
 
   return operation_start_time
 
@@ -171,7 +168,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="kill_tpu_pod_workload"
       )(
           info=cluster_info,
-          running_pods=startup.running_pods,
+          pod_names=startup.running_pods,
       )
 
       wait_for_recovery = jobset.wait_for_jobset_recovered.override(

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -57,7 +57,9 @@ TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 
 @task
-def kill_tpu_pod_workloads(info: node_pool.Info, pod_names: list[str]) -> TimeUtil:
+def kill_tpu_pod_workloads(
+    info: node_pool.Info, pod_names: list[str]
+) -> TimeUtil:
   """
   Kills the python process on a list of pods.
 
@@ -172,7 +174,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           group_id="pre_test",
           timeout=PRE_TEST_TIMEOUT,
       ) as pre_test:
-        create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
             node_pool=cluster_info,
             node_pool_selector=selector,
         ).as_setup()
@@ -212,14 +216,21 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             end_time=wait_for_recovery,
         )
 
-        wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-            task_id="wait_for_jobset_ttr_to_be_found",
-        )(
-            node_pool=cluster_info,
-            jobset_name=jobset_name,
-            start_time=kill_tasks,
+        wait_for_metric_upload = (
+            jobset.wait_for_jobset_ttr_to_be_found.override(
+                task_id="wait_for_jobset_ttr_to_be_found",
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+                start_time=kill_tasks,
+            )
         )
-        chain(kill_tasks, wait_for_recovery, verify_duration, wait_for_metric_upload)
+        chain(
+            kill_tasks,
+            wait_for_recovery,
+            verify_duration,
+            wait_for_metric_upload,
+        )
 
       with TaskGroupWithTimeout(
           group_id="post_test",

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -190,15 +190,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info,
             jobset_config=jobset_config,
             jobset_name=jobset_name,
-        ).as_teardown(
-            setups=startup.jobset_start_time
         )
 
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
         chain(
             cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -123,7 +123,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
       with TaskGroupWithTimeout(
           group_id="test",
@@ -182,7 +182,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_workload = jobset.end_workload.override(
             task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -166,15 +166,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
           jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
           task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      )(node_pool=cluster_info)
 
       chain(
           selector,

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -119,7 +119,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           group_id="pre_test",
           timeout=PRE_TEST_TIMEOUT,
       ) as pre_test:
-        create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
             node_pool=cluster_info,
             node_pool_selector=selector,
         ).as_setup()
@@ -165,14 +167,22 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             end_time=wait_for_recovery,
         )
 
-        wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-            task_id="wait_for_jobset_ttr_to_be_found",
-        )(
-            node_pool=cluster_info,
-            jobset_name=jobset_name,
-            start_time=reboot_node,
+        wait_for_metric_upload = (
+            jobset.wait_for_jobset_ttr_to_be_found.override(
+                task_id="wait_for_jobset_ttr_to_be_found",
+            )(
+                node_pool=cluster_info,
+                jobset_name=jobset_name,
+                start_time=reboot_node,
+            )
         )
-        chain(target_pod, reboot_node, wait_for_recovery, verify_duration, wait_for_metric_upload)
+        chain(
+            target_pod,
+            reboot_node,
+            wait_for_recovery,
+            verify_duration,
+            wait_for_metric_upload,
+        )
 
       with TaskGroupWithTimeout(
           group_id="post_test",

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -41,6 +41,10 @@ DAG_ID = "jobset_ttr_node_reboot"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
+
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
 with models.DAG(  # pylint: disable=unexpected-keyword-arg
@@ -111,77 +115,81 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        ).as_setup()
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
+        chain(create_node_pool, *startup.tasks)
 
-      target_pod = jobset.draw_random_pod(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        target_pod = jobset.draw_random_pod(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      reboot_node = jobset.operate_pod.override(task_id="reboot_node")(
-          node_pool=cluster_info,
-          operation=jobset.PodOperationSpec.reboot(),
-          pod_name=target_pod,
-          namespace="default",
-      )
+        reboot_node = jobset.operate_pod.override(task_id="reboot_node")(
+            node_pool=cluster_info,
+            operation=jobset.PodOperationSpec.reboot(),
+            pod_name=target_pod,
+            namespace="default",
+        )
 
-      wait_for_recovery = jobset.wait_for_jobset_recovered.override(
-          task_id="wait_for_recovery"
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+        wait_for_recovery = jobset.wait_for_jobset_recovered.override(
+            task_id="wait_for_recovery"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      verify_duration = jobset.verify_recovery_duration.override(
-          task_id="verify_recovery_duration"
-      )(
-          start_time=reboot_node,
-          end_time=wait_for_recovery,
-      )
+        verify_duration = jobset.verify_recovery_duration.override(
+            task_id="verify_recovery_duration"
+        )(
+            start_time=reboot_node,
+            end_time=wait_for_recovery,
+        )
 
-      wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
-          task_id="wait_for_jobset_ttr_to_be_found",
-      )(
-          node_pool=cluster_info,
-          jobset_name=jobset_name,
-          start_time=reboot_node,
-      )
+        wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
+            task_id="wait_for_jobset_ttr_to_be_found",
+        )(
+            node_pool=cluster_info,
+            jobset_name=jobset_name,
+            start_time=reboot_node,
+        )
+        chain(target_pod, reboot_node, wait_for_recovery, verify_duration, wait_for_metric_upload)
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          as_teardown_of=create_node_pool,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info)
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info)
+        chain(cleanup_workload, cleanup_node_pool)
 
-      chain(
-          selector,
-          jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          target_pod,
-          reboot_node,
-          wait_for_recovery,
-          verify_duration,
-          wait_for_metric_upload,
-          cleanup_workload,
-          cleanup_node_pool,
-      )
+      chain(pre_test, test, post_test)

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 
 from airflow import models
 from airflow.models.baseoperator import chain
+from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
@@ -94,9 +95,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
-    with TaskGroupWithTimeout(  # pylint: disable=unexpected-keyword-arg
-        group_id=f"v{config.tpu_version.value}",
-        timeout=timedelta(minutes=90),
+    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}"
     ):
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -192,15 +192,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info,
             jobset_config=jobset_config,
             jobset_name=jobset_name,
-        ).as_teardown(
-            setups=startup.jobset_start_time
         )
 
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
         chain(
             cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -26,6 +26,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     GCS_JOBSET_CONFIG_PATH,
@@ -34,14 +35,6 @@ from dags.tpu_observability.configs.common import (
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
-from dags.tpu_observability.configs.common import (
-    MachineConfigMap,
-    GCS_CONFIG_PATH,
-    GCS_JOBSET_CONFIG_PATH,
-)
-from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
-from dags.common.task_group_with_timeout import TaskGroupWithTimeout
-
 
 DAG_ID = "jobset_ttr_pod_delete"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -126,7 +126,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
       with TaskGroupWithTimeout(
           group_id="test",
@@ -184,7 +184,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_workload = jobset.end_workload.override(
             task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -154,11 +154,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             jobset_name=jobset_name,
         )
 
-        intentional_failure = BashOperator(
-            task_id="intentional_failure",
-            bash_command="exit 1"
-        )
-
         verify_duration = jobset.verify_recovery_duration.override(
             task_id="verify_recovery_duration"
         )(
@@ -181,7 +176,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             *startup.tasks,
             rollback_node_pool,
             wait_for_recovery,
-            intentional_failure,
             verify_duration,
             wait_for_metric_upload,
         )

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -20,6 +20,7 @@ from airflow import models
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.operators.bash import BashOperator
 
 from dags import composer_env
 from dags.common.scheduling_helper.scheduling_helper import (
@@ -153,6 +154,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             jobset_name=jobset_name,
         )
 
+        intentional_failure = BashOperator(
+            task_id="intentional_failure",
+            bash_command="exit 1"
+        )
+
         verify_duration = jobset.verify_recovery_duration.override(
             task_id="verify_recovery_duration"
         )(
@@ -170,10 +176,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             )
         )
 
+
         chain(
             *startup.tasks,
             rollback_node_pool,
             wait_for_recovery,
+            intentional_failure,
             verify_duration,
             wait_for_metric_upload,
         )
@@ -189,15 +197,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info,
             jobset_config=jobset_config,
             jobset_name=jobset_name,
-        ).as_teardown(
-            setups=startup.jobset_start_time
         )
 
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
         chain(
             cleanup_workload,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -171,7 +171,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             )
         )
 
-
         chain(
             *startup.tasks,
             rollback_node_pool,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -20,13 +20,13 @@ from airflow import models
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.operators.bash import BashOperator
 
 from dags import composer_env
 from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     GCS_JOBSET_CONFIG_PATH,
@@ -35,14 +35,6 @@ from dags.tpu_observability.configs.common import (
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
-from dags.tpu_observability.configs.common import (
-    MachineConfigMap,
-    GCS_CONFIG_PATH,
-    GCS_JOBSET_CONFIG_PATH,
-)
-from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
-from dags.common.task_group_with_timeout import TaskGroupWithTimeout
-
 
 DAG_ID = "jobset_rollback_ttr"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -128,7 +128,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
       with TaskGroupWithTimeout(
           group_id="test",
@@ -182,7 +182,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_workload = jobset.end_workload.override(
             task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -163,8 +163,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             node_pool=cluster_info,
             jobset_config=jobset_config,
             jobset_name=jobset_name,
-        ).as_teardown(
-            setups=startup.jobset_start_time
         )
 
         jobset_clear_time = get_current_time.override(
@@ -198,9 +196,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       ) as post_test:
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
       chain(
           selector,

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -27,6 +27,7 @@ from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
 )
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.tpu_observability.configs.common import (
     GCS_CONFIG_PATH,
     GCS_JOBSET_CONFIG_PATH,
@@ -36,9 +37,6 @@ from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.utils.time_util import TimeUtil
-from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
-from dags.common.task_group_with_timeout import TaskGroupWithTimeout
-
 
 DAG_ID = "jobset_uptime_validation"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -133,7 +133,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
       with TaskGroupWithTimeout(
           group_id="test",
@@ -192,7 +192,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
+++ b/dags/tpu_observability/multi_host_nodepool_rollback_dag.py
@@ -112,7 +112,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         create_node_pool = node_pool.create.override(
             task_id="create_node_pool",
             owner=test_owner.QUINN_M,
-        )(node_pool=node_pool_info)
+        )(node_pool=node_pool_info).as_setup()
 
         wait_node_pool_available = node_pool.wait_for_availability.override(
             task_id="wait_node_pool_available"
@@ -148,7 +148,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool",

--- a/dags/tpu_observability/node_pool_status.py
+++ b/dags/tpu_observability/node_pool_status.py
@@ -115,7 +115,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             owner=test_owner.YUNA_T,
         )(
             node_pool=node_pool_info,
-        )
+        ).as_setup()
 
         # Intentionally create a node pool with problematic configurations
         # to validate that it enters the ERROR state.
@@ -204,7 +204,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         task_id = "cleanup_node_pool"
         cleanup_node_pool = node_pool.delete.override(

--- a/dags/tpu_observability/node_pool_ttr_disk_size.py
+++ b/dags/tpu_observability/node_pool_ttr_disk_size.py
@@ -100,7 +100,7 @@ with models.DAG(
       ) as pre_test:
         create_node_pool = node_pool.create.override(
             task_id="create_node_pool"
-        )(node_pool=node_pool_info)
+        )(node_pool=node_pool_info).as_setup()
 
         wait_for_provisioning = node_pool.wait_for_status.override(
             task_id="wait_for_provisioning"
@@ -138,7 +138,7 @@ with models.DAG(
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/node_pool_ttr_update_label.py
+++ b/dags/tpu_observability/node_pool_ttr_update_label.py
@@ -99,7 +99,7 @@ with models.DAG(
         task_id = "create_node_pool"
         create_node_pool = node_pool.create.override(task_id=task_id)(
             node_pool=node_pool_info,
-        )
+        ).as_setup()
 
         task_id = "wait_for_provisioning"
         wait_for_provisioning = node_pool.wait_for_status.override(
@@ -139,7 +139,7 @@ with models.DAG(
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         task_id = "cleanup_node_pool"
         cleanup_node_pool = node_pool.delete.override(

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -455,8 +455,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           node_pool=cluster_info,
           jobset_config=jobset_config,
           jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
       )
 
       # Keyword arguments are generated dynamically at runtime (pylint does not
@@ -468,17 +466,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             task_id="cleanup_node_pool_1",
             trigger_rule=TriggerRule.ALL_DONE,
             retries=2,
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
         cleanup_second_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_2",
             trigger_rule=TriggerRule.ALL_DONE,
             retries=2,
-        )(node_pool=cluster_info_2).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info_2)
 
       chain(
           verify_table_amount_task,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -92,32 +92,43 @@ def validate_tpu_info_format(
   from dags.tpu_observability.utils.tpu_info_util import parse_tpu_info_output
   import logging
 
+  failed_pods = []
   for pod_name in pod_names:
     logging.info(
         "Executing tpu-info and performing format validation for pod: %s",
         pod_name,
     )
 
-    # 1. Get tpu-info output from pod
-    with tempfile.NamedTemporaryFile() as temp_config_file:
-      env = os.environ.copy()
-      env["KUBECONFIG"] = temp_config_file.name
+    try:
+      with tempfile.NamedTemporaryFile() as temp_config_file:
+        env = os.environ.copy()
+        env["KUBECONFIG"] = temp_config_file.name
 
-      cmd = " && ".join([
-          jobset.Command.get_credentials_command(info),
-          f"kubectl exec {pod_name} -n default -- tpu-info",
-      ])
+        cmd = " && ".join([
+            jobset.Command.get_credentials_command(info),
+            f"kubectl exec {pod_name} -n default -- tpu-info",
+        ])
 
-      raw_output = subprocess.run_exec(cmd, env=env)
+        raw_output = subprocess.run_exec(cmd, env=env)
 
-    # Parse tpu-info output
-    tpu_info_output = parse_tpu_info_output(raw_output)
+      tpu_info_output = parse_tpu_info_output(raw_output)
 
-    verify_table_amount(tpu_info_output)
-    validate_chips_table(tpu_info_output, tpu_config)
-    validate_runtime_table(tpu_info_output)
-    validate_tensorcore_table(tpu_info_output)
-    validate_latency_table(tpu_info_output)
+      verify_table_amount(tpu_info_output)
+      validate_chips_table(tpu_info_output, tpu_config)
+      validate_runtime_table(tpu_info_output)
+      validate_tensorcore_table(tpu_info_output)
+      validate_latency_table(tpu_info_output)
+      logging.info("Validation succeeded for pod: %s", pod_name)
+    except Exception as e:
+      logging.error("Validation failed for pod: %s. Error: %s", pod_name, e)
+      failed_pods.append((pod_name, e))
+
+  if failed_pods:
+    failed_pod_names = [name for name, _ in failed_pods]
+    logging.error("The following pods failed validation: %s", failed_pod_names)
+    raise AirflowFailException(
+        f"Task failed because validation failed on pods: {failed_pod_names}"
+    )
 
 
 def verify_table_amount(tpu_info_output: list[tpu_info.Table]):

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -486,7 +486,9 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             retries=2,
         )(node_pool=cluster_info_2)
 
-        chain(clean_up_workload, cleanup_first_node_pool, cleanup_second_node_pool)
+        chain(
+            clean_up_workload, cleanup_first_node_pool, cleanup_second_node_pool
+        )
 
       chain(
           selector,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -483,7 +483,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           selector,
           jobset_name,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           validate_format,
           clean_up_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -23,6 +23,7 @@ import datetime
 import os
 import re
 import tempfile
+import logging
 
 from airflow import models
 from airflow.decorators import task
@@ -47,7 +48,9 @@ from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
 from dags.tpu_observability.utils import subprocess_util as subprocess
 from dags.tpu_observability.utils import tpu_info_util as tpu_info
+from dags.tpu_observability.utils.tpu_info_util import parse_tpu_info_output
 from dags.tpu_observability.utils.jobset_util import Workload
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
 DAG_ID = "tpu_info_format_validation_dag"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
@@ -89,8 +92,6 @@ def validate_tpu_info_format(
     pod_names: list[str],
 ) -> None:
   """Executes tpu-info command and runs all validations sequentially across all pods."""
-  from dags.tpu_observability.utils.tpu_info_util import parse_tpu_info_output
-  import logging
 
   failed_pods = []
   for pod_name in pod_names:

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -83,6 +83,43 @@ def get_tpu_info_from_pod(info: node_pool.Info, pod_name: str) -> str:
 
 
 @task
+def validate_tpu_info_format(
+    info: node_pool.Info,
+    tpu_config: TpuConfig,
+    pod_names: list[str],
+) -> None:
+  """Executes tpu-info command and runs all validations sequentially across all pods."""
+  from dags.tpu_observability.utils.tpu_info_util import parse_tpu_info_output
+  import logging
+
+  for pod_name in pod_names:
+    logging.info(
+        "Executing tpu-info and performing format validation for pod: %s",
+        pod_name,
+    )
+
+    # 1. Get tpu-info output from pod
+    with tempfile.NamedTemporaryFile() as temp_config_file:
+      env = os.environ.copy()
+      env["KUBECONFIG"] = temp_config_file.name
+
+      cmd = " && ".join([
+          jobset.Command.get_credentials_command(info),
+          f"kubectl exec {pod_name} -n default -- tpu-info",
+      ])
+
+      raw_output = subprocess.run_exec(cmd, env=env)
+
+    # Parse tpu-info output
+    tpu_info_output = parse_tpu_info_output(raw_output)
+
+    verify_table_amount(tpu_info_output)
+    validate_chips_table(tpu_info_output, tpu_config)
+    validate_runtime_table(tpu_info_output)
+    validate_tensorcore_table(tpu_info_output)
+    validate_latency_table(tpu_info_output)
+
+
 def verify_table_amount(tpu_info_output: list[tpu_info.Table]):
   """
   Verifies if all expected tables are present.
@@ -105,7 +142,6 @@ def verify_table_amount(tpu_info_output: list[tpu_info.Table]):
     )
 
 
-@task
 def validate_chips_table(
     tpu_info_output: list[tpu_info.Table],
     tpu_config: TpuConfig,
@@ -158,7 +194,6 @@ def validate_chips_table(
     )
 
 
-@task
 def validate_runtime_table(tpu_info_output: list[tpu_info.Table]):
   """
   Validates the row count and content of table 'TPU Runtime Utilization'
@@ -213,7 +248,6 @@ def validate_runtime_table(tpu_info_output: list[tpu_info.Table]):
     )
 
 
-@task
 def validate_tensorcore_table(tpu_info_output: list[tpu_info.Table]):
   """
   Validates the row count and content of table 'TensorCore Utilization'
@@ -253,7 +287,6 @@ def validate_tensorcore_table(tpu_info_output: list[tpu_info.Table]):
     )
 
 
-@task
 def validate_latency_table(tpu_info_output: list[tpu_info.Table]):
   """
   Validates the row count and content of table 'TPU Buffer Transfer Latency'
@@ -398,56 +431,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      outputs_of_tpu_info = (
-          get_tpu_info_from_pod.override(task_id="get_tpu_info")
-          .partial(info=cluster_info)
-          .expand(pod_name=startup.running_pods)
+      validate_format = validate_tpu_info_format.override(
+          task_id="validate_tpu_info_format"
+      )(
+          info=cluster_info,
+          tpu_config=config,
+          pod_names=startup.running_pods,
       )
-
-      output_of_tpu_info = (
-          tpu_info.parse_tpu_info_output.override(
-              task_id="get_each_metric_table"
-          )
-          .partial()
-          .expand(output=outputs_of_tpu_info)
-      )
-
-      # Keyword arguments are generated dynamically at runtime (pylint does not
-      # know this signature).
-      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-          group_id="verification_group"
-      ) as verification_group:
-        verify_table_amount_task = (
-            verify_table_amount.override(task_id="verify_table_amount_task")
-            .partial()
-            .expand(tpu_info_output=output_of_tpu_info)
-        )
-
-        validate_tpu_chips_metric = (
-            validate_chips_table.override(task_id="validate_tpu_chips_metric")
-            .partial(tpu_config=config)
-            .expand(tpu_info_output=output_of_tpu_info)
-        )
-
-        validate_runtime_metric = (
-            validate_runtime_table.override(task_id="validate_runtime_metric")
-            .partial()
-            .expand(tpu_info_output=output_of_tpu_info)
-        )
-
-        validate_tensorcore_metric = (
-            validate_tensorcore_table.override(
-                task_id="validate_tensorcore_metric"
-            )
-            .partial()
-            .expand(tpu_info_output=output_of_tpu_info)
-        )
-
-        validate_latency_metric = (
-            validate_latency_table.override(task_id="validate_latency_metric")
-            .partial()
-            .expand(tpu_info_output=output_of_tpu_info)
-        )
 
       clean_up_workload = jobset.end_workload.override(
           task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
@@ -474,16 +464,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             retries=2,
         )(node_pool=cluster_info_2)
 
-      chain(
-          verify_table_amount_task,
-          [
-              validate_tpu_chips_metric,
-              validate_runtime_metric,
-              validate_tensorcore_metric,
-              validate_latency_metric,
-          ],
-      )
-
       chain(create_first_node_pool, create_second_node_pool)
 
       chain(cleanup_first_node_pool, cleanup_second_node_pool)
@@ -492,10 +472,8 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           selector,
           jobset_name,
           create_node_pool,
-          *startup.tasks,
-          outputs_of_tpu_info,
-          output_of_tpu_info,
-          verification_group,
+          startup.task_group,
+          validate_format,
           clean_up_workload,
           cleanup_node_pool,
       )

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -30,6 +30,7 @@ from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
@@ -54,6 +55,10 @@ from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, ge
 
 DAG_ID = "tpu_info_format_validation_dag"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=20)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 
@@ -414,18 +419,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       cluster_info_2 = copy.deepcopy(cluster_info)
       cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"
 
-      # Keyword arguments are generated dynamically at runtime (pylint does not
-      # know this signature).
-      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-          group_id="create_node_pool"
-      ) as create_node_pool:
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
         create_first_node_pool = node_pool.create.override(
             task_id="node_pool_1",
             retries=2,
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
         create_second_node_pool = node_pool.create.override(
             task_id="node_pool_2",
@@ -433,37 +437,43 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         )(
             node_pool=cluster_info_2,
             node_pool_selector=selector,
+        ).as_setup()
+
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
         )
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+        chain([create_first_node_pool, create_second_node_pool], *startup.tasks)
 
-      validate_format = validate_tpu_info_format.override(
-          task_id="validate_tpu_info_format"
-      )(
-          info=cluster_info,
-          tpu_config=config,
-          pod_names=startup.running_pods,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        validate_format = validate_tpu_info_format.override(
+            task_id="validate_tpu_info_format"
+        )(
+            info=cluster_info,
+            tpu_config=config,
+            pod_names=startup.running_pods,
+        )
 
-      clean_up_workload = jobset.end_workload.override(
-          task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          as_teardown_of=create_first_node_pool,
+      ) as post_test:
+        clean_up_workload = jobset.end_workload.override(
+            task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      # Keyword arguments are generated dynamically at runtime (pylint does not
-      # know this signature).
-      with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-          group_id="cleanup_node_pool"
-      ) as cleanup_node_pool:
         cleanup_first_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_1",
             trigger_rule=TriggerRule.ALL_DONE,
@@ -476,16 +486,12 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             retries=2,
         )(node_pool=cluster_info_2)
 
-      chain(create_first_node_pool, create_second_node_pool)
-
-      chain(cleanup_first_node_pool, cleanup_second_node_pool)
+        chain(clean_up_workload, cleanup_first_node_pool, cleanup_second_node_pool)
 
       chain(
           selector,
           jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          validate_format,
-          clean_up_workload,
-          cleanup_node_pool,
+          pre_test,
+          test,
+          post_test,
       )

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -386,24 +386,18 @@ with models.DAG(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
       )
 
       with TaskGroup(group_id="cleanup_node_pool") as cleanup_node_pool:
         cleanup_first_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_1",
             trigger_rule=TriggerRule.ALL_DONE,
-        )(node_pool=cluster_info).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info)
 
         cleanup_second_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_2",
             trigger_rule=TriggerRule.ALL_DONE,
-        )(node_pool=cluster_info_2).as_teardown(
-            setups=create_node_pool,
-        )
+        )(node_pool=cluster_info_2)
 
         chain(cleanup_first_node_pool, cleanup_second_node_pool)
 

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -413,6 +413,8 @@ with models.DAG(
             trigger_rule=TriggerRule.ALL_DONE,
         )(node_pool=cluster_info_2)
 
-        chain(clean_up_workload, cleanup_first_node_pool, cleanup_second_node_pool)
+        chain(
+            clean_up_workload, cleanup_first_node_pool, cleanup_second_node_pool
+        )
 
       chain(pre_test, test, post_test)

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -176,7 +176,9 @@ def verify_metric_for_all_pods(
           end_time=end_time,
       )
 
-      monitoring_values = metric_strategy.parse_from_monitoring(time_series_data)
+      monitoring_values = metric_strategy.parse_from_monitoring(
+          time_series_data
+      )
       cmd_values = metric_strategy.parse_from_tpu_info(tpu_info_output)
 
       tolerance_for_metric = metric_strategy.tolerance_percent
@@ -400,7 +402,7 @@ with models.DAG(
           selector,
           jobset_name,
           create_node_pool,
-          startup.task_group,
+          *startup.tasks,
           all_verification_tasks,
           summary,
           clean_up_workload,

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -25,7 +25,7 @@ import tempfile
 
 from airflow import models
 from airflow.decorators import task
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.models.baseoperator import chain
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
@@ -132,6 +132,7 @@ def verify_metric_for_all_pods(
   """Runs metric verification across all pods sequentially."""
 
   results = []
+  failed_pods = []
   for pod_name in pod_names:
     logging.info(
         "Fetching tpu-info metric '%s' for pod: %s...",
@@ -139,60 +140,72 @@ def verify_metric_for_all_pods(
         pod_name,
     )
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-      kube_dir = tmpdir + "/kubeconfig"
-      env = os.environ.copy()
-      env["KUBECONFIG"] = kube_dir
+    try:
+      with tempfile.TemporaryDirectory() as tmpdir:
+        kube_dir = tmpdir + "/kubeconfig"
+        env = os.environ.copy()
+        env["KUBECONFIG"] = kube_dir
 
-      cmd = " && ".join([
-          jobset.Command.get_credentials_command(node_pool),
-          (
-              f"kubectl --kubeconfig={kube_dir} "
-              f"exec {pod_name} -n {jobset_config.namespace} "
-              f"-- tpu-info --metric {metric_strategy.tpu_info_metric_name}"
-          ),
-      ])
+        cmd = " && ".join([
+            jobset.Command.get_credentials_command(node_pool),
+            (
+                f"kubectl --kubeconfig={kube_dir} "
+                f"exec {pod_name} -n {jobset_config.namespace} "
+                f"-- tpu-info --metric {metric_strategy.tpu_info_metric_name}"
+            ),
+        ])
 
-      output = subprocess.run_exec(cmd=cmd, env=env)
+        output = subprocess.run_exec(cmd=cmd, env=env)
 
-    tpu_info_output = parse_tpu_info_output(output)
+      tpu_info_output = parse_tpu_info_output(output)
 
-    logging.info(
-        "Verifying metric '%s' for pod: %s...",
-        metric_strategy.metric_name,
-        pod_name,
+      logging.info(
+          "Verifying metric '%s' for pod: %s...",
+          metric_strategy.metric_name,
+          pod_name,
+      )
+
+      start_time = job_apply_time
+      end_time = job_apply_time + datetime.timedelta(minutes=10)
+
+      time_series_data = metric_strategy.list_or_query_metric(
+          project_id=node_pool.project_id,
+          cluster_name=node_pool.cluster_name,
+          pod_name=pod_name,
+          start_time=start_time,
+          end_time=end_time,
+      )
+
+      monitoring_values = metric_strategy.parse_from_monitoring(time_series_data)
+      cmd_values = metric_strategy.parse_from_tpu_info(tpu_info_output)
+
+      tolerance_for_metric = metric_strategy.tolerance_percent
+      logging.info(
+          "Using a tolerance of %.2f%% for metric '%s' comparison on pod %s.",
+          tolerance_for_metric,
+          metric_strategy.dag_id_suffix,
+          pod_name,
+      )
+
+      compare_metric_values(
+          cmd_values,
+          monitoring_values,
+          pod_name,
+          metric_display_name=metric_strategy.dag_id_suffix,
+          tolerance_percent=tolerance_for_metric,
+      )
+      results.append(True)
+      logging.info("Validation succeeded for pod: %s", pod_name)
+    except Exception as e:
+      logging.error("Validation failed for pod: %s. Error: %s", pod_name, e)
+      failed_pods.append((pod_name, e))
+
+  if failed_pods:
+    failed_pod_names = [name for name, _ in failed_pods]
+    logging.error("The following pods failed validation: %s", failed_pod_names)
+    raise AirflowFailException(
+        f"Task failed because validation failed on pods: {failed_pod_names}"
     )
-
-    start_time = job_apply_time
-    end_time = job_apply_time + datetime.timedelta(minutes=10)
-
-    time_series_data = metric_strategy.list_or_query_metric(
-        project_id=node_pool.project_id,
-        cluster_name=node_pool.cluster_name,
-        pod_name=pod_name,
-        start_time=start_time,
-        end_time=end_time,
-    )
-
-    monitoring_values = metric_strategy.parse_from_monitoring(time_series_data)
-    cmd_values = metric_strategy.parse_from_tpu_info(tpu_info_output)
-
-    tolerance_for_metric = metric_strategy.tolerance_percent
-    logging.info(
-        "Using a tolerance of %.2f%% for metric '%s' comparison on pod %s.",
-        tolerance_for_metric,
-        metric_strategy.dag_id_suffix,
-        pod_name,
-    )
-
-    compare_metric_values(
-        cmd_values,
-        monitoring_values,
-        pod_name,
-        metric_display_name=metric_strategy.dag_id_suffix,
-        tolerance_percent=tolerance_for_metric,
-    )
-    results.append(True)
 
   return results
 

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -31,6 +31,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
@@ -53,12 +54,17 @@ from dags.tpu_observability.utils.node_pool_util import Info
 from dags.tpu_observability.utils.time_util import TimeUtil
 from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.utils.tpu_info_util import parse_tpu_info_output
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
 
 DAG_ID = "tpu_info_metrics_verification"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 
 def compare_metric_values(
@@ -328,64 +334,75 @@ with models.DAG(
       cluster_info_2 = copy.deepcopy(cluster_info)
       cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"
 
-      with TaskGroup(group_id="create_node_pool") as create_node_pool:
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
         create_first_node_pool = node_pool.create.override(
             task_id="node_pool_1",
         )(
             node_pool=cluster_info,
             node_pool_selector=selector,
-        )
+        ).as_setup()
 
         create_second_node_pool = node_pool.create.override(
             task_id="node_pool_2",
         )(
             node_pool=cluster_info_2,
             node_pool_selector=selector,
+        ).as_setup()
+
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
         )
+        chain([create_first_node_pool, create_second_node_pool], *startup.tasks)
 
-        _ = [create_first_node_pool, create_second_node_pool]
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        verification_results = {}
+        all_verification_tasks = []
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+        for strategy in ALL_METRIC_STRATEGIES:
+          verify_metric = verify_metric_for_all_pods.override(
+              task_id=f"verify_{strategy.dag_id_suffix}"
+          )(
+              node_pool=cluster_info,
+              jobset_config=jobset_config,
+              job_apply_time=startup.jobset_start_time,
+              metric_strategy=strategy,
+              pod_names=startup.running_pods,
+          )
 
-      verification_results = {}
-      all_verification_tasks = []
+          all_verification_tasks.append(verify_metric)
+          verification_results[strategy.dag_id_suffix] = verify_metric
 
-      for strategy in ALL_METRIC_STRATEGIES:
-        verify_metric = verify_metric_for_all_pods.override(
-            task_id=f"verify_{strategy.dag_id_suffix}"
+        summary = summarize_results.override(
+            task_id="summarize_results", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            verification_results_dict=verification_results,
+            active_pods=startup.running_pods,
+        )
+        chain(all_verification_tasks, summary)
+
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          as_teardown_of=create_first_node_pool,
+      ) as post_test:
+        clean_up_workload = jobset.end_workload.override(
+            task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
         )(
             node_pool=cluster_info,
             jobset_config=jobset_config,
-            job_apply_time=startup.jobset_start_time,
-            metric_strategy=strategy,
-            pod_names=startup.running_pods,
+            jobset_name=jobset_name,
         )
 
-        all_verification_tasks.append(verify_metric)
-        verification_results[strategy.dag_id_suffix] = verify_metric
-
-      summary = summarize_results.override(
-          task_id="summarize_results", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          verification_results_dict=verification_results,
-          active_pods=startup.running_pods,
-      )
-
-      clean_up_workload = jobset.end_workload.override(
-          task_id="clean_up_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
-
-      with TaskGroup(group_id="cleanup_node_pool") as cleanup_node_pool:
         cleanup_first_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool_1",
             trigger_rule=TriggerRule.ALL_DONE,
@@ -396,15 +413,6 @@ with models.DAG(
             trigger_rule=TriggerRule.ALL_DONE,
         )(node_pool=cluster_info_2)
 
-        chain(cleanup_first_node_pool, cleanup_second_node_pool)
+        chain(clean_up_workload, cleanup_first_node_pool, cleanup_second_node_pool)
 
-      chain(
-          selector,
-          jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          all_verification_tasks,
-          summary,
-          clean_up_workload,
-          cleanup_node_pool,
-      )
+      chain(pre_test, test, post_test)

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -51,6 +51,10 @@ from dags.tpu_observability.utils import tpu_info_util as tpu_info
 from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.utils.node_pool_util import Info
 from dags.tpu_observability.utils.time_util import TimeUtil
+from dags.tpu_observability.utils.jobset_util import Workload
+from dags.tpu_observability.utils.tpu_info_util import parse_tpu_info_output
+from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
+
 
 DAG_ID = "tpu_info_metrics_verification"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
@@ -118,73 +122,79 @@ def compare_metric_values(
 
 
 @task
-def get_tpu_info_metric_from_pod(
-    node_pool: node_pool.Info,
-    pod_name: str,
-    jobset_config: jobset,
-    metric_name: str,
-) -> str:
-  """Executes the 'tpu-info' command in the specified pod and returns its
-  output."""
-  with tempfile.TemporaryDirectory() as tmpdir:
-    kube_dir = tmpdir + "/kubeconfig"
-    env = os.environ.copy()
-    env["KUBECONFIG"] = kube_dir
-
-    cmd = " && ".join([
-        jobset.Command.get_credentials_command(node_pool),
-        (
-            f"kubectl --kubeconfig={kube_dir} "
-            f"exec {pod_name} -n {jobset_config.namespace} "
-            f"-- tpu-info --metric {metric_name}"
-        ),
-    ])
-
-    return subprocess.run_exec(cmd=cmd, env=env)
-
-
-@task
-def run_metric_verification(
+def verify_metric_for_all_pods(
     node_pool: Info,
+    jobset_config: jobset.JobSet,
     job_apply_time: TimeUtil,
     metric_strategy: BaseMetricStrategy,
-    comparison_data: tuple[str, list[tpu_info.Table]],
-):
-  """A generic task that uses a strategy object to verify a metric."""
-  pod_name, tpu_info_output = comparison_data
-  metric_name = metric_strategy.metric_name
-  logging.info("Verifying metric '%s' for pod: %s...", metric_name, pod_name)
+    pod_names: list[str],
+) -> list[bool]:
+  """Runs metric verification across all pods sequentially."""
 
-  start_time = job_apply_time
-  end_time = job_apply_time + datetime.timedelta(minutes=10)
+  results = []
+  for pod_name in pod_names:
+    logging.info(
+        "Fetching tpu-info metric '%s' for pod: %s...",
+        metric_strategy.tpu_info_metric_name,
+        pod_name,
+    )
 
-  time_series_data = metric_strategy.list_or_query_metric(
-      project_id=node_pool.project_id,
-      cluster_name=node_pool.cluster_name,
-      pod_name=pod_name,
-      start_time=start_time,
-      end_time=end_time,
-  )
+    with tempfile.TemporaryDirectory() as tmpdir:
+      kube_dir = tmpdir + "/kubeconfig"
+      env = os.environ.copy()
+      env["KUBECONFIG"] = kube_dir
 
-  monitoring_values = metric_strategy.parse_from_monitoring(time_series_data)
-  cmd_values = metric_strategy.parse_from_tpu_info(tpu_info_output)
+      cmd = " && ".join([
+          jobset.Command.get_credentials_command(node_pool),
+          (
+              f"kubectl --kubeconfig={kube_dir} "
+              f"exec {pod_name} -n {jobset_config.namespace} "
+              f"-- tpu-info --metric {metric_strategy.tpu_info_metric_name}"
+          ),
+      ])
 
-  tolerance_for_metric = metric_strategy.tolerance_percent
-  logging.info(
-      "Using a tolerance of %.2f%% for metric '%s' comparison.",
-      tolerance_for_metric,
-      metric_strategy.dag_id_suffix,
-  )
+      output = subprocess.run_exec(cmd=cmd, env=env)
 
-  compare_metric_values(
-      cmd_values,
-      monitoring_values,
-      pod_name,
-      metric_display_name=metric_strategy.dag_id_suffix,
-      tolerance_percent=tolerance_for_metric,
-  )
+    tpu_info_output = parse_tpu_info_output(output)
 
-  return True
+    logging.info(
+        "Verifying metric '%s' for pod: %s...",
+        metric_strategy.metric_name,
+        pod_name,
+    )
+
+    start_time = job_apply_time
+    end_time = job_apply_time + datetime.timedelta(minutes=10)
+
+    time_series_data = metric_strategy.list_or_query_metric(
+        project_id=node_pool.project_id,
+        cluster_name=node_pool.cluster_name,
+        pod_name=pod_name,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    monitoring_values = metric_strategy.parse_from_monitoring(time_series_data)
+    cmd_values = metric_strategy.parse_from_tpu_info(tpu_info_output)
+
+    tolerance_for_metric = metric_strategy.tolerance_percent
+    logging.info(
+        "Using a tolerance of %.2f%% for metric '%s' comparison on pod %s.",
+        tolerance_for_metric,
+        metric_strategy.dag_id_suffix,
+        pod_name,
+    )
+
+    compare_metric_values(
+        cmd_values,
+        monitoring_values,
+        pod_name,
+        metric_display_name=metric_strategy.dag_id_suffix,
+        tolerance_percent=tolerance_for_metric,
+    )
+    results.append(True)
+
+  return results
 
 
 @task
@@ -329,48 +339,20 @@ with models.DAG(
       )
 
       verification_results = {}
-      all_verification_groups = []
+      all_verification_tasks = []
 
       for strategy in ALL_METRIC_STRATEGIES:
-        group_id = f"verify_{strategy.dag_id_suffix}"
+        verify_metric = verify_metric_for_all_pods.override(
+            task_id=f"verify_{strategy.dag_id_suffix}"
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            job_apply_time=startup.jobset_start_time,
+            metric_strategy=strategy,
+            pod_names=startup.running_pods,
+        )
 
-        with TaskGroup(group_id=group_id) as verification_group:
-          tpu_info_metric_outputs = (
-              get_tpu_info_metric_from_pod.override(
-                  task_id="get_tpu_info_metric_table"
-              )
-              .partial(
-                  node_pool=cluster_info,
-                  jobset_config=jobset_config,
-                  metric_name=strategy.tpu_info_metric_name,
-              )
-              .expand(pod_name=startup.running_pods)
-          )
-
-          tpu_info_metric_output = (
-              tpu_info.parse_tpu_info_output.override(
-                  task_id="get_each_metric_table"
-              )
-              .partial()
-              .expand(output=tpu_info_metric_outputs)
-          )
-
-          verify_metric = (
-              run_metric_verification.override(task_id="run_verification")
-              .partial(
-                  node_pool=cluster_info,
-                  job_apply_time=startup.jobset_start_time,
-                  metric_strategy=strategy,
-              )
-              .expand(
-                  comparison_data=startup.running_pods.zip(
-                      tpu_info_metric_output
-                  )
-              )
-          )
-
-        all_verification_groups.append(verification_group)
-
+        all_verification_tasks.append(verify_metric)
         verification_results[strategy.dag_id_suffix] = verify_metric
 
       summary = summarize_results.override(
@@ -405,8 +387,8 @@ with models.DAG(
           selector,
           jobset_name,
           create_node_pool,
-          *startup.tasks,
-          all_verification_groups,
+          startup.task_group,
+          all_verification_tasks,
           summary,
           clean_up_workload,
           cleanup_node_pool,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -174,15 +174,11 @@ with models.DAG(
           node_pool=cluster_info,
           jobset_config=jobset_config,
           jobset_name=jobset_name,
-      ).as_teardown(
-          setups=startup.jobset_start_time
       )
 
       cleanup_node_pool = node_pool.delete.override(
           task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info).as_teardown(
-          setups=create_node_pool,
-      )
+      )(node_pool=cluster_info)
 
       chain(
           selector,

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -180,10 +180,12 @@ with models.DAG(
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-    sdk_validation = validate_monitoring_sdk.override(task_id="sdk_validation")(
-        info=cluster_info,
-        pod_names=startup.running_pods,
-    )
+      sdk_validation = validate_monitoring_sdk.override(
+          task_id="sdk_validation"
+      )(
+          info=cluster_info,
+          pod_names=startup.running_pods,
+      )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -16,10 +16,13 @@
 list_supported_metrics() are functional inside TPU worker pods."""
 
 import datetime
+import logging
 
 from airflow import models
 from airflow.decorators import task
+from airflow.exceptions import AirflowFailException
 from airflow.models.baseoperator import chain
+from airflow.utils.task_group import TaskGroup
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -76,15 +79,29 @@ def validate_monitoring_sdk(info: node_pool.Info, pod_names: list[str]) -> None:
       ],
   }
 
+  failed_pods = []
   for pod_name in pod_names:
-    for script, patterns in validate_spec.items():
-      output = sdk.execute_sdk_command(info, pod_name, script)
-      for pattern in patterns:
-        if pattern not in output:
-          raise AssertionError(
-              f"Validation failed for 'tpumonitoring.{script.name.lower()}()' inside pod '{pod_name}': "
-              f"Missing '{pattern}'."
-          )
+    logging.info("Validating tpumonitoring SDK for pod: %s", pod_name)
+    try:
+      for script, patterns in validate_spec.items():
+        output = sdk.execute_sdk_command(info, pod_name, script)
+        for pattern in patterns:
+          if pattern not in output:
+            raise AssertionError(
+                f"Validation failed for 'tpumonitoring.{script.name.lower()}()' inside pod '{pod_name}': "
+                f"Missing '{pattern}'."
+            )
+      logging.info("Validation succeeded for pod: %s", pod_name)
+    except Exception as e:
+      logging.error("Validation failed for pod: %s. Error: %s", pod_name, e)
+      failed_pods.append((pod_name, e))
+
+  if failed_pods:
+    failed_pod_names = [name for name, _ in failed_pods]
+    logging.error("The following pods failed validation: %s", failed_pod_names)
+    raise AirflowFailException(
+        f"Task failed because validation failed on pods: {failed_pod_names}"
+    )
 
 
 with models.DAG(

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -44,7 +44,7 @@ SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
 
 
 @task
-def validate_monitoring_sdk(info: node_pool.Info, pod_name: str) -> None:
+def validate_monitoring_sdk(info: node_pool.Info, pod_names: list[str]) -> None:
   """Validates the tpumonitoring SDK functions inside TPU worker pods.
 
   This task executes both help() and list_supported_metrics() via the SDK
@@ -52,7 +52,7 @@ def validate_monitoring_sdk(info: node_pool.Info, pod_name: str) -> None:
 
   Args:
     info: Cluster info for gcloud credentials.
-    pod_name: Pod name provided by dynamic task mapping.
+    pod_names: List of pod names.
   """
   # A dict of script to its expected result patterns.
   validate_spec: dict[sdk.TpuMonitoringScript, list[str]] = {
@@ -76,14 +76,15 @@ def validate_monitoring_sdk(info: node_pool.Info, pod_name: str) -> None:
       ],
   }
 
-  for script, patterns in validate_spec.items():
-    output = sdk.execute_sdk_command(info, pod_name, script)
-    for pattern in patterns:
-      if pattern not in output:
-        raise AssertionError(
-            f"Validation failed for 'tpumonitoring.{script.name.lower()}()': "
-            f"Missing '{pattern}'."
-        )
+  for pod_name in pod_names:
+    for script, patterns in validate_spec.items():
+      output = sdk.execute_sdk_command(info, pod_name, script)
+      for pattern in patterns:
+        if pattern not in output:
+          raise AssertionError(
+              f"Validation failed for 'tpumonitoring.{script.name.lower()}()' inside pod '{pod_name}': "
+              f"Missing '{pattern}'."
+          )
 
 
 with models.DAG(
@@ -162,11 +163,10 @@ with models.DAG(
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 
-      sdk_validation = (
-          validate_monitoring_sdk.override(task_id="sdk_validation")
-          .partial(info=cluster_info)
-          .expand(pod_name=startup.running_pods)
-      )
+    sdk_validation = validate_monitoring_sdk.override(task_id="sdk_validation")(
+        info=cluster_info,
+        pod_names=startup.running_pods,
+    )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -27,6 +27,7 @@ from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
 
 from dags import composer_env
+from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 from dags.common.scheduling_helper.scheduling_helper import (
     SchedulingHelper,
     get_dag_timeout,
@@ -44,6 +45,10 @@ from dags.tpu_observability.utils.jobset_util import Workload
 DAG_ID = "tpu_sdk_monitoring_validation"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
+
+PRE_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+POST_TEST_TIMEOUT = datetime.timedelta(minutes=10)
+TEST_TIMEOUT = DAGRUN_TIMEOUT - PRE_TEST_TIMEOUT - POST_TEST_TIMEOUT
 
 
 @task
@@ -167,44 +172,51 @@ with models.DAG(
       selector = jobset.generate_node_pool_selector(DAG_ID)
       jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
-      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-          node_pool=cluster_info,
-          node_pool_selector=selector,
-      )
+      with TaskGroupWithTimeout(
+          group_id="pre_test",
+          timeout=PRE_TEST_TIMEOUT,
+      ) as pre_test:
+        create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+            node_pool=cluster_info,
+            node_pool_selector=selector,
+        ).as_setup()
 
-      startup = jobset.create_jobset_startup_tasks(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-          node_pool_selector=selector,
-          workload_type=Workload.JAX_TPU_BENCHMARK,
-      )
+        startup = jobset.create_jobset_startup_tasks(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+            node_pool_selector=selector,
+            workload_type=Workload.JAX_TPU_BENCHMARK,
+        )
+        chain(create_node_pool, *startup.tasks)
 
-      sdk_validation = validate_monitoring_sdk.override(
-          task_id="sdk_validation"
-      )(
-          info=cluster_info,
-          pod_names=startup.running_pods,
-      )
+      with TaskGroupWithTimeout(
+          group_id="test",
+          timeout=TEST_TIMEOUT,
+      ) as test:
+        sdk_validation = validate_monitoring_sdk.override(
+            task_id="sdk_validation"
+        )(
+            info=cluster_info,
+            pod_names=startup.running_pods,
+        )
 
-      cleanup_workload = jobset.end_workload.override(
-          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(
-          node_pool=cluster_info,
-          jobset_config=jobset_config,
-          jobset_name=jobset_name,
-      )
+      with TaskGroupWithTimeout(
+          group_id="post_test",
+          timeout=POST_TEST_TIMEOUT,
+          as_teardown_of=create_node_pool,
+      ) as post_test:
+        cleanup_workload = jobset.end_workload.override(
+            task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+        )(
+            node_pool=cluster_info,
+            jobset_config=jobset_config,
+            jobset_name=jobset_name,
+        )
 
-      cleanup_node_pool = node_pool.delete.override(
-          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info)
+        cleanup_node_pool = node_pool.delete.override(
+            task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+        )(node_pool=cluster_info)
+        chain(cleanup_workload, cleanup_node_pool)
 
-      chain(
-          selector,
-          jobset_name,
-          create_node_pool,
-          *startup.tasks,
-          sdk_validation,
-          cleanup_workload,
-          cleanup_node_pool,
-      )
+      chain(pre_test, test, post_test)

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -176,7 +176,9 @@ with models.DAG(
           group_id="pre_test",
           timeout=PRE_TEST_TIMEOUT,
       ) as pre_test:
-        create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+        create_node_pool = node_pool.create.override(
+            task_id="create_node_pool"
+        )(
             node_pool=cluster_info,
             node_pool_selector=selector,
         ).as_setup()

--- a/dags/tpu_observability/update_node_pool_label.py
+++ b/dags/tpu_observability/update_node_pool_label.py
@@ -102,7 +102,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             owner=test_owner.YUNA_T,
         )(
             node_pool=node_pool_info,
-        )
+        ).as_setup()
 
         wait_for_availability = node_pool.wait_for_availability.override(
             task_id="wait_for_initial_availability"
@@ -138,7 +138,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       with TaskGroupWithTimeout(
           group_id="post_test",
           timeout=POST_TEST_TIMEOUT,
-          is_teardown=True,
+          as_teardown_of=create_node_pool,
       ) as post_test:
         cleanup_node_pool = node_pool.delete.override(
             task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE

--- a/dags/tpu_observability/utils/tpu_info_util.py
+++ b/dags/tpu_observability/utils/tpu_info_util.py
@@ -4,7 +4,6 @@ import re
 from dataclasses import dataclass
 from enum import IntEnum, auto
 
-from airflow.decorators import task
 
 # A type alias for a parsed row, mapping column headers to their values.
 _TableRow = dict[str, str]
@@ -65,7 +64,6 @@ class Table:
     self.body = parsed_body
 
 
-@task
 def parse_tpu_info_output(output: str) -> list[Table]:
   """Splits a multi-table string from tpu-info into a structured TpuInfo object.
 

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -22,14 +22,37 @@ FOLDERS_TO_FORMAT=("dags" "xlml")
 echo "[code-style] Running Semgrep static analysis..."
 semgrep --config scripts/semgrep-rules.yaml --error
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -15,12 +15,15 @@
 """Base task file for a test job."""
 
 import abc
+import contextlib
 import dataclasses
 import datetime
 import shlex
-from typing import Optional, Tuple, Union
+from typing import Any, Tuple, Union
 
 import airflow
+from airflow.models import BaseOperator
+from airflow.models.baseoperator import chain
 from airflow.models.taskmixin import DAGNode
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
@@ -42,7 +45,7 @@ class BaseTask(abc.ABC):
     Returns:
       A DAG node that executes this test.
     """
-    ...
+    pass
 
   def run_with_quarantine(self, quarantine_task_group):
     """Run a test job. If the test job is flaky, wrap it in a special task grop.
@@ -62,12 +65,12 @@ def run_queued_resource_test(
     # TODO(wcromar): make these args less verbose
     task_test_config: test_config.TestConfig[test_config.Tpu],
     task_gcp_config: gcp_config.GCPConfig,
-    task_metric_config: Optional[metric_config.MetricConfig] = None,
+    task_metric_config: metric_config.MetricConfig | None = None,
     tpu_create_timeout: datetime.timedelta = datetime.timedelta(minutes=60),
     tpu_name_env_var: bool = False,
     all_workers: bool = True,
     skip_post_process: bool = False,
-    custom_env: dict[str, str] = {},
+    custom_env: dict[str, str] | None = None,
 ):
   """This is a class to set up tasks for TPU provisioned by Queued Resource.
 
@@ -93,6 +96,9 @@ def run_queued_resource_test(
       A task group with the following tasks chained: provision, run_model,
       post_process and clean_up.
   """
+
+  if custom_env is None:
+    custom_env = {}
 
   with TaskGroup(
       group_id=task_test_config.benchmark_id, prefix_group_id=True
@@ -301,21 +307,162 @@ class AXLearnTask(BaseTask):
           setups=dummy_op_for_teardown, on_failure_fail_dagrun=True
       )
 
-      # flow1: The launcher task (Kubernetes Pod) that runs the workload.
-      # flow2: The monitoring sidecar that tracks status and handles cleanup.
-      # We run them in parallel because flow1 blocks until completion;
-      # flow2 must run concurrently to monitor progress and ensure cleanup.
+      chain(wait_for_workload_start, wait_for_workload_completion, cleanup)
       flow1 = run_workload
-      flow2 = wait_for_workload_start >> wait_for_workload_completion >> cleanup
+      flow2 = wait_for_workload_start
 
-      _ = (
-          update_image_tag_cmd
-          >> gen_cmds
-          >> dummy_op_for_teardown
-          >> [flow1, flow2]
+      chain(
+          update_image_tag_cmd,
+          gen_cmds,
+          dummy_op_for_teardown,
+          # We run them in parallel because flow1 blocks until completion and
+          # flow2 must run concurrently to monitor progress and ensure cleanup.
+          [flow1, flow2],
       )
 
     return group
+
+
+@dataclasses.dataclass
+class XpkRunner:
+  """XpkRunner executes XPK workloads and manages their lifecycle."""
+
+  task_test_config: Union[
+      test_config.TpuGkeTest, test_config.GpuXpkTest, test_config.CpuGkeTest
+  ]
+  task_gcp_config: gcp_config.GCPConfig
+  workload_id: airflow.XComArg
+  gcs_path: airflow.XComArg
+  workload_provision_timeout: datetime.timedelta
+  use_vertex_tensorboard: bool = False
+  use_pathways: bool = False
+  ramdisk_directory: str = ""
+  mtc_enabled: bool = False
+  xpk_branch: str = xpk.MAIN_BRANCH
+  max_restart: int = 0
+  priority: str = "high"
+
+  def launch_workload(self) -> DAGNode:
+    """Create the workload and wait for it to provision."""
+    with TaskGroup(group_id="launch_workload") as group:
+      run_workload = xpk.run_workload.override(
+          owner=self.task_test_config.task_owner
+      )(
+          task_id="run_workload",
+          cluster_project=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          benchmark_id=self.task_test_config.benchmark_id,
+          workload_id=self.workload_id,
+          gcs_path=self.gcs_path,
+          docker_image=self.task_test_config.docker_image,
+          accelerator_type=self.task_test_config.accelerator.name,
+          run_cmds=self.task_test_config.test_script,
+          num_slices=self.task_test_config.num_slices,
+          use_vertex_tensorboard=self.use_vertex_tensorboard,
+          use_pathways=self.use_pathways,
+          ramdisk_directory=self.ramdisk_directory,
+          mtc_enabled=self.mtc_enabled,
+          xpk_branch=self.xpk_branch,
+          max_restart=self.max_restart,
+          priority=self.priority,
+          namespace=self.task_test_config.namespace,
+      )
+      wait_for_workload_start = xpk.wait_for_workload_start.override(
+          timeout=self.workload_provision_timeout.total_seconds()
+      )(
+          workload_id=self.workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.task_gcp_config.zone),
+          cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
+      )
+      chain(run_workload, wait_for_workload_start)
+      return group
+
+  def wait_workload_complete(self) -> BaseOperator:
+    return xpk.wait_for_workload_completion.override(
+        timeout=int(self.task_test_config.timeout.total_seconds()),
+    )(
+        workload_id=self.workload_id,
+        project_id=self.task_gcp_config.project_name,
+        region=gke.zone_to_region(self.task_gcp_config.zone),
+        cluster_name=self.task_test_config.cluster_name,
+        namespace=self.task_test_config.namespace,
+    )
+
+  def cleanup_workload(self, tear_down_of: BaseOperator) -> DAGNode:
+    return xpk.clean_up_workload(
+        workload_id=self.workload_id,
+        project_id=self.task_gcp_config.project_name,
+        zone=self.task_gcp_config.zone,
+        cluster_name=self.task_test_config.cluster_name,
+        xpk_branch=self.xpk_branch,
+        namespace=self.task_test_config.namespace,
+    ).as_teardown(
+        setups=tear_down_of,
+        on_failure_fail_dagrun=True,
+    )
+
+  def wait_workload_reach_to_step(
+      self,
+      expect_reach_to_step: int,
+      check_file_exists: bool,
+  ) -> DAGNode:
+    with TaskGroup(group_id="wait_workload") as group:
+      wait_reach_to_step = xpk.wait_for_workload_reach_step.override(
+          task_id="wait_for_workload_reach_step"
+      )(
+          workload_id=self.workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.task_gcp_config.zone),
+          cluster_name=self.task_test_config.cluster_name,
+          expect_reach_to_step=str(expect_reach_to_step),
+          namespace=self.task_test_config.namespace,
+      )
+
+      task_id_wait_file_exist = "wait_for_file_to_exist"
+      wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
+          task_id=task_id_wait_file_exist
+      )(
+          file_path=(
+              f"{self.gcs_path}/{str(expect_reach_to_step)}/commit_success.txt"
+          ),
+      )
+      task_id_do_nothing = "do_nothing"
+      do_nothing = EmptyOperator(task_id=task_id_do_nothing)
+
+      @task.branch
+      def task_path_decider(check_file_exists: bool = False) -> str:
+        """Dynamically route the workflow depending on check_file_exists."""
+        if check_file_exists:
+          return f"{group.group_id}.{task_id_wait_file_exist}"
+        return f"{group.group_id}.{task_id_do_nothing}"
+
+      # Conditional checks: depending on the `check_file_exists` argument
+      # specified by the upper-level caller.
+      maybe_check_file_exists = task_path_decider(check_file_exists)
+
+      chain(
+          wait_reach_to_step,
+          maybe_check_file_exists,
+          [wait_for_file_to_exist, do_nothing],
+      )
+
+      return group
+
+  def interrupt_workload(self, is_targeting_on_last_node: bool) -> DAGNode:
+    return xpk.delete_node.override(
+        owner=self.task_test_config.task_owner, trigger_rule="none_failed"
+    )(
+        project=self.task_gcp_config.project_name,
+        zone=self.task_gcp_config.zone,
+        cluster_name=self.task_test_config.cluster_name,
+        workload_id=self.workload_id,
+        dry_run=False,
+        last_node=is_targeting_on_last_node,
+        namespace=self.task_test_config.namespace,
+    )
 
 
 @dataclasses.dataclass
@@ -333,16 +480,17 @@ class XpkTask(BaseTask):
       test_config.TpuGkeTest, test_config.GpuXpkTest, test_config.CpuGkeTest
   ]
   task_gcp_config: gcp_config.GCPConfig
-  task_metric_config: Optional[metric_config.MetricConfig] = None
+  task_metric_config: metric_config.MetricConfig | None = None
   workload_provision_timeout: datetime.timedelta = datetime.timedelta(
-      # Set the provision timeout from 300 to 60 minutes for decreasing the duration of failed tasks
+      # Set the provision timeout from 300 to 60 minutes for decreasing the
+      # duration of failed tasks
       minutes=60
   )
 
   def run(
       self,
       *,
-      gcs_location: Optional[airflow.XComArg] = None,
+      gcs_location: airflow.XComArg | None = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
       skip_post_process: bool = False,
@@ -364,373 +512,54 @@ class XpkTask(BaseTask):
       post_process.
     """
     with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      run_model, gcs_path = self.run_model(
-          gcs_location,
-          use_vertex_tensorboard,
-          use_pathways,
-          ramdisk_directory,
-          mtc_enabled,
-          xpk_branch,
-          max_restart,
-          priority=priority,
-      )
-      if not skip_post_process:
-        _ = run_model >> self.post_process(gcs_path)
-
-    return group
-
-  def run_with_node_interruption(
-      self,
-      *,
-      gcs_location: Optional[airflow.XComArg] = None,
-      use_vertex_tensorboard: bool = False,
-      expect_reach_to_step: int,
-      use_pathways: bool = False,
-      skip_post_process: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      last_node: bool = False,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
-  ) -> DAGNode:
-    """Run a test job within a docker image.
-
-       Will run a workload with an injected interruption of a GKE node.
-       Then is expected to automatically restart and continuing running.
-
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
-      expect_reach_to_step: The training step at which the node interruption
-        should be triggered.
-      use_pathways: Set to True to use the Pathways execution framework.
-      skip_post_process: If True, the post processing step will be skipped.
-      ramdisk_directory: The directory for enabling emergency checkpointing.
-      mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
-      xpk_branch: The specific git branch of the xpk tool to use.
-      last_node: If True, the interruption will target the last node in the
-        workload; otherwise, it targets the first node.
-      max_restart: By default, this is 0.
-        This will restart the job with flag "--max-restarts"
-      check_file_exists: By default, this is False. If set to True,
-        task branch task_path_decider will be performed.
-    Returns:
-      A task group with the following tasks chained: run_model and
-      post_process.
-    """
-    with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      run_model, gcs_path = self.run_model_with_node_interruption(
+      pre_process, xpk_runner = self._pre_process(
           gcs_location=gcs_location,
           use_vertex_tensorboard=use_vertex_tensorboard,
-          expect_reach_to_step=expect_reach_to_step,
           use_pathways=use_pathways,
           ramdisk_directory=ramdisk_directory,
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
-          last_node=last_node,
           max_restart=max_restart,
-          check_file_exists=check_file_exists,
+          priority=priority,
       )
+
+      run_model = self._run_model(xpk_runner)
+
+      nodes = [pre_process, run_model]
       if not skip_post_process:
-        _ = run_model >> self.post_process(gcs_path)
+        nodes.append(self._post_process(xpk_runner.gcs_path))
+
+      chain(*nodes)
+
     return group
 
-  def run_model_with_node_interruption(
-      self,
-      *,
-      gcs_location: Optional[airflow.XComArg] = None,
-      use_vertex_tensorboard: bool = False,
-      expect_reach_to_step: int,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      last_node: bool = False,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
-  ) -> DAGNode:
-    """Run the TPU/GPU test in `task_test_config` using xpk.
-
-      Different behavior for testing node interruption.
-
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
-      expect_reach_to_step: The training step at which the node interruption
-        should be triggered.
-      use_pathways: Set to True to use the Pathways execution framework.
-      ramdisk_directory: The directory for enabling emergency checkpointing.
-      mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
-      xpk_branch: The specific git branch of the xpk tool to use.
-      last_node: If True, the interruption will target the last node in the
-        workload; otherwise, it targets the first node.
-      max_restart: By default, this is 0.
-        This will restart the job with flag "--max-restarts"
-      check_file_exists: By default, this is False. If set to True,
-        task branch task_path_decider will be performed.
-    Returns:
-      A DAG node that executes the model test.
-    """
+  def _run_model(self, xpk_runner: XpkRunner) -> DAGNode:
     with TaskGroup(group_id="run_model") as group:
-      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      if gcs_location:
-        gcs_path = gcs_location
-      else:
-        gcs_path = name_format.generate_gcs_folder_location(
-            self.task_test_config.gcs_subfolder,
-            self.task_test_config.benchmark_id,
-        )
+      dummy_op = self._dummy_op_for_teardown()
 
-      dummy_op_for_teardown = EmptyOperator(
-          task_id="dummy_op_for_teardown"
-      ).as_setup()
-
-      launch_workload_and_wait_for_reach_step = (
-          self.launch_workload_with_node_reach_to_step(
-              workload_id,
-              gcs_path,
-              expect_reach_to_step,
-              use_vertex_tensorboard,
-              use_pathways,
-              ramdisk_directory,
-              mtc_enabled,
-              xpk_branch,
-              max_restart,
-              check_file_exists,
-          )
+      chain(
+          dummy_op,
+          xpk_runner.launch_workload(),
+          xpk_runner.wait_workload_complete(),
+          xpk_runner.cleanup_workload(tear_down_of=dummy_op),
       )
-
-      run_node_interruption = xpk.delete_node.override(
-          owner=self.task_test_config.task_owner, trigger_rule="none_failed"
-      )(
-          project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          workload_id=workload_id,
-          dry_run=False,
-          last_node=last_node,
-          namespace=self.task_test_config.namespace,
-      )
-
-      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-          timeout=int(self.task_test_config.timeout.total_seconds()),
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-          namespace=self.task_test_config.namespace,
-      )
-
-      clean_up_workload = xpk.clean_up_workload(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          xpk_branch=xpk_branch,
-          namespace=self.task_test_config.namespace,
-      ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
-
-      _ = (
-          (workload_id, gcs_path)
-          >> dummy_op_for_teardown
-          >> launch_workload_and_wait_for_reach_step
-          >> run_node_interruption
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
-    return group, gcs_path
-
-  def launch_workload_with_node_reach_to_step(
-      self,
-      workload_id: str,
-      gcs_path: str,
-      expect_reach_to_step: int,
-      use_vertex_tensorboard: bool,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
-  ) -> DAGNode:
-    """Create the workload and wait for it to provision."""
-    with TaskGroup(group_id="launch_workload_with_node_reach_to_step") as group:
-      run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
-      )(
-          task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
-          workload_id=workload_id,
-          gcs_path=gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-          namespace=self.task_test_config.namespace,
-      )
-      wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-          namespace=self.task_test_config.namespace,
-      )
-      wait_for_workload_to_reach_step = (
-          xpk.wait_for_workload_reach_step.override(
-              task_id="wait_for_workload_reach_step"
-          )(
-              workload_id=workload_id,
-              project_id=self.task_gcp_config.project_name,
-              region=gke.zone_to_region(self.task_gcp_config.zone),
-              cluster_name=self.task_test_config.cluster_name,
-              expect_reach_to_step=str(expect_reach_to_step),
-              namespace=self.task_test_config.namespace,
-          )
-      )
-
-      task_id_wait_file_exist = "wait_for_file_to_exist"
-      wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
-          task_id=task_id_wait_file_exist
-      )(
-          file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
-      )
-      task_id_do_nothing = "do_nothing"
-      do_nothing = EmptyOperator(task_id=task_id_do_nothing)
-
-      @task.branch
-      def task_path_decider(check_file_exists: bool = False) -> str:
-        """
-        Dynamically route the workflow depending on the `check_file_exists`.
-        """
-        if check_file_exists:
-          return f"{group.group_id}.{task_id_wait_file_exist}"
-        return f"{group.group_id}.{task_id_do_nothing}"
-
-      # Conditional checks: depending on the `check_file_exists` argument
-      # specified by the upper-level caller.
-      maybe_check_file_exists = task_path_decider(check_file_exists)
-
-      _ = (
-          run_workload
-          >> wait_for_workload_start
-          >> wait_for_workload_to_reach_step
-          >> maybe_check_file_exists
-      )
-      _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
-
       return group
 
-  def run_with_name_gen_and_quarantine(
+  def _maybe_generate_gcs_location(
       self,
-      quarantine_task_group,
-      use_pathways: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      run_name_env: str = "M_RUN_NAME",
-      nested_run_name_in_tb_file_location: bool = True,
-  ) -> DAGNode:
-    test_name = self.task_test_config.benchmark_id
-    if QuarantineTests.is_quarantined(test_name):
-      with quarantine_task_group:
-        return self.run_with_run_name_generation(
-            use_pathways,
-            xpk_branch,
-            run_name_env,
-            nested_run_name_in_tb_file_location,
-        )
-    else:
-      return self.run_with_run_name_generation(
-          use_pathways,
-          xpk_branch,
-          run_name_env,
-          nested_run_name_in_tb_file_location,
-      )
+      gcs_location: airflow.XComArg | None = None,
+  ) -> airflow.XComArg:
+    if gcs_location:
+      return gcs_location
 
-  def run_with_run_name_generation(
+    return name_format.generate_gcs_folder_location(
+        self.task_test_config.gcs_subfolder,
+        self.task_test_config.benchmark_id,
+    )
+
+  def _pre_process(
       self,
-      use_pathways: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      run_name_env: str = "M_RUN_NAME",
-      nested_run_name_in_tb_file_location: bool = True,
-  ) -> DAGNode:
-    """Generate a unique run name, tensorboard file location,
-    and profile file location (if metric config has profile),
-    then run a test job within a docker image.
-
-    Returns:
-      A task group with the following tasks chained: generate_run_name,
-      generate_tb_file_location, generate_profile_file_location (optional),
-      run provision, run_model, post_process.
-    """
-    with TaskGroup(
-        group_id=self.task_test_config.benchmark_id, prefix_group_id=True
-    ) as group:
-      run_name = name_format.generate_run_name(
-          self.task_test_config.benchmark_id
-      )
-      tb_file_location = name_format.generate_tb_file_location(
-          run_name,
-          self.task_metric_config.tensorboard_summary.file_location,
-          nested_run_name_in_tb_file_location,
-      )
-
-      # Set run_name in run_model_cmds
-      new_run_model_cmds = [f"export {run_name_env}={run_name}"]
-      for cmd in self.task_test_config.run_model_cmds:
-        new_run_model_cmds.append(cmd)
-      self.task_test_config.run_model_cmds = new_run_model_cmds
-
-      # Update tensorboard file location
-      self.task_metric_config.tensorboard_summary.file_location = (
-          tb_file_location
-      )
-
-      # Update profile file location
-      if self.task_metric_config.profile:
-        profile_file_location = name_format.generate_profile_file_location(
-            run_name, self.task_metric_config.profile.file_location
-        )
-        self.task_metric_config.profile.file_location = profile_file_location
-        run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways,
-            xpk_branch=xpk_branch,
-        )
-        _ = (
-            run_name
-            >> (tb_file_location, profile_file_location)
-            >> run_model
-            >> self.post_process(gcs_path)
-        )
-      else:
-        run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways,
-            xpk_branch=xpk_branch,
-        )
-        _ = (
-            run_name
-            >> tb_file_location
-            >> run_model
-            >> self.post_process(gcs_path)
-        )
-    return group
-
-  def run_model(
-      self,
-      gcs_location: Optional[airflow.XComArg] = None,
+      gcs_location: airflow.XComArg | None = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
       ramdisk_directory: str = "",
@@ -738,98 +567,18 @@ class XpkTask(BaseTask):
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
       priority: str = "high",
-  ) -> DAGNode:
-    """Run the TPU/GPU test in `task_test_config` using xpk.
-
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
-
-    Returns:
-      A DAG node that executes the model test.
-    """
-    with TaskGroup(group_id="run_model") as group:
+  ) -> tuple[DAGNode, XpkRunner]:
+    with TaskGroup(group_id="pre_process") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      if gcs_location:
-        gcs_path = gcs_location
-      else:
-        gcs_path = name_format.generate_gcs_folder_location(
-            self.task_test_config.gcs_subfolder,
-            self.task_test_config.benchmark_id,
-        )
 
-      dummy_op_for_teardown = EmptyOperator(
-          task_id="dummy_op_for_teardown"
-      ).as_setup()
+      gcs_path = self._maybe_generate_gcs_location(gcs_location)
 
-      launch_workload = self.launch_workload(
-          workload_id,
-          gcs_path,
-          use_vertex_tensorboard,
-          use_pathways,
-          ramdisk_directory,
-          mtc_enabled,
-          xpk_branch,
-          max_restart,
-          priority=priority,
-      )
-      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-          timeout=int(self.task_test_config.timeout.total_seconds()),
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-          namespace=self.task_test_config.namespace,
-      )
-
-      clean_up_workload = xpk.clean_up_workload(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          xpk_branch=xpk_branch,
-          namespace=self.task_test_config.namespace,
-      ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
-
-      _ = (
-          (workload_id, gcs_path)
-          >> dummy_op_for_teardown
-          >> launch_workload
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
-      return group, gcs_path
-
-  def launch_workload(
-      self,
-      workload_id: str,
-      gcs_path: str,
-      use_vertex_tensorboard: bool,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
-  ) -> DAGNode:
-    """Create the workload and wait for it to provision."""
-    with TaskGroup(group_id="launch_workload") as group:
-      run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
-      )(
-          task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
+      xpk_runner = XpkRunner(
+          task_test_config=self.task_test_config,
+          task_gcp_config=self.task_gcp_config,
           workload_id=workload_id,
           gcs_path=gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
+          workload_provision_timeout=self.workload_provision_timeout,
           use_vertex_tensorboard=use_vertex_tensorboard,
           use_pathways=use_pathways,
           ramdisk_directory=ramdisk_directory,
@@ -837,21 +586,11 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
-          namespace=self.task_test_config.namespace,
       )
-      wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-          namespace=self.task_test_config.namespace,
-      )
-      _ = run_workload >> wait_for_workload_start
-      return group
 
-  def post_process(self, result_location: Optional[str] = None) -> DAGNode:
+    return group, xpk_runner
+
+  def _post_process(self, result_location: str | None = None) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
     Returns:
@@ -873,15 +612,165 @@ class XpkTask(BaseTask):
                 self.task_metric_config.profile.file_location
             )
         )
-        _ = (
-            process_id
-            >> self.task_metric_config.profile.metrics
-            >> post_process_metrics
+        chain(
+            process_id,
+            self.task_metric_config.profile.metrics,
+            post_process_metrics,
         )
       else:
-        _ = process_id >> post_process_metrics
+        chain(process_id, post_process_metrics)
 
       return group
+
+  def _dummy_op_for_teardown(self) -> BaseOperator:
+    return EmptyOperator(task_id="dummy_op_for_teardown").as_setup()
+
+
+@dataclasses.dataclass
+class XpkNodeInterruptionTask(XpkTask):
+  """Task for running XPK workloads with node interruption."""
+
+  expect_reach_to_step: int = 0
+  last_node: bool = False
+  check_file_exists: bool = False
+
+  def _run_model(self, xpk_runner: XpkRunner) -> DAGNode:
+    with TaskGroup(group_id="run_model") as group:
+      dummy_op = self._dummy_op_for_teardown()
+
+      chain(
+          dummy_op,
+          xpk_runner.launch_workload(),
+          xpk_runner.wait_workload_reach_to_step(
+              self.expect_reach_to_step,
+              self.check_file_exists,
+          ),
+          xpk_runner.interrupt_workload(self.last_node),
+          xpk_runner.wait_workload_complete(),
+          xpk_runner.cleanup_workload(tear_down_of=dummy_op),
+      )
+
+      return group
+
+
+@dataclasses.dataclass
+class XpkNameGenAndQuarantineTask(XpkTask):
+  """Task for running XPK workloads with name generation and quarantine."""
+
+  quarantine_task_group: Any = None
+  run_name_env: str = "M_RUN_NAME"
+  nested_run_name_in_tb_file_location: bool = True
+
+  def run(
+      self,
+      *,
+      gcs_location: airflow.XComArg | None = None,
+      use_vertex_tensorboard: bool = False,
+      use_pathways: bool = False,
+      skip_post_process: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      max_restart: int = 0,
+      priority: str = "high",
+  ) -> DAGNode:
+    """Generate a unique run name, tensorboard file location,
+    and profile file location (if metric config has profile),
+    then run a test job within a docker image.
+
+    Returns:
+      A task group with the following tasks chained: generate_run_name,
+      generate_tb_file_location, generate_profile_file_location (optional),
+      run provision, run_model, post_process.
+    """
+
+    test_name = self.task_test_config.benchmark_id
+    cm = (
+        self.quarantine_task_group
+        if QuarantineTests.is_quarantined(test_name)
+        and self.quarantine_task_group
+        else contextlib.nullcontext()
+    )
+
+    with cm:
+      return super().run(
+          gcs_location=gcs_location,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=use_pathways,
+          skip_post_process=skip_post_process,
+          ramdisk_directory=ramdisk_directory,
+          mtc_enabled=mtc_enabled,
+          xpk_branch=xpk_branch,
+          max_restart=max_restart,
+          priority=priority,
+      )
+
+  def _pre_process(
+      self,
+      gcs_location: airflow.XComArg | None = None,
+      use_vertex_tensorboard: bool = False,
+      use_pathways: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      max_restart: int = 0,
+      priority: str = "high",
+  ) -> tuple[DAGNode, XpkRunner]:
+    with TaskGroup(group_id="pre_process") as group:
+      run_name = name_format.generate_run_name(
+          self.task_test_config.benchmark_id
+      )
+      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+
+      gcs_path = self._maybe_generate_gcs_location(gcs_location)
+
+      nodes = [run_name]
+
+      tb_file_location = name_format.generate_tb_file_location(
+          run_name,
+          self.task_metric_config.tensorboard_summary.file_location,
+          self.nested_run_name_in_tb_file_location,
+      )
+
+      # Set run_name in run_model_cmds
+      new_run_model_cmds = [f"export {self.run_name_env}={run_name}"]
+      for cmd in self.task_test_config.run_model_cmds:
+        new_run_model_cmds.append(cmd)
+      self.task_test_config.run_model_cmds = new_run_model_cmds
+
+      # Update tensorboard file location
+      self.task_metric_config.tensorboard_summary.file_location = (
+          tb_file_location
+      )
+
+      # Update profile file location
+      if self.task_metric_config and self.task_metric_config.profile:
+        profile_file_location = name_format.generate_profile_file_location(
+            run_name, self.task_metric_config.profile.file_location
+        )
+        self.task_metric_config.profile.file_location = profile_file_location
+        nodes.append([tb_file_location, profile_file_location])
+      else:
+        nodes.append(tb_file_location)
+
+      xpk_runner = XpkRunner(
+          task_test_config=self.task_test_config,
+          task_gcp_config=self.task_gcp_config,
+          workload_id=workload_id,
+          gcs_path=gcs_path,
+          workload_provision_timeout=self.workload_provision_timeout,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=use_pathways,
+          ramdisk_directory=ramdisk_directory,
+          mtc_enabled=mtc_enabled,
+          xpk_branch=xpk_branch,
+          max_restart=max_restart,
+          priority=priority,
+      )
+
+      chain(*nodes)
+
+    return group, xpk_runner
 
 
 @dataclasses.dataclass
@@ -904,7 +793,7 @@ class GpuCreateResourceTask(BaseTask):
   image_family: str
   task_test_config: test_config.TestConfig[test_config.Gpu]
   task_gcp_config: gcp_config.GCPConfig
-  task_metric_config: Optional[metric_config.MetricConfig] = None
+  task_metric_config: metric_config.MetricConfig | None = None
   gpu_create_timeout: datetime.timedelta = datetime.timedelta(minutes=60)
   install_nvidia_drivers: bool = False
   existing_instance_name: str = None
@@ -1061,7 +950,7 @@ class GpuCreateResourceTask(BaseTask):
       self,
       resource: airflow.XComArg,
       ssh_keys: airflow.XComArg,
-      env: Optional[airflow.XComArg] = None,
+      env: airflow.XComArg | None = None,
   ) -> DAGNode:
     """Run the GPU test in `task_test_config`.
 
@@ -1085,7 +974,7 @@ class GpuCreateResourceTask(BaseTask):
 
   def post_process(
       self,
-      result_location: Optional[airflow.XComArg] = None,
+      result_location: airflow.XComArg | None = None,
   ) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
@@ -1155,7 +1044,7 @@ class GpuGkeTask(BaseTask):
   task_gcp_config: gcp_config.GCPConfig
   cluster_name: str
   job_create_timeout: datetime.timedelta = datetime.timedelta(minutes=10)
-  task_metric_config: Optional[metric_config.MetricConfig] = None
+  task_metric_config: metric_config.MetricConfig | None = None
 
   def run(self) -> DAGNode:
     """Run a test job and do post data process.
@@ -1187,7 +1076,7 @@ class GpuGkeTask(BaseTask):
     return group
 
   def post_process(
-      self, result_location: Optional[airflow.XComArg] = None
+      self, result_location: airflow.XComArg | None = None
   ) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -512,6 +512,7 @@ class XpkTask(BaseTask):
           workload_id=workload_id,
           dry_run=False,
           last_node=last_node,
+          namespace=self.task_test_config.namespace,
       )
 
       wait_for_workload_completion = xpk.wait_for_workload_completion.override(
@@ -521,6 +522,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
 
       clean_up_workload = xpk.clean_up_workload(
@@ -529,6 +531,7 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
+          namespace=self.task_test_config.namespace,
       ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
 
       _ = (
@@ -576,6 +579,7 @@ class XpkTask(BaseTask):
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
           max_restart=max_restart,
+          namespace=self.task_test_config.namespace,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
           timeout=self.workload_provision_timeout.total_seconds()
@@ -584,6 +588,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
       wait_for_workload_to_reach_step = (
           xpk.wait_for_workload_reach_step.override(
@@ -594,6 +599,7 @@ class XpkTask(BaseTask):
               region=gke.zone_to_region(self.task_gcp_config.zone),
               cluster_name=self.task_test_config.cluster_name,
               expect_reach_to_step=str(expect_reach_to_step),
+              namespace=self.task_test_config.namespace,
           )
       )
 
@@ -700,7 +706,8 @@ class XpkTask(BaseTask):
         )
         self.task_metric_config.profile.file_location = profile_file_location
         run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
+            use_pathways=use_pathways,
+            xpk_branch=xpk_branch,
         )
         _ = (
             run_name
@@ -710,7 +717,8 @@ class XpkTask(BaseTask):
         )
       else:
         run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
+            use_pathways=use_pathways,
+            xpk_branch=xpk_branch,
         )
         _ = (
             run_name
@@ -773,6 +781,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
 
       clean_up_workload = xpk.clean_up_workload(
@@ -781,6 +790,7 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
+          namespace=self.task_test_config.namespace,
       ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
 
       _ = (
@@ -827,6 +837,7 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
+          namespace=self.task_test_config.namespace,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
           timeout=self.workload_provision_timeout.total_seconds()
@@ -835,6 +846,7 @@ class XpkTask(BaseTask):
           project_id=self.task_gcp_config.project_name,
           region=gke.zone_to_region(self.task_gcp_config.zone),
           cluster_name=self.task_test_config.cluster_name,
+          namespace=self.task_test_config.namespace,
       )
       _ = run_workload >> wait_for_workload_start
       return group

--- a/xlml/apis/test_config.py
+++ b/xlml/apis/test_config.py
@@ -266,6 +266,7 @@ class CpuGkeTest(TestConfig[Cpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
+  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:
@@ -301,6 +302,7 @@ class TpuGkeTest(TestConfig[Tpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
+  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:
@@ -343,6 +345,7 @@ class GpuXpkTest(TestConfig[Gpu]):
     run_model_cmds: List of commands to run the model under test.
     startup_time_out_in_sec: Timeout to start up the pod.
     num_slices: Number of GPU slices.
+    namespace: Kubernetes namespace of the cluster.
   """
 
   test_name: str
@@ -352,6 +355,7 @@ class GpuXpkTest(TestConfig[Gpu]):
   run_model_cmds: Iterable[str]
   startup_time_out_in_sec: int = attrs.field(default=300, kw_only=True)
   num_slices: int = attrs.field(default=1, kw_only=True)
+  namespace: str = attrs.field(default='default', kw_only=True)
 
   @property
   def benchmark_id(self) -> str:

--- a/xlml/apis/xpk_cluster_config.py
+++ b/xlml/apis/xpk_cluster_config.py
@@ -15,7 +15,7 @@
 """Config file for XPK cluster."""
 
 import dataclasses
-from typing import Union
+from typing import Optional, Union
 
 
 @dataclasses.dataclass
@@ -28,6 +28,7 @@ class XpkClusterConfig:
     core_count: Core count of the cluster
     project: Project of the cluster
     zone: Zone of the cluster
+    namespace: Kubernetes namespace of the cluster
   """
 
   name: str
@@ -35,3 +36,18 @@ class XpkClusterConfig:
   core_count: int
   project: str
   zone: str
+  namespace: str = 'default'
+
+  def override(
+      self,
+      *,
+      core_count: Optional[int] = None,
+      namespace: Optional[str] = None,
+  ) -> 'XpkClusterConfig':
+    """Returns a copy of this cluster config with specified fields overridden."""
+    changes = {}
+    if core_count is not None:
+      changes['core_count'] = core_count
+    if namespace is not None:
+      changes['namespace'] = namespace
+    return dataclasses.replace(self, **changes)

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -35,7 +35,7 @@ from dags.common.vm_resource import GpuVersion
 
 # NOTE: This version needs to be pinned to ensure compatibility when using
 # xpk.py for workload creation.
-MAIN_BRANCH = "v0.17.3"
+MAIN_BRANCH = "v1.16.0"
 
 # Duration = past 7 days
 LOGGING_URL_FORMAT = (

--- a/xlml/utils/xpk.py
+++ b/xlml/utils/xpk.py
@@ -44,7 +44,7 @@ LOGGING_URL_FORMAT = (
     + "resource.labels.project_id%3D%22{project}%22%0A"
     + "resource.labels.location%3D%22{region}%22%0A"
     + "resource.labels.cluster_name%3D%22{cluster}%22%0A"
-    + "resource.labels.namespace_name%3D%22default%22%0A"
+    + "resource.labels.namespace_name%3D%22{namespace}%22%0A"
     + "labels.k8s-pod%2Fjobset_sigs_k8s_io%2F"
     + "jobset-name%3D%22{workload_id}%22%20severity%3E%3DDEFAULT;"
     + "storageScope=project;duration=P7D?e=13803378&"
@@ -115,6 +115,7 @@ def run_workload(
     max_restart: int = 0,
     # to avoid workload preemption by manual tests.
     priority: str = "high",
+    namespace: str = "default",
 ):
   """Run workload through xpk tool."""
 
@@ -154,6 +155,9 @@ def run_workload(
         f" --priority={priority}"
         f" --env {metric_config.SshEnvVars.GCS_OUTPUT.name}={gcs_path}"
     )
+
+    if namespace and namespace != "default":
+      workload_create_cmd += f" --namespace={namespace}"
 
     if ramdisk_directory and not use_pathways:
       workload_create_cmd += f" --ramdisk-directory={ramdisk_directory}"
@@ -209,13 +213,17 @@ def _get_core_api_client(
 
 
 def _list_workload_pods(
-    core_api: k8s_client.CoreV1Api, workload_id: str
+    core_api: k8s_client.CoreV1Api,
+    workload_id: str,
+    namespace: str = "default",
 ) -> k8s_client.V1PodList:
   """List all pods for the given workload."""
-  logging.info(f"Getting pods for workload_id: {workload_id}")
+  logging.info(
+      f"Getting pods for workload_id: {workload_id} in namespace: {namespace}"
+  )
   pods = core_api.list_namespaced_pod(
       label_selector=f"jobset.sigs.k8s.io/jobset-name={workload_id}",
-      namespace="default",
+      namespace=namespace,
   )
   return pods
 
@@ -235,13 +243,17 @@ def _get_batch_api_client(
 
 
 def _get_workload_job(
-    batch_api: k8s_client.BatchV1Api, workload_id: str
+    batch_api: k8s_client.BatchV1Api,
+    workload_id: str,
+    namespace: str = "default",
 ) -> k8s_client.V1Job:
   """Get the job for a given workload."""
-  logging.info(f"Getting job for workload_id: {workload_id}")
+  logging.info(
+      f"Getting job for workload_id: {workload_id} in namespace: {namespace}"
+  )
   jobs = batch_api.list_namespaced_job(
       label_selector=f"jobset.sigs.k8s.io/jobset-name={workload_id}",
-      namespace="default",
+      namespace=namespace,
   )
   if len(jobs.items) == 0:
     logging.info(f"Getting job for workload_id: {workload_id}")
@@ -293,11 +305,15 @@ def _log_workload_pod_statuses(workload_id: str, pods) -> None:
 
 @task.sensor(poke_interval=60, timeout=600, mode="reschedule")
 def wait_for_workload_start(
-    workload_id: str, project_id: str, region: str, cluster_name: str
+    workload_id: str,
+    project_id: str,
+    region: str,
+    cluster_name: str,
+    namespace: str = "default",
 ) -> bool:
   """Check if the workload has started."""
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   _log_workload_pod_statuses(workload_id, pods)
   print(f"Found {len(pods.items)} pods for workload {workload_id}")
@@ -306,11 +322,15 @@ def wait_for_workload_start(
 
 @task.sensor(poke_interval=60, timeout=600, mode="reschedule")
 def wait_for_workload_completion(
-    workload_id: str, project_id: str, region: str, cluster_name: str
+    workload_id: str,
+    project_id: str,
+    region: str,
+    cluster_name: str,
+    namespace: str = "default",
 ) -> bool:
   """Check the workload status."""
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   _log_workload_pod_statuses(workload_id, pods)
 
@@ -320,7 +340,7 @@ def wait_for_workload_completion(
     # Pathways jobs delete all pods on failure so we must also check if the job
     # is complete
     batch_api = _get_batch_api_client(project_id, region, cluster_name)
-    job = _get_workload_job(batch_api, workload_id)
+    job = _get_workload_job(batch_api, workload_id, namespace=namespace)
     if job is None:
       logging.info(
           f"No pods or jobs were found for workload selector: {workload_id}"
@@ -367,6 +387,7 @@ def wait_for_workload_completion(
         project=project_id,
         region=region,
         cluster=cluster_name,
+        namespace=namespace,
         workload_id=workload_id,
     )
     logging.info(f"Link to logs: {url}")
@@ -382,6 +403,7 @@ def clean_up_workload(
     zone: str,
     cluster_name: str,
     xpk_branch: str = MAIN_BRANCH,
+    namespace: str = "default",
 ) -> bool:
   """Delete workload."""
   with tempfile.TemporaryDirectory() as tmpdir:
@@ -391,6 +413,8 @@ def clean_up_workload(
         f" --cluster={cluster_name} --workload={workload_id}"
         f" --project={project_id} --zone={zone}"
     )
+    if namespace and namespace != "default":
+      workload_delete_cmd += f" --namespace={namespace}"
 
     cmds = get_xpk_setup_cmd(tmpdir, xpk_branch)
     cmds.append(workload_delete_cmd)
@@ -411,13 +435,14 @@ def wait_for_workload_reach_step(
     cluster_name: str,
     workload_id: str,
     expect_reach_to_step: str,
+    namespace: str = "default",
 ) -> bool:
   """
   Watch any given training pod, check the given step is already reach before
   deleting a node
   """
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   if not pods.items:
     logging.info("No pods found for workload selector: %s.", workload_id)
@@ -471,10 +496,11 @@ def _find_target_pod_node(
     cluster_name: str,
     workload_id: str,
     last_node: bool = False,
+    namespace: str = "default",
 ) -> str:
   """find the node name for the workload."""
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
   pod_node_pairs = []
   pattern = re.compile(r".*slice-job-(\d+)-(\d+)-\w+")
 
@@ -515,6 +541,7 @@ def delete_node(
     project: str,
     dry_run: bool = False,
     last_node: bool = False,
+    namespace: str = "default",
 ) -> None:
   """Delete node."""
   delete_info = _find_target_pod_node(
@@ -523,6 +550,7 @@ def delete_node(
       cluster_name,
       workload_id,
       last_node,
+      namespace=namespace,
   )
   node_name = delete_info["node"]
   # Delete the specified compute instance.
@@ -554,13 +582,16 @@ def delete_node(
 # TODO(cienet): naming/description, interrupt <-> SIGILL?
 @task
 def interrupt_worker_pod(
-    workload_id: str, cluster_name: str, region: str, project_id: str
+    workload_id: str,
+    cluster_name: str,
+    region: str,
+    project_id: str,
+    namespace: str = "default",
 ):
   """
   Authenticates with the GKE cluster and sends SIGILL to worker pod 0-1.
   """
 
-  namespace = "default"
   target_worker_index = "0-1"
 
   # TODO(cienet): use Kubernetes API instead of kubectl CLI + raw command
@@ -601,13 +632,14 @@ def check_last_logs(
     cluster_name: str,
     workload_id: str,
     expect_log_contains: str,
+    namespace: str = "default",
 ) -> bool:
   """
   Checks if the last 45 seconds of a running pod's logs
   contain a specific substring.
   """
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   if not pods.items:
     logging.info("No pods found for workload selector: %s.", workload_id)
@@ -651,13 +683,14 @@ def check_logs_exist(
     workload_id: str,
     expect_log_contains: str,
     expected_count: int = 1,
+    namespace: str = "default",
 ) -> bool:
   """
   Counts occurrences of a regex pattern in full pod logs and
   verifies it meets the minimum count.
   """
   core_api = _get_core_api_client(project_id, region, cluster_name)
-  pods = _list_workload_pods(core_api, workload_id)
+  pods = _list_workload_pods(core_api, workload_id, namespace=namespace)
 
   if not pods.items:
     logging.info("No pods found for workload selector: %s.", workload_id)


### PR DESCRIPTION
# Description

This PR refactors the TPU observability DAGs to remove Airflow dynamic task mapping (the .expand() pattern). Instead, validations and operations across multiple pods are now executed sequentially inside a single Airflow task. This change simplifies the DAG structure, improves task-level logging, and streamlines error handling.

## Removal of Dynamic Task Mapping (.expand())
Converted tasks that previously targeted a single pod using dynamic task mapping to accept a list of pod names (list[str]) and process them sequentially.
Removed complex nested TaskGroup structures and the usage of .zip() and chain(), resulting in cleaner and more maintainable DAG graphs.
Removed the @task decorator from parsing and helper validation functions (such as parse_tpu_info_output, validate_chips_table, validate_runtime_table, validate_tensorcore_table, and validate_latency_table), converting them back to standard Python functions to reduce Airflow task instantiation overhead.

# Modified Files & Implementation Details
1. dags/tpu_observability/jobset_ttr_kill_process.py
    - Refactored `kill_tpu_pod_workload` to `kill_tpu_pod_workloads`, taking pod_names: list[str].
    - Replaced .partial(...).expand(pod_name=startup.running_pods) in the DAG definition with a direct single-task invocation passing the list of running pods.

2. dags/tpu_observability/tpu_info_format_validation_dags.py
    - Removed @task decorators from validate_chips_table, validate_runtime_table, validate_tensorcore_table, and validate_latency_table.
    - Introduced a new `validate_tpu_info_format` task to coordinate the tpu-info execution, parsing, and format checks for all pods.
    - Removed the verification_group TaskGroup and its dynamic mapping steps, replacing them with a single task.

3. dags/tpu_observability/tpu_info_metrics_dag.py
    - Removed `get_tpu_info_metric_from_pod` and `run_metric_verification` tasks.
    - Created a new `verify_metric_for_all_pods` task to sequentially execute tpu-info --metric, parse outputs, query Cloud Monitoring, and run validation strategies for all pods.
    - Removed the TaskGroup and .zip mapping from the main DAG workflow.

4. dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
    - Refactored validate_monitoring_sdk to accept pod_names: list[str].
    - Removed .expand(pod_name=startup.running_pods).
    - Added sequential pod validation loop and error aggregation logic.

5. dags/tpu_observability/utils/tpu_info_util.py
    - Removed @task decorator from parse_tpu_info_output to keep it a standard utility function.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.