### PR TITLE
Refactor TPU Observability DAGs Standardize Selector and JobSet Name Passing

### DIFF
--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -65,7 +65,6 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "jobset_ttr_drain_restart": DefaultTimeout,
         "tpu_info_metrics_verification": DefaultTimeout,
         "jobset_ttr_node_reboot": dt.timedelta(minutes=90),
-        "jobset_ttr_kill_process_exist": dt.timedelta(minutes=90),
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {
         "validate_interruption_count_gce_bare_metal_preemption": DefaultTimeout,

--- a/dags/common/scheduling_helper/scheduling_helper.py
+++ b/dags/common/scheduling_helper/scheduling_helper.py
@@ -65,6 +65,7 @@ REGISTERED_DAGS: dict[str, DagIdToTimeout] = {
         "jobset_ttr_drain_restart": DefaultTimeout,
         "tpu_info_metrics_verification": DefaultTimeout,
         "jobset_ttr_node_reboot": dt.timedelta(minutes=90),
+        "jobset_ttr_kill_process_exist": dt.timedelta(minutes=90),
     },
     TPU_INTERRUPTION_MOCK_CLUSTER.name: {
         "validate_interruption_count_gce_bare_metal_preemption": DefaultTimeout,

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -131,13 +131,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -129,7 +129,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -138,16 +137,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_ttr_drain_restart.py
+++ b/dags/tpu_observability/jobset_ttr_drain_restart.py
@@ -37,7 +37,6 @@ from dags.tpu_observability.configs.common import (
 )
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
-
 DAG_ID = "jobset_ttr_drain_restart"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
@@ -124,13 +123,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      selector = jobset.generate_node_pool_selector(DAG_ID)
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -138,6 +130,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -147,6 +147,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -178,7 +179,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_metric_upload"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -186,6 +187,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -198,6 +200,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           select_node,

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -133,13 +133,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -132,7 +132,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -141,16 +140,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_ttr_kill_process.py
+++ b/dags/tpu_observability/jobset_ttr_kill_process.py
@@ -28,7 +28,6 @@ from airflow.models.baseoperator import chain
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.task_group import TaskGroup
 
-
 from dags import composer_env
 from dags.tpu_observability.utils import jobset_util as jobset
 from dags.tpu_observability.utils import node_pool_util as node_pool
@@ -40,7 +39,6 @@ from dags.tpu_observability.configs.common import (
     GCS_JOBSET_CONFIG_PATH,
 )
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
-
 
 DAG_ID = "jobset_ttr_kill_process"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
@@ -127,13 +125,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      selector = jobset.generate_node_pool_selector("jobset-ttr-kill-process")
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -141,6 +132,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -150,6 +149,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -164,7 +164,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_metric_upload"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -172,6 +172,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -184,6 +185,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           kill_tasks,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -96,7 +96,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -105,16 +104,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -89,15 +89,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      selector = jobset.generate_node_pool_selector(
-          "jobset-ttr-node-pool-resize"
-      )
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -105,6 +96,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -114,6 +114,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -129,7 +130,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_jobset_ttr_to_be_found"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -137,6 +138,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -149,6 +151,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           node_pool_resize,

--- a/dags/tpu_observability/jobset_ttr_node_pool_resize.py
+++ b/dags/tpu_observability/jobset_ttr_node_pool_resize.py
@@ -97,14 +97,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
 
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -101,14 +101,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
           privileged=True,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -100,7 +100,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
           privileged=True,
       )
 
@@ -110,16 +109,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_ttr_node_reboot.py
+++ b/dags/tpu_observability/jobset_ttr_node_reboot.py
@@ -36,11 +36,9 @@ from dags.common.scheduling_helper.scheduling_helper import (
 )
 from dags.common.task_group_with_timeout import TaskGroupWithTimeout
 
-
 DAG_ID = "jobset_ttr_node_reboot"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
-
 
 # Keyword arguments are generated dynamically at runtime (pylint does not
 # know this signature).
@@ -95,14 +93,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}",
         timeout=timedelta(minutes=90),
     ):
-      selector = jobset.generate_node_pool_selector("jobset-ttr-node-reboot")
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-          privileged=True,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -110,6 +100,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+          privileged=True,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -119,6 +118,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -126,6 +126,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       target_pod = jobset.draw_random_pod(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       reboot_node = jobset.operate_pod.override(task_id="reboot_node")(
@@ -139,12 +140,16 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_jobset_ttr_to_be_found"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info, jobset_config=jobset_config).as_teardown(
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      ).as_teardown(
           setups=startup.jobset_start_time
       )
 
@@ -156,6 +161,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           target_pod,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -94,13 +94,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -92,7 +92,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -101,16 +100,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_ttr_pod_delete.py
+++ b/dags/tpu_observability/jobset_ttr_pod_delete.py
@@ -32,7 +32,6 @@ from dags.tpu_observability.configs.common import (
 )
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
-
 DAG_ID = "jobset_ttr_pod_delete"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
@@ -87,13 +86,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      selector = jobset.generate_node_pool_selector("jobset-ttr-pod-delete")
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -101,6 +93,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -110,6 +110,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -119,18 +120,23 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       wait_for_metric_upload = jobset.wait_for_jobset_ttr_to_be_found.override(
           task_id="wait_for_jobset_ttr_to_be_found"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       cleanup_workload = jobset.end_workload.override(
           task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-      )(node_pool=cluster_info, jobset_config=jobset_config).as_teardown(
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      ).as_teardown(
           setups=startup.jobset_start_time
       )
 
@@ -142,6 +148,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           delete_random_pod,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -32,7 +32,6 @@ from dags.tpu_observability.configs.common import (
 )
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
-
 DAG_ID = "jobset_rollback_ttr"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
@@ -88,13 +87,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      selector = jobset.generate_node_pool_selector("jobset-rollback-ttr")
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -102,6 +94,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -111,6 +111,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -123,7 +124,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_jobset_ttr_to_be_found"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
       )
 
       cleanup_workload = jobset.end_workload.override(
@@ -131,6 +132,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -143,6 +145,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           rollback_node_pool,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -95,13 +95,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/jobset_ttr_rollback.py
+++ b/dags/tpu_observability/jobset_ttr_rollback.py
@@ -93,7 +93,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -102,16 +101,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -104,7 +104,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -113,16 +112,17 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
+          node_pool_selector=selector,
       )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -34,7 +34,6 @@ from dags.tpu_observability.utils.jobset_util import Workload
 from dags.tpu_observability.utils.time_util import TimeUtil
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
-
 DAG_ID = "jobset_uptime_validation"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
@@ -99,13 +98,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      selector = jobset.generate_node_pool_selector("jobset-rollback-ttr")
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -113,6 +105,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,
@@ -122,6 +122,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -130,7 +131,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="wait_for_jobset_uptime_data"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
           jobset_apply_time=startup.jobset_start_time,
       )
 
@@ -139,6 +140,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -151,7 +153,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           task_id="ensure_no_jobset_uptime_data"
       )(
           node_pool=cluster_info,
-          jobset_config=jobset_config,
+          jobset_name=jobset_name,
           jobset_clear_time=jobset_clear_time,
           # Wait 5 minutes to confirm no data has been detected.
           wait_time_seconds=300,
@@ -165,6 +167,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           wait_for_jobset_uptime_data,

--- a/dags/tpu_observability/jobset_uptime_validation.py
+++ b/dags/tpu_observability/jobset_uptime_validation.py
@@ -106,13 +106,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -343,20 +343,11 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
   for machine in MachineConfigMap:
     config = machine.value
 
-    selector = jobset.generate_node_pool_selector(
-        "tpu-info-format-validation-dag"
-    )
-
     # Keyword arguments are generated dynamically at runtime (pylint does not
     # know this signature).
     with TaskGroup(  # pylint: disable=unexpected-keyword-arg
         group_id=f"v{config.tpu_version.value}"
     ):
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -364,6 +355,15 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       cluster_info_2 = copy.deepcopy(cluster_info)
       cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"
@@ -392,6 +392,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -452,6 +453,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -493,6 +495,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           outputs_of_tpu_info,

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -356,14 +356,14 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
 
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       cluster_info_2 = copy.deepcopy(cluster_info)
       cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"

--- a/dags/tpu_observability/tpu_info_format_validation_dags.py
+++ b/dags/tpu_observability/tpu_info_format_validation_dags.py
@@ -355,7 +355,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -364,7 +363,6 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       cluster_info_2 = copy.deepcopy(cluster_info)
@@ -380,6 +378,7 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             retries=2,
         )(
             node_pool=cluster_info,
+            node_pool_selector=selector,
         )
 
         create_second_node_pool = node_pool.create.override(
@@ -387,11 +386,13 @@ with models.DAG(  # pylint: disable=unexpected-keyword-arg
             retries=2,
         )(
             node_pool=cluster_info_2,
+            node_pool_selector=selector,
         )
 
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -48,7 +48,6 @@ from dags.tpu_observability.utils.time_util import TimeUtil
 from dags.tpu_observability.utils.jobset_util import Workload
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
-
 DAG_ID = "tpu_info_metrics_verification"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
@@ -279,15 +278,6 @@ with models.DAG(
     config = machine.value
 
     with TaskGroup(group_id=f"v{config.tpu_version.value}"):
-      selector = jobset.generate_node_pool_selector(
-          "tpu_info_metrics_verification"
-      )
-
-      jobset_config = jobset.build_jobset_from_gcs_yaml(
-          gcs_path=GCS_JOBSET_CONFIG_PATH,
-          dag_name=DAG_ID,
-      )
-
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
           gcs_path=GCS_CONFIG_PATH,
           dag_name=DAG_ID,
@@ -295,6 +285,14 @@ with models.DAG(
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
       )
+
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
+
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
       cluster_info_2 = copy.deepcopy(cluster_info)
       cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"
@@ -319,6 +317,7 @@ with models.DAG(
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
           node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
@@ -380,6 +379,7 @@ with models.DAG(
       )(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          jobset_name=jobset_name,
       ).as_teardown(
           setups=startup.jobset_start_time
       )
@@ -403,6 +403,7 @@ with models.DAG(
 
       chain(
           selector,
+          jobset_name,
           create_node_pool,
           *startup.tasks,
           all_verification_groups,

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -286,13 +286,13 @@ with models.DAG(
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       cluster_info_2 = copy.deepcopy(cluster_info)
       cluster_info_2.node_pool_name = f"{cluster_info.node_pool_name}-2"

--- a/dags/tpu_observability/tpu_info_metrics_dag.py
+++ b/dags/tpu_observability/tpu_info_metrics_dag.py
@@ -286,7 +286,6 @@ with models.DAG(
       jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
-          node_pool_selector=selector,
       )
 
       cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -295,7 +294,6 @@ with models.DAG(
           is_prod=composer_env.is_prod_env(),
           machine_type=config.machine_version.value,
           tpu_topology=config.tpu_topology,
-          node_pool_selector=selector,
       )
 
       cluster_info_2 = copy.deepcopy(cluster_info)
@@ -306,12 +304,14 @@ with models.DAG(
             task_id="node_pool_1",
         )(
             node_pool=cluster_info,
+            node_pool_selector=selector,
         )
 
         create_second_node_pool = node_pool.create.override(
             task_id="node_pool_2",
         )(
             node_pool=cluster_info_2,
+            node_pool_selector=selector,
         )
 
         _ = [create_first_node_pool, create_second_node_pool]
@@ -319,6 +319,7 @@ with models.DAG(
       startup = jobset.create_jobset_startup_tasks(
           node_pool=cluster_info,
           jobset_config=jobset_config,
+          node_pool_selector=selector,
           workload_type=Workload.JAX_TPU_BENCHMARK,
       )
 

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -35,7 +35,6 @@ from dags.tpu_observability.configs.common import (
 )
 from dags.common.scheduling_helper.scheduling_helper import SchedulingHelper, get_dag_timeout
 
-
 DAG_ID = "tpu_sdk_monitoring_validation"
 DAGRUN_TIMEOUT = get_dag_timeout(DAG_ID)
 SCHEDULE = SchedulingHelper.arrange_schedule_time(DAG_ID)
@@ -126,66 +125,68 @@ with models.DAG(
   for machine in MachineConfigMap:
     config = machine.value
 
-  # Keyword arguments are generated dynamically at runtime (pylint does not
-  # know this signature).
-  with TaskGroup(  # pylint: disable=unexpected-keyword-arg
-      group_id=f"v{config.tpu_version.value}"
-  ):
-    selector = jobset.generate_node_pool_selector(
-        "tpu-sdk-monitoring-validation"
-    )
+    # Keyword arguments are generated dynamically at runtime (pylint does not
+    # know this signature).
+    with TaskGroup(  # pylint: disable=unexpected-keyword-arg
+        group_id=f"v{config.tpu_version.value}"
+    ):
+      cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
+          gcs_path=GCS_CONFIG_PATH,
+          dag_name=DAG_ID,
+          is_prod=composer_env.is_prod_env(),
+          machine_type=config.machine_version.value,
+          tpu_topology=config.tpu_topology,
+      )
 
-    jobset_config = jobset.build_jobset_from_gcs_yaml(
-        gcs_path=GCS_JOBSET_CONFIG_PATH,
-        dag_name=DAG_ID,
-    )
+      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+          gcs_path=GCS_JOBSET_CONFIG_PATH,
+          dag_name=DAG_ID,
+      )
 
-    cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
-        gcs_path=GCS_CONFIG_PATH,
-        dag_name=DAG_ID,
-        is_prod=composer_env.is_prod_env(),
-        machine_type=config.machine_version.value,
-        tpu_topology=config.tpu_topology,
-    )
+      selector = jobset.generate_node_pool_selector(DAG_ID)
+      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
 
-    create_node_pool = node_pool.create.override(task_id="create_node_pool")(
-        node_pool=cluster_info,
-        node_pool_selector=selector,
-    )
+      create_node_pool = node_pool.create.override(task_id="create_node_pool")(
+          node_pool=cluster_info,
+          node_pool_selector=selector,
+      )
 
-    startup = jobset.create_jobset_startup_tasks(
-        node_pool=cluster_info,
-        jobset_config=jobset_config,
-        node_pool_selector=selector,
-        workload_type=Workload.JAX_TPU_BENCHMARK,
-    )
+      startup = jobset.create_jobset_startup_tasks(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+          node_pool_selector=selector,
+          workload_type=Workload.JAX_TPU_BENCHMARK,
+      )
 
-    sdk_validation = (
-        validate_monitoring_sdk.override(task_id="sdk_validation")
-        .partial(info=cluster_info)
-        .expand(pod_name=startup.running_pods)
-    )
+      sdk_validation = (
+          validate_monitoring_sdk.override(task_id="sdk_validation")
+          .partial(info=cluster_info)
+          .expand(pod_name=startup.running_pods)
+      )
 
-    cleanup_workload = jobset.end_workload.override(
-        task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
-    )(
-        node_pool=cluster_info,
-        jobset_config=jobset_config,
-    ).as_teardown(
-        setups=startup.jobset_start_time
-    )
+      cleanup_workload = jobset.end_workload.override(
+          task_id="cleanup_workload", trigger_rule=TriggerRule.ALL_DONE
+      )(
+          node_pool=cluster_info,
+          jobset_config=jobset_config,
+          jobset_name=jobset_name,
+      ).as_teardown(
+          setups=startup.jobset_start_time
+      )
 
-    cleanup_node_pool = node_pool.delete.override(
-        task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
-    )(node_pool=cluster_info).as_teardown(
-        setups=create_node_pool,
-    )
+      cleanup_node_pool = node_pool.delete.override(
+          task_id="cleanup_node_pool", trigger_rule=TriggerRule.ALL_DONE
+      )(node_pool=cluster_info).as_teardown(
+          setups=create_node_pool,
+      )
 
-    chain(
-        selector,
-        create_node_pool,
-        *startup.tasks,
-        sdk_validation,
-        cleanup_workload,
-        cleanup_node_pool,
-    )
+      chain(
+          selector,
+          jobset_name,
+          create_node_pool,
+          *startup.tasks,
+          sdk_validation,
+          cleanup_workload,
+          cleanup_node_pool,
+      )

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -138,7 +138,6 @@ with models.DAG(
     jobset_config = jobset.build_jobset_from_gcs_yaml(
         gcs_path=GCS_JOBSET_CONFIG_PATH,
         dag_name=DAG_ID,
-        node_pool_selector=selector,
     )
 
     cluster_info = node_pool.build_node_pool_info_from_gcs_yaml(
@@ -147,16 +146,17 @@ with models.DAG(
         is_prod=composer_env.is_prod_env(),
         machine_type=config.machine_version.value,
         tpu_topology=config.tpu_topology,
-        node_pool_selector=selector,
     )
 
     create_node_pool = node_pool.create.override(task_id="create_node_pool")(
         node_pool=cluster_info,
+        node_pool_selector=selector,
     )
 
     startup = jobset.create_jobset_startup_tasks(
         node_pool=cluster_info,
         jobset_config=jobset_config,
+        node_pool_selector=selector,
         workload_type=Workload.JAX_TPU_BENCHMARK,
     )
 

--- a/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
+++ b/dags/tpu_observability/tpu_sdk_monitoring_validation_dag.py
@@ -138,13 +138,13 @@ with models.DAG(
           tpu_topology=config.tpu_topology,
       )
 
-      jobset_config, dag_id_prefix = jobset.build_jobset_from_gcs_yaml(
+      jobset_config = jobset.build_jobset_from_gcs_yaml(
           gcs_path=GCS_JOBSET_CONFIG_PATH,
           dag_name=DAG_ID,
       )
 
       selector = jobset.generate_node_pool_selector(DAG_ID)
-      jobset_name = jobset.generate_jobset_name(dag_id_prefix)
+      jobset_name = jobset.generate_jobset_name(jobset_config.dag_id_prefix)
 
       create_node_pool = node_pool.create.override(task_id="create_node_pool")(
           node_pool=cluster_info,

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -280,15 +280,17 @@ class JobSet:
   container_name: str
   image: str
   tpu_cores_per_pod: int
-  node_pool_selector: str
   privileged: bool = False
 
-  def generate_yaml(self, workload_script: Workload) -> str:
+  def generate_yaml(
+      self, workload_script: Workload, node_pool_selector: str = None
+  ) -> str:
     """Generates the final JobSet YAML content.
 
     Args:
         workload_script: A pre-formatted, JSON-escaped string from the Workload
           class.
+        node_pool_selector: The node pool selector to use.
 
     Returns:
         A string containing the complete JobSet YAML.
@@ -296,7 +298,7 @@ class JobSet:
     params = dataclasses.asdict(self)
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
-    params["node_pool_selector"] = self.node_pool_selector or ""
+    params["node_pool_selector"] = node_pool_selector or ""
     params["privileged"] = "true" if self.privileged else "false"
     params["host_pid"] = "true" if self.privileged else "false"
 
@@ -568,7 +570,10 @@ def build_jobset_from_gcs_yaml(
 
 @task
 def run_workload(
-    node_pool: node_pool_info, jobset_config: JobSet, workload_type: Workload
+    node_pool: node_pool_info,
+    jobset_config: JobSet,
+    workload_type: Workload,
+    node_pool_selector: str = None,
 ) -> TimeUtil:
   """
   Applies the specified YAML file to the GKE cluster.
@@ -577,13 +582,17 @@ def run_workload(
     node_pool: Configuration object with cluster details.
     jobset_config: The JobSet object containing YAML configuration.
     workload_type: The workload script to execute.
+    node_pool_selector: The node pool selector to use.
   Returns:
     The UTC time when the workload was started.
   """
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
     env["KUBECONFIG"] = temp_config_file.name
-    yaml_config = jobset_config.generate_yaml(workload_script=workload_type)
+    yaml_config = jobset_config.generate_yaml(
+        workload_script=workload_type,
+        node_pool_selector=node_pool_selector,
+    )
 
     cmd = " && ".join([
         Command.get_credentials_command(node_pool),
@@ -952,6 +961,7 @@ def wait_for_all_pods_running(
 def create_jobset_startup_tasks(
     node_pool: node_pool_info,
     jobset_config: JobSet,
+    node_pool_selector: str = None,
     workload_type: str = Workload.JAX_TPU_BENCHMARK,
 ) -> JobSetStartupOutput:
   """Provides a standardized sequence of tasks for JobSet startup and preparation.
@@ -964,6 +974,7 @@ def create_jobset_startup_tasks(
   Args:
     node_pool: Configuration object containing cluster and project details.
     jobset_config: The JobSet object containing YAML and scaling configurations.
+    node_pool_selector: The node pool selector to use.
     workload_type: The predefined workload script to execute.
 
   Returns:
@@ -974,6 +985,7 @@ def create_jobset_startup_tasks(
       node_pool=node_pool,
       jobset_config=jobset_config,
       workload_type=workload_type,
+      node_pool_selector=node_pool_selector,
   )
 
   running_pods = wait_for_all_pods_running.override(

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -267,7 +267,6 @@ class JobSet:
       standard workloads. Defaults to False.
   """
 
-  jobset_name: str
   namespace: str
   max_restarts: int
   replicated_job_name: str
@@ -283,19 +282,24 @@ class JobSet:
   privileged: bool = False
 
   def generate_yaml(
-      self, workload_script: Workload, node_pool_selector: str = None
+      self,
+      workload_script: Workload,
+      jobset_name: str,
+      node_pool_selector: str = None,
   ) -> str:
     """Generates the final JobSet YAML content.
 
     Args:
         workload_script: A pre-formatted, JSON-escaped string from the Workload
           class.
+        jobset_name: The name of the JobSet.
         node_pool_selector: The node pool selector to use.
 
     Returns:
         A string containing the complete JobSet YAML.
     """
     params = dataclasses.asdict(self)
+    params["jobset_name"] = jobset_name
     params["command"] = ["bash", "-c"]
     params["args"] = workload_script
     params["node_pool_selector"] = node_pool_selector or ""
@@ -514,13 +518,14 @@ def get_running_pods(
   return running_pods
 
 
-def _generate_jobset_name(dag_id_prefix: str) -> str:
-  """
-  Generates a jobset name.
+@task
+def generate_jobset_name(dag_id_prefix: str) -> str:
+  """Generates a jobset name.
 
   Args:
-    dag_id_prefix: The DAG ID to use as a prefix for the jobset name.
-    (should be shorter than 40 characters to fit k8s naming 63 characters limit)
+    dag_id_prefix: The DAG ID to use as a prefix for the jobset name (should be
+      shorter than 40 characters to fit k8s naming 63 characters limit).
+
   Returns:
     A string representing the generated jobset name.
   """
@@ -535,15 +540,16 @@ def build_jobset_from_gcs_yaml(
     gcs_path: str,
     dag_name: str,
     **overrides,
-) -> JobSet:
-  """
-  Builds a JobSet instance by merging YAML defaults and generating
-  a timestamped name based on dag_id_prefix.
+) -> tuple[JobSet, str]:
+  """Builds a JobSet instance by merging YAML defaults.
 
   Args:
     gcs_path: The GCS path to the YAML configuration file.
     dag_name: The name of the DAG to extract specific configurations.
     **overrides: Additional parameters to override default configurations.
+
+  Returns:
+    A tuple containing the JobSet instance and the dag_id_prefix.
   """
   config = gcs.load_yaml_from_gcs(gcs_path)
   known_fields = {f.name for f in dataclasses.fields(JobSet)}
@@ -553,19 +559,18 @@ def build_jobset_from_gcs_yaml(
       if k in known_fields
   }
   dag_cfg = config.get("dag", {}).get(dag_name, {})
-  dag_id_prefix = dag_cfg.get("dag_id_prefix")
+  dag_id_prefix = dag_cfg.get("dag_id_prefix", dag_name)
 
   for k, v in dag_cfg.items():
     if k in known_fields and v is not None:
       merged[k] = v
 
   merged.update({k: v for k, v in overrides.items() if k in known_fields})
-  merged["jobset_name"] = _generate_jobset_name(dag_id_prefix)
 
   logging.info(
-      f"Final JobSet '{merged['jobset_name']}' created for DAG '{dag_name}'"
+      f"Final JobSet config created for DAG '{dag_name}'"
   )
-  return JobSet(**merged)
+  return JobSet(**merged), dag_id_prefix
 
 
 @task
@@ -573,6 +578,7 @@ def run_workload(
     node_pool: node_pool_info,
     jobset_config: JobSet,
     workload_type: Workload,
+    jobset_name: str,
     node_pool_selector: str = None,
 ) -> TimeUtil:
   """
@@ -582,6 +588,7 @@ def run_workload(
     node_pool: Configuration object with cluster details.
     jobset_config: The JobSet object containing YAML configuration.
     workload_type: The workload script to execute.
+    jobset_name: The name of the JobSet.
     node_pool_selector: The node pool selector to use.
   Returns:
     The UTC time when the workload was started.
@@ -591,6 +598,7 @@ def run_workload(
     env["KUBECONFIG"] = temp_config_file.name
     yaml_config = jobset_config.generate_yaml(
         workload_script=workload_type,
+        jobset_name=jobset_name,
         node_pool_selector=node_pool_selector,
     )
 
@@ -608,12 +616,12 @@ def run_workload(
     #   {jobset_name}-{replicated_job_name}-{job-index}-{pod-index}-{random}
     # The jobset_name prefix is stable across pod recreations, so a regex
     # pattern is more reliable than an exact pod name list.
-    pod_name_pattern = f"{jobset_config.jobset_name}.*"
+    pod_name_pattern = f"{jobset_name}.*"
     jobset_metadata = {
         "project_id": node_pool.project_id,
         "cluster_name": node_pool.cluster_name,
         "node_pool_name": node_pool.node_pool_name,
-        "jobset_name": jobset_config.jobset_name,
+        "jobset_name": jobset_name,
         "pod_name_pattern": pod_name_pattern,
     }
     composer.log_metadata_for_xlml_dashboard(jobset_metadata)
@@ -625,7 +633,9 @@ def run_workload(
 
 
 @task
-def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
+def end_workload(
+    node_pool: node_pool_info, jobset_config: JobSet, jobset_name: str
+):
   """
   Deletes all JobSets from the GKE cluster to clean up resources.
 
@@ -635,8 +645,8 @@ def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
 
   Args:
     node_pool: Configuration object with cluster details.
+    jobset_config: The JobSet object containing configuration details.
     jobset_name: The name of the JobSet to delete.
-    namespace: The Kubernetes namespace to delete the JobSet from.
   """
   with tempfile.NamedTemporaryFile() as temp_config_file:
     env = os.environ.copy()
@@ -646,7 +656,7 @@ def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
         Command.get_credentials_command(node_pool),
         Command.k8s_delete_jobset_command(
             temp_config_file.name,
-            jobset_config.jobset_name,
+            jobset_name,
             jobset_config.namespace,
         ),
     ])
@@ -656,7 +666,7 @@ def end_workload(node_pool: node_pool_info, jobset_config: JobSet):
 
 @task
 def list_pod_names(
-    node_pool: node_pool_info, jobset_config: JobSet
+    node_pool: node_pool_info, jobset_config: JobSet, jobset_name: str
 ) -> list[str]:
   """
   Lists the names of all active pods in the specified namespace for a given
@@ -669,6 +679,7 @@ def list_pod_names(
   Args:
     node_pool: Configuration object with cluster details.
     jobset_config: The JobSet object containing configuration details.
+    jobset_name: The name of the JobSet.
 
   Returns:
     A list of strings representing the names of the active pods.
@@ -684,7 +695,7 @@ def list_pod_names(
     cmd = " && ".join([
         Command.get_credentials_command(node_pool),
         Command.k8s_get_pod_name_command(
-            jobset_config.jobset_name,
+            jobset_name,
             jobset_config.namespace,
             Command.K8sGetPodsOutput.POD_NAME,
         ),
@@ -704,6 +715,7 @@ def list_pod_names(
 def delete_one_random_pod(
     node_pool: node_pool_info,
     jobset_config: JobSet,
+    jobset_name: str,
 ):
   """
   Randomly selects and deletes one pod that is currently in the "running" state.
@@ -715,8 +727,8 @@ def delete_one_random_pod(
   Args:
     node_pool: The Info object containing the cluster information needed for
       the kubernetes API to connect to it.
-    namespace: The kubernetes namespace where the target pod resides.
-      Defaults to "default".
+    jobset_config: The JobSet object containing configuration details.
+    jobset_name: The name of the JobSet.
 
   Raises:
     AirflowFailException: If no running pods are found in the specified
@@ -724,7 +736,7 @@ def delete_one_random_pod(
   """
   running_pods = get_running_pods(
       node_pool=node_pool,
-      jobset_name=jobset_config.jobset_name,
+      jobset_name=jobset_name,
       namespace=jobset_config.namespace,
   )
   if not running_pods:
@@ -757,11 +769,12 @@ def delete_one_random_pod(
 def draw_random_pod(
     node_pool: node_pool_info,
     jobset_config: JobSet,
+    jobset_name: str,
 ) -> str:
   """Randomly selects one running pod from the specified JobSet pool."""
   running_pods = get_running_pods(
       node_pool=node_pool,
-      jobset_name=jobset_config.jobset_name,
+      jobset_name=jobset_name,
       namespace=jobset_config.namespace,
   )
   if not running_pods:
@@ -886,7 +899,7 @@ def wait_for_jobset_started(
 @task.sensor(poke_interval=60, timeout=3600, mode="poke")
 def wait_for_jobset_ttr_to_be_found(
     node_pool: node_pool_info,
-    jobset_config: JobSet,
+    jobset_name: str,
     start_time: TimeUtil = None,
 ) -> bool:
   """Polls the jobset time-to-recover metric.
@@ -900,8 +913,7 @@ def wait_for_jobset_ttr_to_be_found(
 
   Args:
     node_pool (Info): An instance of the Info class containing GKE metadata.
-    jobset_config: An instance of the JobSet class representing the jobset
-      configuration.
+    jobset_name: The name of the JobSet.
     start_time (TimeUtil, optional): The UTC timestamp to start polling from.
     If not provided, defaults to 60 minutes before the current time.
 
@@ -917,7 +929,7 @@ def wait_for_jobset_ttr_to_be_found(
       filter_str=(
           'metric.type="kubernetes.io/jobset/times_to_recover" '
           f'resource.labels.cluster_name="{node_pool.cluster_name}" '
-          f'resource.labels.entity_name="{jobset_config.jobset_name}"'
+          f'resource.labels.entity_name="{jobset_name}"'
       ),
       start_time=query_start,
       end_time=TimeUtil.now(),
@@ -929,13 +941,14 @@ def wait_for_jobset_ttr_to_be_found(
 
 @task.sensor(poke_interval=30, timeout=600, mode="poke")
 def wait_for_all_pods_running(
-    node_pool: node_pool_info, jobset_config: JobSet
+    node_pool: node_pool_info, jobset_config: JobSet, jobset_name: str
 ) -> PokeReturnValue:
   """Waits for all pods to be running and returns the pod names.
 
   Args:
     node_pool: The Info object containing the cluster information.
     jobset_config: The JobSet configuration.
+    jobset_name: The name of the JobSet.
 
   Returns:
     PokeReturnValue with is_done=True and pod names when all pods are running,
@@ -943,7 +956,7 @@ def wait_for_all_pods_running(
   """
   running_pods = get_running_pods(
       node_pool=node_pool,
-      jobset_name=jobset_config.jobset_name,
+      jobset_name=jobset_name,
       namespace="default",
   )
   num_pods = jobset_config.replicas * jobset_config.parallelism
@@ -951,7 +964,7 @@ def wait_for_all_pods_running(
     logging.info(
         "All %d pods are running for JobSet '%s': %s",
         num_pods,
-        jobset_config.jobset_name,
+        jobset_name,
         running_pods,
     )
     return PokeReturnValue(is_done=True, xcom_value=running_pods)
@@ -961,19 +974,23 @@ def wait_for_all_pods_running(
 def create_jobset_startup_tasks(
     node_pool: node_pool_info,
     jobset_config: JobSet,
+    jobset_name: str,
     node_pool_selector: str = None,
     workload_type: str = Workload.JAX_TPU_BENCHMARK,
 ) -> JobSetStartupOutput:
   """Provides a standardized sequence of tasks for JobSet startup and preparation.
 
-  This helper encapsulates and chains the three essential steps for a stable JobSet:
+  This helper encapsulates and chains the three essential steps for a stable
+  JobSet:
   1. run_workload: Applies the JobSet YAML to the cluster.
-  2. wait_for_all_pods_running: Polls until all worker pods are in 'Running' state.
+  2. wait_for_all_pods_running: Polls until all worker pods are in 'Running'
+  state.
   3. wait_for_job_start: Ensures the JAX/workload initialization is complete.
 
   Args:
     node_pool: Configuration object containing cluster and project details.
     jobset_config: The JobSet object containing YAML and scaling configurations.
+    jobset_name: The name of the JobSet.
     node_pool_selector: The node pool selector to use.
     workload_type: The predefined workload script to execute.
 
@@ -985,6 +1002,7 @@ def create_jobset_startup_tasks(
       node_pool=node_pool,
       jobset_config=jobset_config,
       workload_type=workload_type,
+      jobset_name=jobset_name,
       node_pool_selector=node_pool_selector,
   )
 
@@ -993,6 +1011,7 @@ def create_jobset_startup_tasks(
   )(
       node_pool=node_pool,
       jobset_config=jobset_config,
+      jobset_name=jobset_name,
   )
 
   wait_start = wait_for_jobset_started.override(task_id="wait_for_job_start")(
@@ -1037,14 +1056,14 @@ def query_uptime_metrics(
 @task.sensor(poke_interval=30, timeout=3600, mode="poke")
 def wait_for_jobset_uptime_data(
     node_pool: node_pool_info,
-    jobset_config: JobSet,
+    jobset_name: str,
     jobset_apply_time: TimeUtil,
 ):
   """Verify uptime data exists after jobset application."""
   start_time = jobset_apply_time
   end_time = TimeUtil.now()
   data = query_uptime_metrics(
-      node_pool, jobset_config.jobset_name, start_time, end_time
+      node_pool, jobset_name, start_time, end_time
   )
 
   logging.info(f"Uptime data query result: {data}")
@@ -1056,7 +1075,7 @@ def wait_for_jobset_uptime_data(
 @task.sensor(poke_interval=30, timeout=360, mode="poke")
 def ensure_no_jobset_uptime_data(
     node_pool: node_pool_info,
-    jobset_config: JobSet,
+    jobset_name: str,
     jobset_clear_time: TimeUtil,
     wait_time_seconds: int,
 ):
@@ -1064,7 +1083,7 @@ def ensure_no_jobset_uptime_data(
   start_time = jobset_clear_time
   now = TimeUtil.now()
   data = query_uptime_metrics(
-      node_pool, jobset_config.jobset_name, start_time, now
+      node_pool, jobset_name, start_time, now
   )
 
   logging.info(f"Uptime data query result: {data}")

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -570,9 +570,7 @@ def build_jobset_from_gcs_yaml(
 
   merged.update({k: v for k, v in overrides.items() if k in known_fields})
 
-  logging.info(
-      f"Final JobSet config created for DAG '{dag_name}'"
-  )
+  logging.info(f"Final JobSet config created for DAG '{dag_name}'")
   return JobSet(**merged)
 
 
@@ -1065,9 +1063,7 @@ def wait_for_jobset_uptime_data(
   """Verify uptime data exists after jobset application."""
   start_time = jobset_apply_time
   end_time = TimeUtil.now()
-  data = query_uptime_metrics(
-      node_pool, jobset_name, start_time, end_time
-  )
+  data = query_uptime_metrics(node_pool, jobset_name, start_time, end_time)
 
   logging.info(f"Uptime data query result: {data}")
   if len(data) > 0:
@@ -1085,9 +1081,7 @@ def ensure_no_jobset_uptime_data(
   """Ensure no uptime data is recorded after jobset deletion."""
   start_time = jobset_clear_time
   now = TimeUtil.now()
-  data = query_uptime_metrics(
-      node_pool, jobset_name, start_time, now
-  )
+  data = query_uptime_metrics(node_pool, jobset_name, start_time, now)
 
   logging.info(f"Uptime data query result: {data}")
   if len(data) > 0:

--- a/dags/tpu_observability/utils/jobset_util.py
+++ b/dags/tpu_observability/utils/jobset_util.py
@@ -280,6 +280,7 @@ class JobSet:
   image: str
   tpu_cores_per_pod: int
   privileged: bool = False
+  dag_id_prefix: str = ""
 
   def generate_yaml(
       self,
@@ -540,7 +541,7 @@ def build_jobset_from_gcs_yaml(
     gcs_path: str,
     dag_name: str,
     **overrides,
-) -> tuple[JobSet, str]:
+) -> JobSet:
   """Builds a JobSet instance by merging YAML defaults.
 
   Args:
@@ -549,7 +550,7 @@ def build_jobset_from_gcs_yaml(
     **overrides: Additional parameters to override default configurations.
 
   Returns:
-    A tuple containing the JobSet instance and the dag_id_prefix.
+    The JobSet instance.
   """
   config = gcs.load_yaml_from_gcs(gcs_path)
   known_fields = {f.name for f in dataclasses.fields(JobSet)}
@@ -565,12 +566,14 @@ def build_jobset_from_gcs_yaml(
     if k in known_fields and v is not None:
       merged[k] = v
 
+  merged["dag_id_prefix"] = dag_id_prefix
+
   merged.update({k: v for k, v in overrides.items() if k in known_fields})
 
   logging.info(
       f"Final JobSet config created for DAG '{dag_name}'"
   )
-  return JobSet(**merged), dag_id_prefix
+  return JobSet(**merged)
 
 
 @task

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -163,13 +163,14 @@ def _node_pool_exists(node_pool: Info) -> bool:
 @task
 def create(
     node_pool: Info,
-    node_pool_selector: str,
+    node_pool_selector: str = None,
     ignore_failure: bool = False,
 ) -> None:
   """Creates a GKE node pool by the given node pool information.
 
   Args:
     node_pool: The node pool configuration.
+    node_pool_selector: The selector for the node pool.
     ignore_failure: If True, command failures are ignored.
   """
 
@@ -201,6 +202,8 @@ def create(
 
   if node_pool.reservation:
     command += f" --reservation-affinity=specific --reservation={node_pool.reservation}"
+  else:
+    command += " --spot "
 
   if node_pool_selector:
     command += f" --node-labels={NODE_POOL_SELECTOR_KEY}={node_pool_selector}"

--- a/dags/tpu_observability/utils/node_pool_util.py
+++ b/dags/tpu_observability/utils/node_pool_util.py
@@ -83,7 +83,6 @@ class Info:
   num_nodes: int = None
   tpu_topology: str = None
   reservation: str = None
-  node_pool_selector: str = None
 
 
 def build_node_pool_info_from_gcs_yaml(
@@ -164,6 +163,7 @@ def _node_pool_exists(node_pool: Info) -> bool:
 @task
 def create(
     node_pool: Info,
+    node_pool_selector: str,
     ignore_failure: bool = False,
 ) -> None:
   """Creates a GKE node pool by the given node pool information.
@@ -202,8 +202,8 @@ def create(
   if node_pool.reservation:
     command += f" --reservation-affinity=specific --reservation={node_pool.reservation}"
 
-  if node_pool.node_pool_selector:
-    command += f" --node-labels={NODE_POOL_SELECTOR_KEY}={node_pool.node_pool_selector}"
+  if node_pool_selector:
+    command += f" --node-labels={NODE_POOL_SELECTOR_KEY}={node_pool_selector}"
 
   if ignore_failure:
     command += "2>&1 || true "


### PR DESCRIPTION
# Description

This PR refactors the TPU observability DAGs to decouple dynamic runtime configurations ( node_pool_selector  and  jobset_name ) from the static configuration objects ( Info and JobSet dataclasses).

By passing these parameters directly to the downstream tasks that require them, we improve the flexibility and maintainability of the DAGs. Additionally, task definitions have been reordered for consistency, and indentation bugs in some DAGs have been fixed.

# Key Changes
## 1. Nodepool Selector Refactoring
• Decoupled Selector: Removed  node_pool_selector  from  Info  and  JobSet  dataclasses. It is now passed directly to tasks (e.g.,  node_pool.create ,  jobset.run_workload ).
• Standardized Arguments: Updated all  jobset.generate_node_pool_selector(...)  calls to use the  DAG_ID  variable instead of hardcoded string literals (e.g.,  "jobset-ttr-kill-process" ).

## 2. JobSet Name Refactoring
• Decoupled JobSet Name: Removed  jobset_name  from  JobSet  dataclass.
• New Task:  jobset.build_jobset_from_gcs_yaml  now returns  (jobset_config, dag_id_prefix) . A new task jobset.generate_jobset_name(dag_id_prefix)  is used to generate the jobset name.
• Direct Passing:  jobset_name  is now passed directly to downstream tasks (e.g.,  run_workload , wait_for_all_pods_running ,  end_workload ).

# Tests
## test 1
  - Dag Name : tpu_info_format_validation_dag
  - Airflow test results: https://b371d513bb74418681c3aab7b27bbf12-dot-us-east1.composer.googleusercontent.com/dags/tpu_info_format_validation_dag/grid
## test 2
  - Dag Name : jobset_ttr_kill_process
  - Airflow test results: https://b371d513bb74418681c3aab7b27bbf12-dot-us-east1.composer.googleusercontent.com/dags/jobset_ttr_kill_process/grid

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.