### PR TITLE
feat: Add Llama3.1-70b and Gemma4-26b E2E training pipeline

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -115,7 +115,7 @@ with models.DAG(
           },
       },
   }
-  # pylint: disable=line-too-long
+  # pylint: enable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
@@ -128,7 +128,7 @@ with models.DAG(
       ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
       convert_to_maxtext_task = gke_config.get_gke_config(
           time_out_in_min=60,
-          test_name=f"convert-to-maxtext",
+          test_name="convert-to-maxtext",
           run_model_cmds=convert_to_maxtext_cmd,
           docker_image="{{ params.docker_image }}",
           cluster=XpkClusters.TPU_V5P_8_CLUSTER_V2,

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -79,15 +79,51 @@ with models.DAG(
               },
           },
       },
+      "gemma4-26b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/sft/{run_name}/checkpoints/5/model_params",
+                  "to_hf_flags": "false false",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/rl/{run_name}/checkpoints/actor/5/model_params",
+                  "to_hf_flags": "false false",
+              },
+          },
+      },
+      "llama3_1_70b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
+          },
+          "post_training": {
+              "sft": {
+                  "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_sft.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/sft/{run_name}/checkpoints/5/model_params",
+              },
+              "rl": {
+                  "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_rl.sh",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/rl/{run_name}/checkpoints/actor/5/model_params",
+              },
+          },
+      },
   }
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
       run_name = "post-{{ ts_nodash }}"
 
-      convert_to_maxtext_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-          f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",
-      )
+      convert_to_maxtext_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
       convert_to_maxtext_task = gke_config.get_gke_config(
           time_out_in_min=60,
           test_name=f"convert-to-maxtext",
@@ -134,7 +170,11 @@ with models.DAG(
           model_path = mode_test_config["maxtext_ckpt_path"].format(
               run_name=run_name
           )
-          convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+          convert_to_huggingface_cmd = (
+              f"export HF_TOKEN={HF_TOKEN}",
+              'export HF_HOME="/dev/shm/hf_cache"',
+              'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+          ) + (
               f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -53,6 +53,7 @@ with models.DAG(
         ),
     },
 ) as dag:
+  # pylint: disable=line-too-long
   test_models = {
       "gemma3-4b": {
           "checkpoint_conversion": {
@@ -114,6 +115,7 @@ with models.DAG(
           },
       },
   }
+  # pylint: disable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
@@ -175,7 +177,8 @@ with models.DAG(
               'export HF_HOME="/dev/shm/hf_cache"',
               'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
           ) + (
-              f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path} {to_hf_flags}",
+              f"{test_config['checkpoint_conversion']['to_huggingface']} "
+              f"{run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(
               time_out_in_min=60,

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -54,15 +54,37 @@ with models.DAG(
               "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/train/{run_name}/checkpoints/4/items",
           },
       },
+      "gemma4-26b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/gemma4/26b/test_gemma4.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma4-26b/train/{run_name}/checkpoints/4/items",
+          },
+      },
+      "llama3_1-70b": {
+          "checkpoint_conversion": {
+              "to_maxtext": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_mt.sh",
+              "to_huggingface": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b_to_hf.sh",
+          },
+          "training": {
+              "command": "bash tests/end_to_end/tpu/llama3.1/70b/test_llama3.1_70b.sh",
+              "maxtext_ckpt_path": "gs://runner-maxtext-logs/llama3.1-70b/train/{run_name}/checkpoints/4/items",
+          },
+      },
   }
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
       run_name = "pre-{{ ts_nodash }}"
 
-      convert_to_maxtext_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-          f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",
-      )
+      convert_to_maxtext_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (f"{test_config['checkpoint_conversion']['to_maxtext']} {run_name}",)
       convert_to_maxtext_task = gke_config.get_gke_config(
           time_out_in_min=60,
           test_name="convert-to-maxtext",
@@ -87,7 +109,11 @@ with models.DAG(
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
       )
-      convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+      convert_to_huggingface_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          'export HF_HOME="/dev/shm/hf_cache"',
+          'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
+      ) + (
           f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path}",
       )
       convert_to_huggingface_task = gke_config.get_gke_config(

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -76,7 +76,7 @@ with models.DAG(
           },
       },
   }
-  # pylint: disable=line-too-long
+  # pylint: enable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -43,6 +43,7 @@ with models.DAG(
         ),
     },
 ) as dag:
+  # pylint: disable=line-too-long
   test_models = {
       "gemma3-4b": {
           "checkpoint_conversion": {
@@ -75,6 +76,7 @@ with models.DAG(
           },
       },
   }
+  # pylint: disable=line-too-long
 
   for model, test_config in test_models.items():
     with TaskGroup(group_id=model) as model_group:
@@ -114,7 +116,8 @@ with models.DAG(
           'export HF_HOME="/dev/shm/hf_cache"',
           'export LIBTPU_INIT_ARGS="--xla_tpu_scoped_vmem_limit_kib=20480"',
       ) + (
-          f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path}",
+          f"{test_config['checkpoint_conversion']['to_huggingface']} "
+          f"{run_name} {model_path}",
       )
       convert_to_huggingface_task = gke_config.get_gke_config(
           time_out_in_min=60,

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -22,14 +22,37 @@ FOLDERS_TO_FORMAT=("dags" "xlml")
 echo "[code-style] Running Semgrep static analysis..."
 semgrep --config scripts/semgrep-rules.yaml --error
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."


### PR DESCRIPTION
# Description
According to this ticket: [b/528418808](https://b.corp.google.com/issues/528418808) and [b/528440611](https://b.corp.google.com/issues/528440611)
This PR introduces the end-to-end (E2E) pre-training validation pipeline for the **Llama3.1-70b** and **Gemma4-26b**model in MaxText.

# Tests

Do the manual tests with xpk.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.