### PR TITLE
Maxtext/user/ryan/revise xpktask

### DIFF
--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ Used upon library upgrades.
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -54,7 +54,11 @@ with models.DAG(
     for model_size in models:
       run_cmds = [
           "pip show aqtp",
-          f"bash src/maxtext/configs/tpu/{tpu}/{model_size}.sh EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} PLATFORM=gke",
+          (
+              f"bash src/maxtext/configs/tpu/{tpu}/{model_size}.sh "
+              f"EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} "
+              "PLATFORM=gke"
+          ),
       ]
 
       tests.extend(

--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -98,4 +98,4 @@ with models.DAG(
 
   # Run jobs
   for test in tests:
-    test.run_with_run_name_generation()
+    test.run(generate_run_name=True)

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -14,7 +14,7 @@
 
 """
 An example DAG to extract profile metrics from pretraining mixtral-8x7b model on 1xv4-128.
-Profile extraction can be easily integrated with gke_config + run_with_run_name_generation.
+Profile extraction can be easily integrated with gke_config + run(generate_run_name=True).
 """
 
 import datetime
@@ -88,7 +88,7 @@ with models.DAG(
 ) as dag:
   for run_name, test_scripts_details in test_models_tpu.items():
     for image in docker_image.keys():
-      # file_location: pass in base_output_directory, will be altered in `run_with_run_name_generation`
+      # file_location: pass in base_output_directory, will be altered in `run(generate_run_name=True)`
       job_metric_config = metric_config.MetricConfig()
       # optionally, add tensorboard metrics
       job_metric_config.tensorboard_summary = metric_config.SummaryConfig(
@@ -114,4 +114,4 @@ with models.DAG(
           test_owner=test_owner.SHUNING_J,
           cluster=test_scripts_details["cluster"],
           user_specified_job_metric_config=job_metric_config,  # customize config
-      ).run_with_run_name_generation(run_name_env="RUN_NAME")
+      ).run(generate_run_name=True, run_name_env="RUN_NAME")

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-An example DAG to extract profile metrics from pretraining mixtral-8x7b model on 1xv4-128.
-Profile extraction can be easily integrated with gke_config + run(generate_run_name=True).
+"""An example DAG to extract profile metrics.
+
+Pretraining mixtral-8x7b model on 1xv4-128.
+Profile extraction can be easily integrated with gke_config +
+run(generate_run_name=True).
 """
 
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters
 from dags.multipod.configs import gke_config
 from xlml.apis import metric_config
 
@@ -28,33 +30,54 @@ SCHEDULED_TIME = None
 BASE_OUTPUT_PATH = "gs://runner-maxtext-logs"
 
 docker_image = {
-    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-20",
+    "stable": (
+        "gcr.io/tpu-prod-env-multipod/"
+        "maxtext_jax_stable_stack:2025-05-20"
+    ),
 }
 
 base_command = (
     f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-    + "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+    "python3 -m maxtext.trainers.pre_train.train "
+    "src/maxtext/configs/base.yml "
+    "base_output_directory=gs://runner-maxtext-logs "
+    "run_name=${RUN_NAME} "
+    "model_name=mixtral-8x7b "
+    "tokenizer_path=assets/tokenizer.mistral-v1 "
+    "dataset_path=gs://maxtext-dataset "
+    "per_device_batch_size=4 "
+    "enable_checkpointing=false "
+    "ici_fsdp_parallelism=-1 "
+    "max_target_length=1024 "
+    "async_checkpointing=false "
+    "attention=flash "
+    "dtype=bfloat16 "
+    "weight_dtype=bfloat16"
 )
 
 test_models_tpu = {
     # use: upload single profile from the first host, extract profile
-    # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+    # add profiler config: ensure steps >
+    # skip_first_n_steps_for_profiler + profiler_steps
     "mixtral-8x7b_pretraining-megablox_config-true_upload-one": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
             base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+            + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3",
         ],
     },
     # use: upload profiles from all hosts, extract one of the profiles
-    # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+    # add profiler config: ensure steps >
+    # skip_first_n_steps_for_profiler + profiler_steps
     "mixtral-8x7b_pretraining-megablox_config-true_upload-all": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
             base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 upload_all_profiler_results=True",
+            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 "
+            "profiler_steps=3 upload_all_profiler_results=True",
         ],
     },
     # testing: handle edge case, attempt to extract, find no match, proceed to post_process without error
@@ -65,13 +88,15 @@ test_models_tpu = {
             base_command + " steps=10",
         ],
     },
-    # testing: not generate profile location, not extract profile in post_process
+    # testing: not generate profile location, not extract profile in
+    # post_process
     "testing_config-false_upload-one": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
             base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 "
+            "profiler_steps=3",
         ],
         "not_add_profile_config": True,
     },
@@ -87,8 +112,9 @@ with models.DAG(
     concurrency=2,
 ) as dag:
   for run_name, test_scripts_details in test_models_tpu.items():
-    for image in docker_image.keys():
-      # file_location: pass in base_output_directory, will be altered in `run(generate_run_name=True)`
+    for image in docker_image:
+      # file_location: pass in base_output_directory, will be altered in
+      # `run(generate_run_name=True)`
       job_metric_config = metric_config.MetricConfig()
       # optionally, add tensorboard metrics
       job_metric_config.tensorboard_summary = metric_config.SummaryConfig(

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -31,8 +31,7 @@ BASE_OUTPUT_PATH = "gs://runner-maxtext-logs"
 
 docker_image = {
     "stable": (
-        "gcr.io/tpu-prod-env-multipod/"
-        "maxtext_jax_stable_stack:2025-05-20"
+        "gcr.io/tpu-prod-env-multipod/" "maxtext_jax_stable_stack:2025-05-20"
     ),
 }
 
@@ -63,8 +62,7 @@ test_models_tpu = {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane "
+            base_command + " steps=10 profiler=xplane "
             "skip_first_n_steps_for_profiler=5 profiler_steps=3",
         ],
     },

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -57,4 +57,4 @@ with models.DAG(
 
   # Run jobs
   for test in maxtext_sweep_gke_test:
-    test.run_with_run_name_generation()
+    test.run(generate_run_name=True)

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ on 1xv4-128.
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -37,7 +37,13 @@ with models.DAG(
   # MaxText set up and run commands
   base_output_directory = "gs://maxtext-experiments-multipod"
   base_run_model_cmds = [
-      f"python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory={base_output_directory} dataset_path=gs://max-datasets-rogue enable_checkpointing=false global_parameter_scale=16 steps=10",
+      (
+          "python3 -m maxtext.trainers.pre_train.train "
+          "src/maxtext/configs/base.yml "
+          f"base_output_directory={base_output_directory} "
+          "dataset_path=gs://max-datasets-rogue "
+          "enable_checkpointing=false global_parameter_scale=16 steps=10"
+      ),
   ]
 
   # Get list of MaxText GKE XPK jobs

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -84,7 +84,8 @@ with models.DAG(
 
   sequential_tests = []
   for test_name, run_command in convergence_tests.items():
-    # The grain dataset takes longer to run, so we give it a longer timeout. The other tests are expected to complete within 5 hours.
+    # The grain dataset takes longer to run, so we give it a longer timeout.
+    # The other tests are expected to complete within 5 hours.
     timeout_in_min = 360 if test_name == "maxtext-convergence-grain" else 300
 
     test_task = gke_config.get_gke_config(

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -96,7 +96,7 @@ with models.DAG(
         test_owner=test_owner.MATT_D,
         base_output_directory=base_output_directory,
         metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
-    ).run_with_run_name_generation()
+    ).run(generate_run_name=True)
     if test_name not in parallel_test_names:
       sequential_tests.append(test_task)
 

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -581,7 +581,7 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
-      ).as_teardown(setups=launch_workload)
+      ).as_teardown(setups=launch_workload, on_failure_fail_dagrun=True)
 
       if expect_reach_to_step is not None:
         run_node_interruption = xpk.delete_node.override(

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -42,7 +42,7 @@ class BaseTask(abc.ABC):
     Returns:
       A DAG node that executes this test.
     """
-    ...
+    pass
 
   def run_with_quarantine(self, quarantine_task_group):
     """Run a test job. If the test job is flaky, wrap it in a special task grop.
@@ -67,7 +67,7 @@ def run_queued_resource_test(
     tpu_name_env_var: bool = False,
     all_workers: bool = True,
     skip_post_process: bool = False,
-    custom_env: dict[str, str] = {},
+    custom_env: Optional[dict[str, str]] = None,
 ):
   """This is a class to set up tasks for TPU provisioned by Queued Resource.
 
@@ -93,6 +93,9 @@ def run_queued_resource_test(
       A task group with the following tasks chained: provision, run_model,
       post_process and clean_up.
   """
+
+  if custom_env is None:
+    custom_env = {}
 
   with TaskGroup(
       group_id=task_test_config.benchmark_id, prefix_group_id=True
@@ -324,7 +327,8 @@ class XpkTask(BaseTask):
   task_gcp_config: gcp_config.GCPConfig
   task_metric_config: Optional[metric_config.MetricConfig] = None
   workload_provision_timeout: datetime.timedelta = datetime.timedelta(
-      # Set the provision timeout from 300 to 60 minutes for decreasing the duration of failed tasks
+      # Set the provision timeout from 300 to 60 minutes for decreasing the
+      # duration of failed tasks
       minutes=60
   )
 
@@ -658,7 +662,8 @@ class XpkTask(BaseTask):
       )
       _ = run_workload >> wait_for_workload_start
 
-      # If we are expecting to reach a step (Node Interruption path), add the monitoring tasks
+      # If we are expecting to reach a step (Node Interruption path), add the
+      # monitoring tasks
       if expect_reach_to_step is not None:
         wait_for_workload_to_reach_step = (
             xpk.wait_for_workload_reach_step.override(
@@ -675,7 +680,9 @@ class XpkTask(BaseTask):
         wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
             task_id=task_id_wait_file_exist
         )(
-            file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
+            file_path=(
+                f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt"
+            ),
         )
         task_id_do_nothing = "do_nothing"
         do_nothing = EmptyOperator(task_id=task_id_do_nothing)

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -408,208 +408,208 @@ class XpkTask(BaseTask):
       post_process.
     """
     with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      run_model, gcs_path = self.run_model_with_node_interruption(
+      run_model, gcs_path = self.run_model(
           gcs_location=gcs_location,
           use_vertex_tensorboard=use_vertex_tensorboard,
-          expect_reach_to_step=expect_reach_to_step,
           use_pathways=use_pathways,
           ramdisk_directory=ramdisk_directory,
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
-          last_node=last_node,
           max_restart=max_restart,
+          expect_reach_to_step=expect_reach_to_step,
+          last_node=last_node,
           check_file_exists=check_file_exists,
       )
       if not skip_post_process:
         _ = run_model >> self.post_process(gcs_path)
     return group
 
-  def run_model_with_node_interruption(
-      self,
-      *,
-      gcs_location: Optional[airflow.XComArg] = None,
-      use_vertex_tensorboard: bool = False,
-      expect_reach_to_step: int,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      last_node: bool = False,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
-  ) -> DAGNode:
-    """Run the TPU/GPU test in `task_test_config` using xpk.
+  # def run_model_with_node_interruption(
+  #     self,
+  #     *,
+  #     gcs_location: Optional[airflow.XComArg] = None,
+  #     use_vertex_tensorboard: bool = False,
+  #     expect_reach_to_step: int,
+  #     use_pathways: bool = False,
+  #     ramdisk_directory: str = "",
+  #     mtc_enabled: bool = False,
+  #     xpk_branch: str = xpk.MAIN_BRANCH,
+  #     last_node: bool = False,
+  #     max_restart: int = 0,
+  #     check_file_exists: bool = False,
+  # ) -> DAGNode:
+  #   """Run the TPU/GPU test in `task_test_config` using xpk.
 
-      Different behavior for testing node interruption.
+  #     Different behavior for testing node interruption.
 
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
-      expect_reach_to_step: The training step at which the node interruption
-        should be triggered.
-      use_pathways: Set to True to use the Pathways execution framework.
-      ramdisk_directory: The directory for enabling emergency checkpointing.
-      mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
-      xpk_branch: The specific git branch of the xpk tool to use.
-      last_node: If True, the interruption will target the last node in the
-        workload; otherwise, it targets the first node.
-      max_restart: By default, this is 0.
-        This will restart the job with flag "--max-restarts"
-      check_file_exists: By default, this is False. If set to True,
-        task branch task_path_decider will be performed.
-    Returns:
-      A DAG node that executes the model test.
-    """
-    with TaskGroup(group_id="run_model") as group:
-      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      if gcs_location:
-        gcs_path = gcs_location
-      else:
-        gcs_path = name_format.generate_gcs_folder_location(
-            self.task_test_config.gcs_subfolder,
-            self.task_test_config.benchmark_id,
-        )
+  #   Attributes:
+  #     gcs_location: GCS path for all artifacts of the test.
+  #     use_vertex_tensorboard: Set to True to view workload data on
+  #       Vertex AI Tensorboard.
+  #     expect_reach_to_step: The training step at which the node interruption
+  #       should be triggered.
+  #     use_pathways: Set to True to use the Pathways execution framework.
+  #     ramdisk_directory: The directory for enabling emergency checkpointing.
+  #     mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
+  #     xpk_branch: The specific git branch of the xpk tool to use.
+  #     last_node: If True, the interruption will target the last node in the
+  #       workload; otherwise, it targets the first node.
+  #     max_restart: By default, this is 0.
+  #       This will restart the job with flag "--max-restarts"
+  #     check_file_exists: By default, this is False. If set to True,
+  #       task branch task_path_decider will be performed.
+  #   Returns:
+  #     A DAG node that executes the model test.
+  #   """
+  #   with TaskGroup(group_id="run_model") as group:
+  #     workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+  #     if gcs_location:
+  #       gcs_path = gcs_location
+  #     else:
+  #       gcs_path = name_format.generate_gcs_folder_location(
+  #           self.task_test_config.gcs_subfolder,
+  #           self.task_test_config.benchmark_id,
+  #       )
 
-      launch_workload_and_wait_for_reach_step = (
-          self.launch_workload_with_node_reach_to_step(
-              workload_id,
-              gcs_path,
-              expect_reach_to_step,
-              use_vertex_tensorboard,
-              use_pathways,
-              ramdisk_directory,
-              mtc_enabled,
-              xpk_branch,
-              max_restart,
-              check_file_exists,
-          )
-      )
+  #     launch_workload_and_wait_for_reach_step = (
+  #         self.launch_workload_with_node_reach_to_step(
+  #             workload_id,
+  #             gcs_path,
+  #             expect_reach_to_step,
+  #             use_vertex_tensorboard,
+  #             use_pathways,
+  #             ramdisk_directory,
+  #             mtc_enabled,
+  #             xpk_branch,
+  #             max_restart,
+  #             check_file_exists,
+  #         )
+  #     )
 
-      run_node_interruption = xpk.delete_node.override(
-          owner=self.task_test_config.task_owner, trigger_rule="none_failed"
-      )(
-          project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          workload_id=workload_id,
-          dry_run=False,
-          last_node=last_node,
-      )
+  #     run_node_interruption = xpk.delete_node.override(
+  #         owner=self.task_test_config.task_owner, trigger_rule="none_failed"
+  #     )(
+  #         project=self.task_gcp_config.project_name,
+  #         zone=self.task_gcp_config.zone,
+  #         cluster_name=self.task_test_config.cluster_name,
+  #         workload_id=workload_id,
+  #         dry_run=False,
+  #         last_node=last_node,
+  #     )
 
-      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-          timeout=int(self.task_test_config.timeout.total_seconds()),
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
+  #     wait_for_workload_completion = xpk.wait_for_workload_completion.override(
+  #         timeout=int(self.task_test_config.timeout.total_seconds()),
+  #     )(
+  #         workload_id=workload_id,
+  #         project_id=self.task_gcp_config.project_name,
+  #         region=gke.zone_to_region(self.task_gcp_config.zone),
+  #         cluster_name=self.task_test_config.cluster_name,
+  #     )
 
-      clean_up_workload = xpk.clean_up_workload(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          xpk_branch=xpk_branch,
-      )
+  #     clean_up_workload = xpk.clean_up_workload(
+  #         workload_id=workload_id,
+  #         project_id=self.task_gcp_config.project_name,
+  #         zone=self.task_gcp_config.zone,
+  #         cluster_name=self.task_test_config.cluster_name,
+  #         xpk_branch=xpk_branch,
+  #     )
 
-      _ = (
-          (workload_id, gcs_path)
-          >> launch_workload_and_wait_for_reach_step
-          >> run_node_interruption
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
-    return group, gcs_path
+  #     _ = (
+  #         (workload_id, gcs_path)
+  #         >> launch_workload_and_wait_for_reach_step
+  #         >> run_node_interruption
+  #         >> wait_for_workload_completion
+  #         >> clean_up_workload
+  #     )
+  #   return group, gcs_path
 
-  def launch_workload_with_node_reach_to_step(
-      self,
-      workload_id: str,
-      gcs_path: str,
-      expect_reach_to_step: int,
-      use_vertex_tensorboard: bool,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
-  ) -> DAGNode:
-    """Create the workload and wait for it to provision."""
-    with TaskGroup(group_id="launch_workload_with_node_reach_to_step") as group:
-      run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
-      )(
-          task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
-          workload_id=workload_id,
-          gcs_path=gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-      )
-      wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
-      wait_for_workload_to_reach_step = (
-          xpk.wait_for_workload_reach_step.override(
-              task_id="wait_for_workload_reach_step"
-          )(
-              workload_id=workload_id,
-              project_id=self.task_gcp_config.project_name,
-              region=gke.zone_to_region(self.task_gcp_config.zone),
-              cluster_name=self.task_test_config.cluster_name,
-              expect_reach_to_step=str(expect_reach_to_step),
-          )
-      )
+  # def launch_workload_with_node_reach_to_step(
+  #     self,
+  #     workload_id: str,
+  #     gcs_path: str,
+  #     expect_reach_to_step: int,
+  #     use_vertex_tensorboard: bool,
+  #     use_pathways: bool = False,
+  #     ramdisk_directory: str = "",
+  #     mtc_enabled: bool = False,
+  #     xpk_branch: str = xpk.MAIN_BRANCH,
+  #     max_restart: int = 0,
+  #     check_file_exists: bool = False,
+  # ) -> DAGNode:
+    # """Create the workload and wait for it to provision."""
+    # with TaskGroup(group_id="launch_workload_with_node_reach_to_step") as group:
+    #   run_workload = xpk.run_workload.override(
+    #       owner=self.task_test_config.task_owner
+    #   )(
+    #       task_id="run_workload",
+    #       cluster_project=self.task_gcp_config.project_name,
+    #       zone=self.task_gcp_config.zone,
+    #       cluster_name=self.task_test_config.cluster_name,
+    #       benchmark_id=self.task_test_config.benchmark_id,
+    #       workload_id=workload_id,
+    #       gcs_path=gcs_path,
+    #       docker_image=self.task_test_config.docker_image,
+    #       accelerator_type=self.task_test_config.accelerator.name,
+    #       run_cmds=self.task_test_config.test_script,
+    #       num_slices=self.task_test_config.num_slices,
+    #       use_vertex_tensorboard=use_vertex_tensorboard,
+    #       use_pathways=use_pathways,
+    #       ramdisk_directory=ramdisk_directory,
+    #       mtc_enabled=mtc_enabled,
+    #       xpk_branch=xpk_branch,
+    #       max_restart=max_restart,
+    #   )
+    #   wait_for_workload_start = xpk.wait_for_workload_start.override(
+    #       timeout=self.workload_provision_timeout.total_seconds()
+    #   )(
+    #       workload_id=workload_id,
+    #       project_id=self.task_gcp_config.project_name,
+    #       region=gke.zone_to_region(self.task_gcp_config.zone),
+    #       cluster_name=self.task_test_config.cluster_name,
+    #   )
+    #   wait_for_workload_to_reach_step = (
+    #       xpk.wait_for_workload_reach_step.override(
+    #           task_id="wait_for_workload_reach_step"
+    #       )(
+    #           workload_id=workload_id,
+    #           project_id=self.task_gcp_config.project_name,
+    #           region=gke.zone_to_region(self.task_gcp_config.zone),
+    #           cluster_name=self.task_test_config.cluster_name,
+    #           expect_reach_to_step=str(expect_reach_to_step),
+    #       )
+    #   )
 
-      task_id_wait_file_exist = "wait_for_file_to_exist"
-      wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
-          task_id=task_id_wait_file_exist
-      )(
-          file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
-      )
-      task_id_do_nothing = "do_nothing"
-      do_nothing = EmptyOperator(task_id=task_id_do_nothing)
+    #   task_id_wait_file_exist = "wait_for_file_to_exist"
+    #   wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
+    #       task_id=task_id_wait_file_exist
+    #   )(
+    #       file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
+    #   )
+    #   task_id_do_nothing = "do_nothing"
+    #   do_nothing = EmptyOperator(task_id=task_id_do_nothing)
 
-      @task.branch
-      def task_path_decider(check_file_exists: bool = False) -> str:
-        """
-        Dynamically route the workflow depending on the `check_file_exists`.
-        """
-        if check_file_exists:
-          return f"{group.group_id}.{task_id_wait_file_exist}"
-        return f"{group.group_id}.{task_id_do_nothing}"
+    #   @task.branch
+    #   def task_path_decider(check_file_exists: bool = False) -> str:
+    #     """
+    #     Dynamically route the workflow depending on the `check_file_exists`.
+    #     """
+    #     if check_file_exists:
+    #       return f"{group.group_id}.{task_id_wait_file_exist}"
+    #     return f"{group.group_id}.{task_id_do_nothing}"
 
-      # Conditional checks: depending on the `check_file_exists` argument
-      # specified by the upper-level caller.
-      maybe_check_file_exists = task_path_decider(check_file_exists)
+    #   # Conditional checks: depending on the `check_file_exists` argument
+    #   # specified by the upper-level caller.
+    #   maybe_check_file_exists = task_path_decider(check_file_exists)
 
-      _ = (
-          run_workload
-          >> wait_for_workload_start
-          >> wait_for_workload_to_reach_step
-          >> maybe_check_file_exists
-      )
-      _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
+    #   _ = (
+    #       run_workload
+    #       >> wait_for_workload_start
+    #       >> wait_for_workload_to_reach_step
+    #       >> maybe_check_file_exists
+    #   )
+    #   _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
 
-      return group
+    #   return group
 
   def run_with_name_gen_and_quarantine(
       self,
@@ -711,13 +711,31 @@ class XpkTask(BaseTask):
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
+      # Optional node interruption parameters
+      expect_reach_to_step: Optional[int] = None,
+      last_node: bool = False,
+      check_file_exists: bool = False,
   ) -> DAGNode:
     """Run the TPU/GPU test in `task_test_config` using xpk.
+
+      Different behavior for testing node interruption.
 
     Attributes:
       gcs_location: GCS path for all artifacts of the test.
       use_vertex_tensorboard: Set to True to view workload data on
         Vertex AI Tensorboard.
+      expect_reach_to_step: The training step at which the node interruption
+        should be triggered.
+      use_pathways: Set to True to use the Pathways execution framework.
+      ramdisk_directory: The directory for enabling emergency checkpointing.
+      mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
+      xpk_branch: The specific git branch of the xpk tool to use.
+      last_node: If True, the interruption will target the last node in the
+        workload; otherwise, it targets the first node.
+      max_restart: By default, this is 0.
+        This will restart the job with flag "--max-restarts"
+      check_file_exists: By default, this is False. If set to True,
+        task branch task_path_decider will be performed.
 
     Returns:
       A DAG node that executes the model test.
@@ -740,6 +758,8 @@ class XpkTask(BaseTask):
           mtc_enabled,
           xpk_branch,
           max_restart,
+          expect_reach_to_step,
+          check_file_exists,
       )
       wait_for_workload_completion = xpk.wait_for_workload_completion.override(
           timeout=int(self.task_test_config.timeout.total_seconds()),
@@ -758,12 +778,32 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
       )
 
-      _ = (
-          (workload_id, gcs_path)
-          >> launch_workload
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
+      if expect_reach_to_step is not None:
+        run_node_interruption = xpk.delete_node.override(
+            owner=self.task_test_config.task_owner, trigger_rule="none_failed"
+        )(
+            project=self.task_gcp_config.project_name,
+            zone=self.task_gcp_config.zone,
+            cluster_name=self.task_test_config.cluster_name,
+            workload_id=workload_id,
+            dry_run=False,
+            last_node=last_node,
+        )
+        _ = (
+            (workload_id, gcs_path)
+            >> launch_workload
+            >> run_node_interruption
+            >> wait_for_workload_completion
+            >> clean_up_workload
+        )
+      else:
+        _ = (
+            (workload_id, gcs_path)
+            >> launch_workload
+            >> wait_for_workload_completion
+            >> clean_up_workload
+        )
+
       return group, gcs_path
 
   def launch_workload(
@@ -776,6 +816,9 @@ class XpkTask(BaseTask):
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
+      # Optional node interruption parameters
+      expect_reach_to_step: Optional[int] = None,
+      check_file_exists: bool = False,
   ) -> DAGNode:
     """Create the workload and wait for it to provision."""
     with TaskGroup(group_id="launch_workload") as group:
@@ -809,6 +852,46 @@ class XpkTask(BaseTask):
           cluster_name=self.task_test_config.cluster_name,
       )
       _ = run_workload >> wait_for_workload_start
+
+      # If we are expecting to reach a step (Node Interruption path), add the monitoring tasks
+      if expect_reach_to_step is not None:
+        wait_for_workload_to_reach_step = (
+            xpk.wait_for_workload_reach_step.override(
+                task_id="wait_for_workload_reach_step"
+            )(
+                workload_id=workload_id,
+                project_id=self.task_gcp_config.project_name,
+                region=gke.zone_to_region(self.task_gcp_config.zone),
+                cluster_name=self.task_test_config.cluster_name,
+                expect_reach_to_step=str(expect_reach_to_step),
+            )
+        )
+        task_id_wait_file_exist = "wait_for_file_to_exist"
+        wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
+            task_id=task_id_wait_file_exist
+        )(
+            file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
+        )
+        task_id_do_nothing = "do_nothing"
+        do_nothing = EmptyOperator(task_id=task_id_do_nothing)
+
+        @task.branch
+        def task_path_decider(check_file_exists: bool = False) -> str:
+          if check_file_exists:
+            return f"{group.group_id}.{task_id_wait_file_exist}"
+          return f"{group.group_id}.{task_id_do_nothing}"
+
+        # Conditional checks: depending on the `check_file_exists` argument
+        # specified by the upper-level caller.
+        maybe_check_file_exists = task_path_decider(check_file_exists)
+
+        _ = (
+              wait_for_workload_start
+              >> wait_for_workload_to_reach_step
+              >> maybe_check_file_exists
+          )
+        _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
+
       return group
 
   def post_process(self, result_location: Optional[str] = None) -> DAGNode:

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -18,7 +18,7 @@ import abc
 import dataclasses
 import datetime
 import shlex
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import airflow
 from airflow.models.taskmixin import DAGNode
@@ -339,8 +339,18 @@ class XpkTask(BaseTask):
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
+      # Optional node interruption parameters
+      expect_reach_to_step: Optional[int] = None,
+      last_node: bool = False,
+      check_file_exists: bool = False,
+      # Optional run name generation parameters
+      generate_run_name: bool = False,
+      run_name_env: str = "M_RUN_NAME",
+      nested_run_name_in_tb_file_location: bool = True,
+      # Optional quarantine parameters
+      quarantine_task_group: Optional[Any] = None,
   ) -> DAGNode:
-    """Run a test job within a docker image.
+    """Run a test job within a docker image with optional features.
 
     Attributes:
       gcs_location: GCS path for all artifacts of the test.
@@ -351,20 +361,78 @@ class XpkTask(BaseTask):
       A task group with the following tasks chained: run_model and
       post_process.
     """
-    with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      run_model, gcs_path = self.run_model(
-          gcs_location,
-          use_vertex_tensorboard,
-          use_pathways,
-          ramdisk_directory,
-          mtc_enabled,
-          xpk_branch,
-          max_restart,
-      )
-      if not skip_post_process:
-        _ = run_model >> self.post_process(gcs_path)
+    is_quarantined = False
+    if quarantine_task_group is not None:
+      test_name = self.task_test_config.benchmark_id
+      is_quarantined = QuarantineTests.is_quarantined(test_name)
 
-    return group
+    def _build_run_dag():
+      with TaskGroup(
+          group_id=self.task_test_config.benchmark_id,
+      ) as group:
+        profile_file_location = None
+        if generate_run_name:
+          run_name = name_format.generate_run_name(
+              self.task_test_config.benchmark_id
+          )
+          tb_file_location = name_format.generate_tb_file_location(
+              run_name,
+              self.task_metric_config.tensorboard_summary.file_location,
+              nested_run_name_in_tb_file_location,
+          )
+
+          # Set run_name in run_model_cmds
+          new_run_model_cmds = [f"export {run_name_env}={run_name}"]
+          for cmd in self.task_test_config.run_model_cmds:
+            new_run_model_cmds.append(cmd)
+          self.task_test_config.run_model_cmds = new_run_model_cmds
+
+          # Update tensorboard file location
+          self.task_metric_config.tensorboard_summary.file_location = (
+              tb_file_location
+          )
+
+          # Update profile file location
+          if self.task_metric_config.profile:
+            profile_file_location = name_format.generate_profile_file_location(
+                run_name, self.task_metric_config.profile.file_location
+            )
+            self.task_metric_config.profile.file_location = (
+                profile_file_location
+            )
+
+        run_model, gcs_path = self.run_model(
+            gcs_location=gcs_location,
+            use_vertex_tensorboard=use_vertex_tensorboard,
+            use_pathways=use_pathways,
+            ramdisk_directory=ramdisk_directory,
+            mtc_enabled=mtc_enabled,
+            xpk_branch=xpk_branch,
+            max_restart=max_restart,
+            expect_reach_to_step=expect_reach_to_step,
+            last_node=last_node,
+            check_file_exists=check_file_exists,
+        )
+
+        if generate_run_name:
+          if profile_file_location:
+            _ = (
+                run_name
+                >> (tb_file_location, profile_file_location)
+                >> run_model
+            )
+          else:
+            _ = run_name >> tb_file_location >> run_model
+
+        if not skip_post_process:
+          _ = run_model >> self.post_process(gcs_path)
+      return group
+
+    if is_quarantined:
+      with quarantine_task_group:
+        return _build_run_dag()
+    else:
+      return _build_run_dag()
 
   def run_with_node_interruption(
       self,
@@ -407,209 +475,19 @@ class XpkTask(BaseTask):
       A task group with the following tasks chained: run_model and
       post_process.
     """
-    with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      run_model, gcs_path = self.run_model(
-          gcs_location=gcs_location,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-          expect_reach_to_step=expect_reach_to_step,
-          last_node=last_node,
-          check_file_exists=check_file_exists,
-      )
-      if not skip_post_process:
-        _ = run_model >> self.post_process(gcs_path)
-    return group
-
-  # def run_model_with_node_interruption(
-  #     self,
-  #     *,
-  #     gcs_location: Optional[airflow.XComArg] = None,
-  #     use_vertex_tensorboard: bool = False,
-  #     expect_reach_to_step: int,
-  #     use_pathways: bool = False,
-  #     ramdisk_directory: str = "",
-  #     mtc_enabled: bool = False,
-  #     xpk_branch: str = xpk.MAIN_BRANCH,
-  #     last_node: bool = False,
-  #     max_restart: int = 0,
-  #     check_file_exists: bool = False,
-  # ) -> DAGNode:
-  #   """Run the TPU/GPU test in `task_test_config` using xpk.
-
-  #     Different behavior for testing node interruption.
-
-  #   Attributes:
-  #     gcs_location: GCS path for all artifacts of the test.
-  #     use_vertex_tensorboard: Set to True to view workload data on
-  #       Vertex AI Tensorboard.
-  #     expect_reach_to_step: The training step at which the node interruption
-  #       should be triggered.
-  #     use_pathways: Set to True to use the Pathways execution framework.
-  #     ramdisk_directory: The directory for enabling emergency checkpointing.
-  #     mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
-  #     xpk_branch: The specific git branch of the xpk tool to use.
-  #     last_node: If True, the interruption will target the last node in the
-  #       workload; otherwise, it targets the first node.
-  #     max_restart: By default, this is 0.
-  #       This will restart the job with flag "--max-restarts"
-  #     check_file_exists: By default, this is False. If set to True,
-  #       task branch task_path_decider will be performed.
-  #   Returns:
-  #     A DAG node that executes the model test.
-  #   """
-  #   with TaskGroup(group_id="run_model") as group:
-  #     workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-  #     if gcs_location:
-  #       gcs_path = gcs_location
-  #     else:
-  #       gcs_path = name_format.generate_gcs_folder_location(
-  #           self.task_test_config.gcs_subfolder,
-  #           self.task_test_config.benchmark_id,
-  #       )
-
-  #     launch_workload_and_wait_for_reach_step = (
-  #         self.launch_workload_with_node_reach_to_step(
-  #             workload_id,
-  #             gcs_path,
-  #             expect_reach_to_step,
-  #             use_vertex_tensorboard,
-  #             use_pathways,
-  #             ramdisk_directory,
-  #             mtc_enabled,
-  #             xpk_branch,
-  #             max_restart,
-  #             check_file_exists,
-  #         )
-  #     )
-
-  #     run_node_interruption = xpk.delete_node.override(
-  #         owner=self.task_test_config.task_owner, trigger_rule="none_failed"
-  #     )(
-  #         project=self.task_gcp_config.project_name,
-  #         zone=self.task_gcp_config.zone,
-  #         cluster_name=self.task_test_config.cluster_name,
-  #         workload_id=workload_id,
-  #         dry_run=False,
-  #         last_node=last_node,
-  #     )
-
-  #     wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-  #         timeout=int(self.task_test_config.timeout.total_seconds()),
-  #     )(
-  #         workload_id=workload_id,
-  #         project_id=self.task_gcp_config.project_name,
-  #         region=gke.zone_to_region(self.task_gcp_config.zone),
-  #         cluster_name=self.task_test_config.cluster_name,
-  #     )
-
-  #     clean_up_workload = xpk.clean_up_workload(
-  #         workload_id=workload_id,
-  #         project_id=self.task_gcp_config.project_name,
-  #         zone=self.task_gcp_config.zone,
-  #         cluster_name=self.task_test_config.cluster_name,
-  #         xpk_branch=xpk_branch,
-  #     )
-
-  #     _ = (
-  #         (workload_id, gcs_path)
-  #         >> launch_workload_and_wait_for_reach_step
-  #         >> run_node_interruption
-  #         >> wait_for_workload_completion
-  #         >> clean_up_workload
-  #     )
-  #   return group, gcs_path
-
-  # def launch_workload_with_node_reach_to_step(
-  #     self,
-  #     workload_id: str,
-  #     gcs_path: str,
-  #     expect_reach_to_step: int,
-  #     use_vertex_tensorboard: bool,
-  #     use_pathways: bool = False,
-  #     ramdisk_directory: str = "",
-  #     mtc_enabled: bool = False,
-  #     xpk_branch: str = xpk.MAIN_BRANCH,
-  #     max_restart: int = 0,
-  #     check_file_exists: bool = False,
-  # ) -> DAGNode:
-    # """Create the workload and wait for it to provision."""
-    # with TaskGroup(group_id="launch_workload_with_node_reach_to_step") as group:
-    #   run_workload = xpk.run_workload.override(
-    #       owner=self.task_test_config.task_owner
-    #   )(
-    #       task_id="run_workload",
-    #       cluster_project=self.task_gcp_config.project_name,
-    #       zone=self.task_gcp_config.zone,
-    #       cluster_name=self.task_test_config.cluster_name,
-    #       benchmark_id=self.task_test_config.benchmark_id,
-    #       workload_id=workload_id,
-    #       gcs_path=gcs_path,
-    #       docker_image=self.task_test_config.docker_image,
-    #       accelerator_type=self.task_test_config.accelerator.name,
-    #       run_cmds=self.task_test_config.test_script,
-    #       num_slices=self.task_test_config.num_slices,
-    #       use_vertex_tensorboard=use_vertex_tensorboard,
-    #       use_pathways=use_pathways,
-    #       ramdisk_directory=ramdisk_directory,
-    #       mtc_enabled=mtc_enabled,
-    #       xpk_branch=xpk_branch,
-    #       max_restart=max_restart,
-    #   )
-    #   wait_for_workload_start = xpk.wait_for_workload_start.override(
-    #       timeout=self.workload_provision_timeout.total_seconds()
-    #   )(
-    #       workload_id=workload_id,
-    #       project_id=self.task_gcp_config.project_name,
-    #       region=gke.zone_to_region(self.task_gcp_config.zone),
-    #       cluster_name=self.task_test_config.cluster_name,
-    #   )
-    #   wait_for_workload_to_reach_step = (
-    #       xpk.wait_for_workload_reach_step.override(
-    #           task_id="wait_for_workload_reach_step"
-    #       )(
-    #           workload_id=workload_id,
-    #           project_id=self.task_gcp_config.project_name,
-    #           region=gke.zone_to_region(self.task_gcp_config.zone),
-    #           cluster_name=self.task_test_config.cluster_name,
-    #           expect_reach_to_step=str(expect_reach_to_step),
-    #       )
-    #   )
-
-    #   task_id_wait_file_exist = "wait_for_file_to_exist"
-    #   wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
-    #       task_id=task_id_wait_file_exist
-    #   )(
-    #       file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
-    #   )
-    #   task_id_do_nothing = "do_nothing"
-    #   do_nothing = EmptyOperator(task_id=task_id_do_nothing)
-
-    #   @task.branch
-    #   def task_path_decider(check_file_exists: bool = False) -> str:
-    #     """
-    #     Dynamically route the workflow depending on the `check_file_exists`.
-    #     """
-    #     if check_file_exists:
-    #       return f"{group.group_id}.{task_id_wait_file_exist}"
-    #     return f"{group.group_id}.{task_id_do_nothing}"
-
-    #   # Conditional checks: depending on the `check_file_exists` argument
-    #   # specified by the upper-level caller.
-    #   maybe_check_file_exists = task_path_decider(check_file_exists)
-
-    #   _ = (
-    #       run_workload
-    #       >> wait_for_workload_start
-    #       >> wait_for_workload_to_reach_step
-    #       >> maybe_check_file_exists
-    #   )
-    #   _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
-
-    #   return group
+    return self.run(
+        gcs_location=gcs_location,
+        use_vertex_tensorboard=use_vertex_tensorboard,
+        use_pathways=use_pathways,
+        skip_post_process=skip_post_process,
+        ramdisk_directory=ramdisk_directory,
+        mtc_enabled=mtc_enabled,
+        xpk_branch=xpk_branch,
+        max_restart=max_restart,
+        expect_reach_to_step=expect_reach_to_step,
+        last_node=last_node,
+        check_file_exists=check_file_exists,
+    )
 
   def run_with_name_gen_and_quarantine(
       self,
@@ -619,88 +497,15 @@ class XpkTask(BaseTask):
       run_name_env: str = "M_RUN_NAME",
       nested_run_name_in_tb_file_location: bool = True,
   ) -> DAGNode:
-    test_name = self.task_test_config.benchmark_id
-    if QuarantineTests.is_quarantined(test_name):
-      with quarantine_task_group:
-        return self.run_with_run_name_generation(
-            use_pathways,
-            xpk_branch,
-            run_name_env,
-            nested_run_name_in_tb_file_location,
-        )
-    else:
-      return self.run_with_run_name_generation(
-          use_pathways,
-          xpk_branch,
-          run_name_env,
-          nested_run_name_in_tb_file_location,
-      )
-
-  def run_with_run_name_generation(
-      self,
-      use_pathways: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      run_name_env: str = "M_RUN_NAME",
-      nested_run_name_in_tb_file_location: bool = True,
-  ) -> DAGNode:
-    """Generate a unique run name, tensorboard file location,
-    and profile file location (if metric config has profile),
-    then run a test job within a docker image.
-
-    Returns:
-      A task group with the following tasks chained: generate_run_name,
-      generate_tb_file_location, generate_profile_file_location (optional),
-      run provision, run_model, post_process.
-    """
-    with TaskGroup(
-        group_id=self.task_test_config.benchmark_id, prefix_group_id=True
-    ) as group:
-      run_name = name_format.generate_run_name(
-          self.task_test_config.benchmark_id
-      )
-      tb_file_location = name_format.generate_tb_file_location(
-          run_name,
-          self.task_metric_config.tensorboard_summary.file_location,
-          nested_run_name_in_tb_file_location,
-      )
-
-      # Set run_name in run_model_cmds
-      new_run_model_cmds = [f"export {run_name_env}={run_name}"]
-      for cmd in self.task_test_config.run_model_cmds:
-        new_run_model_cmds.append(cmd)
-      self.task_test_config.run_model_cmds = new_run_model_cmds
-
-      # Update tensorboard file location
-      self.task_metric_config.tensorboard_summary.file_location = (
-          tb_file_location
-      )
-
-      # Update profile file location
-      if self.task_metric_config.profile:
-        profile_file_location = name_format.generate_profile_file_location(
-            run_name, self.task_metric_config.profile.file_location
-        )
-        self.task_metric_config.profile.file_location = profile_file_location
-        run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
-        )
-        _ = (
-            run_name
-            >> (tb_file_location, profile_file_location)
-            >> run_model
-            >> self.post_process(gcs_path)
-        )
-      else:
-        run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
-        )
-        _ = (
-            run_name
-            >> tb_file_location
-            >> run_model
-            >> self.post_process(gcs_path)
-        )
-    return group
+    """Run a test job with name generation and quarantine handling."""
+    return self.run(
+        use_pathways=use_pathways,
+        xpk_branch=xpk_branch,
+        generate_run_name=True,
+        run_name_env=run_name_env,
+        nested_run_name_in_tb_file_location=nested_run_name_in_tb_file_location,
+        quarantine_task_group=quarantine_task_group,
+    )
 
   def run_model(
       self,

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -691,10 +691,10 @@ class XpkTask(BaseTask):
         maybe_check_file_exists = task_path_decider(check_file_exists)
 
         _ = (
-              wait_for_workload_start
-              >> wait_for_workload_to_reach_step
-              >> maybe_check_file_exists
-          )
+            wait_for_workload_start
+            >> wait_for_workload_to_reach_step
+            >> maybe_check_file_exists
+        )
         _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
 
       return group

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -581,7 +581,7 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
-      )
+      ).as_teardown(setups=launch_workload)
 
       if expect_reach_to_step is not None:
         run_node_interruption = xpk.delete_node.override(


### PR DESCRIPTION
# Description
This Pull Request introduces two key improvements to our workload orchestration task classes and DAG reporting reliability:

1. Unification and Refactoring of `XpkTask`
Unified and simplified the internal structure of the `XpkTask` class.
Preserved the original task structures and relationships while improving code readability and maintainability.
2. Correct DAG Status Reporting via Airflow Setup/Teardown API
__The Problem:__ By default, Airflow evaluates the final DAG run status based on the success of its leaf nodes. In our workload runs, `clean_up_workload` acts as a leaf node that is typically triggered with `all_done` rules. When a training workload failed, the cleanup task still completed successfully, causing the Airflow DAG to be incorrectly reported as SUCCESS.
__The Solution:__ We transitioned the cleanup logic to use Airflow's Setup/Teardown API:
Marked `clean_up_workload` as a teardown task linked to `launch_workload` via `.as_teardown(setups=launch_workload)`. This ensures that successful cleanup runs do not mask upstream failures (the DAG run status will now be determined by the actual work task, `wait_for_workload_completion`).
Configured `on_failure_fail_dagrun=True` inside `as_teardown(...)`. This ensures that if the cleanup task itself fails (e.g., if we fail to delete GKE resources, risking resource leaks), the DAG run will be flagged as FAILED.

# Tests
[maxtext_e2e_tpu_post_training](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_e2e_tpu_post_training/grid?dag_run_id=manual__2026-07-03T08%3A22%3A15%2B00%3A00)

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.