### PR TITLE
Refactor `XpkTask`

### DIFF
--- a/.github/workflows/dag-check.yml
+++ b/.github/workflows/dag-check.yml
@@ -3,7 +3,6 @@ name: DAG Check
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/.github/workflows/pyink-check.yml
+++ b/.github/workflows/pyink-check.yml
@@ -2,10 +2,11 @@ name: Formatter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   format_check:

--- a/.github/workflows/pylint-check.yml
+++ b/.github/workflows/pylint-check.yml
@@ -2,11 +2,12 @@ name: Linter
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:
     branches: [master]
+
+  workflow_dispatch: {}
 
 jobs:
   linting_check:

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -2,6 +2,9 @@ name: Require Checklist
 on:
   pull_request:
     types: [opened, edited, synchronize]
+
+  workflow_dispatch: {}
+
 jobs:
   check_pr_body:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,6 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [master]
     types: [opened, synchronize, edited]
 
   push:

--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -102,4 +102,4 @@ with models.DAG(
 
   # Run jobs
   for test in tests:
-    test.to_name_gen_and_quarantine_task().run()
+    test.run()

--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ Used upon library upgrades.
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -54,7 +54,11 @@ with models.DAG(
     for model_size in models:
       run_cmds = [
           "pip show aqtp",
-          f"bash src/maxtext/configs/tpu/{tpu}/{model_size}.sh EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} PLATFORM=gke",
+          (
+              f"bash src/maxtext/configs/tpu/{tpu}/{model_size}.sh "
+              f"EXECUTABLE=train.py OUTPUT_PATH={base_output_directory} "
+              "PLATFORM=gke"
+          ),
       ]
 
       tests.extend(

--- a/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_aqtp_version_sweep_gke_example_dag.py
@@ -98,4 +98,4 @@ with models.DAG(
 
   # Run jobs
   for test in tests:
-    test.run_with_run_name_generation()
+    test.to_name_gen_and_quarantine_task().run()

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -15,7 +15,8 @@
 """An example DAG to extract profile metrics.
 
 Pretraining mixtral-8x7b model on 1xv4-128.
-Profile extraction can be easily integrated with gke_config + (to_name_gen_and_quarantine_task + run).
+Profile extraction can be easily integrated with gke_config
++ (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -14,7 +14,7 @@
 
 """
 An example DAG to extract profile metrics from pretraining mixtral-8x7b model on 1xv4-128.
-Profile extraction can be easily integrated with gke_config + run_with_run_name_generation.
+Profile extraction can be easily integrated with gke_config + (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime
@@ -88,7 +88,8 @@ with models.DAG(
 ) as dag:
   for run_name, test_scripts_details in test_models_tpu.items():
     for image in docker_image.keys():
-      # file_location: pass in base_output_directory, will be altered in `run_with_run_name_generation`
+      # file_location: pass in base_output_directory, will be altered in
+      # XpkNameGenAndQuarantineTask.run_with_run_name_generation
       job_metric_config = metric_config.MetricConfig()
       # optionally, add tensorboard metrics
       job_metric_config.tensorboard_summary = metric_config.SummaryConfig(
@@ -105,13 +106,17 @@ with models.DAG(
       if "not_add_profile_config" in test_scripts_details:
         job_metric_config.profile = None
 
-      tpu_task = gke_config.get_gke_config(
-          num_slices=1,
-          time_out_in_min=test_scripts_details["time_out_in_min"],
-          test_name=f"maxtext_{image}_{run_name}",
-          run_model_cmds=test_scripts_details["train_command"],
-          docker_image=docker_image[image],
-          test_owner=test_owner.SHUNING_J,
-          cluster=test_scripts_details["cluster"],
-          user_specified_job_metric_config=job_metric_config,  # customize config
-      ).run_with_run_name_generation(run_name_env="RUN_NAME")
+      tpu_task = (
+          gke_config.get_gke_config(
+              num_slices=1,
+              time_out_in_min=test_scripts_details["time_out_in_min"],
+              test_name=f"maxtext_{image}_{run_name}",
+              run_model_cmds=test_scripts_details["train_command"],
+              docker_image=docker_image[image],
+              test_owner=test_owner.SHUNING_J,
+              cluster=test_scripts_details["cluster"],
+              user_specified_job_metric_config=job_metric_config,  # customize config
+          )
+          .to_name_gen_and_quarantine_task(run_name_env="RUN_NAME")
+          .run()
+      )

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -122,19 +122,16 @@ with models.DAG(
       if "not_add_profile_config" in test_scripts_details:
         job_metric_config.profile = None
 
-      tpu_task = (
-          gke_config.get_gke_config(
-              num_slices=1,
-              time_out_in_min=test_scripts_details["time_out_in_min"],
-              test_name=f"maxtext_{image}_{run_name}",
-              run_model_cmds=test_scripts_details["train_command"],
-              docker_image=img_val,
-              test_owner=test_owner.SHUNING_J,
-              cluster=test_scripts_details["cluster"],
-              user_specified_job_metric_config=(
-                  job_metric_config
-              ),  # customize config
-          )
-          .to_name_gen_and_quarantine_task(run_name_env="RUN_NAME")
-          .run()
-      )
+      tpu_task = gke_config.get_gke_config_with_name_gen_and_quarantine(
+          num_slices=1,
+          time_out_in_min=test_scripts_details["time_out_in_min"],
+          test_name=f"maxtext_{image}_{run_name}",
+          run_model_cmds=test_scripts_details["train_command"],
+          docker_image=img_val,
+          test_owner=test_owner.SHUNING_J,
+          cluster=test_scripts_details["cluster"],
+          user_specified_job_metric_config=(
+              job_metric_config
+          ),  # customize config
+          run_name_env="RUN_NAME",
+      ).run()

--- a/dags/examples/maxtext_profile_namegen_example_dag.py
+++ b/dags/examples/maxtext_profile_namegen_example_dag.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-An example DAG to extract profile metrics from pretraining mixtral-8x7b model on 1xv4-128.
+"""An example DAG to extract profile metrics.
+
+Pretraining mixtral-8x7b model on 1xv4-128.
 Profile extraction can be easily integrated with gke_config + (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters
 from dags.multipod.configs import gke_config
 from xlml.apis import metric_config
 
@@ -28,36 +29,50 @@ SCHEDULED_TIME = None
 BASE_OUTPUT_PATH = "gs://runner-maxtext-logs"
 
 docker_image = {
-    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-20",
+    "stable": (
+        "gcr.io/tpu-prod-env-multipod/" "maxtext_jax_stable_stack:2025-05-20"
+    ),
 }
 
 base_command = (
     f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-    + "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=gs://runner-maxtext-logs run_name=${RUN_NAME} model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral-v1 dataset_path=gs://maxtext-dataset per_device_batch_size=4 enable_checkpointing=false ici_fsdp_parallelism=-1 max_target_length=1024 async_checkpointing=false attention=flash dtype=bfloat16 weight_dtype=bfloat16"
+    "python3 -m maxtext.trainers.pre_train.train "
+    "src/maxtext/configs/base.yml "
+    "base_output_directory=gs://runner-maxtext-logs "
+    "run_name=${RUN_NAME} model_name=mixtral-8x7b "
+    "tokenizer_path=assets/tokenizer.mistral-v1 "
+    "dataset_path=gs://maxtext-dataset per_device_batch_size=4 "
+    "enable_checkpointing=false ici_fsdp_parallelism=-1 "
+    "max_target_length=1024 async_checkpointing=false "
+    "attention=flash dtype=bfloat16 weight_dtype=bfloat16"
 )
 
 test_models_tpu = {
     # use: upload single profile from the first host, extract profile
-    # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+    # add profiler config: ensure steps >
+    # skip_first_n_steps_for_profiler + profiler_steps
     "mixtral-8x7b_pretraining-megablox_config-true_upload-one": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+            base_command + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3",
         ],
     },
     # use: upload profiles from all hosts, extract one of the profiles
-    # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
+    # add profiler config: ensure steps >
+    # skip_first_n_steps_for_profiler + profiler_steps
     "mixtral-8x7b_pretraining-megablox_config-true_upload-all": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 upload_all_profiler_results=True",
+            base_command + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            "upload_all_profiler_results=True",
         ],
     },
-    # testing: handle edge case, attempt to extract, find no match, proceed to post_process without error
+    # testing: handle edge case, attempt to extract, find no match,
+    # proceed to post_process without error
     "testing_config-true_upload-none": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
@@ -65,13 +80,14 @@ test_models_tpu = {
             base_command + " steps=10",
         ],
     },
-    # testing: not generate profile location, not extract profile in post_process
+    # testing: not generate profile location, not extract profile in
+    # post_process
     "testing_config-false_upload-one": {
         "cluster": XpkClusters.TPU_V4_128_CLUSTER,
         "time_out_in_min": 60,
         "train_command": [
-            base_command
-            + " steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3",
+            base_command + " steps=10 profiler=xplane "
+            "skip_first_n_steps_for_profiler=5 profiler_steps=3",
         ],
         "not_add_profile_config": True,
     },
@@ -87,7 +103,7 @@ with models.DAG(
     concurrency=2,
 ) as dag:
   for run_name, test_scripts_details in test_models_tpu.items():
-    for image in docker_image.keys():
+    for image, img_val in docker_image.items():
       # file_location: pass in base_output_directory, will be altered in
       # XpkNameGenAndQuarantineTask.run_with_run_name_generation
       job_metric_config = metric_config.MetricConfig()
@@ -112,10 +128,12 @@ with models.DAG(
               time_out_in_min=test_scripts_details["time_out_in_min"],
               test_name=f"maxtext_{image}_{run_name}",
               run_model_cmds=test_scripts_details["train_command"],
-              docker_image=docker_image[image],
+              docker_image=img_val,
               test_owner=test_owner.SHUNING_J,
               cluster=test_scripts_details["cluster"],
-              user_specified_job_metric_config=job_metric_config,  # customize config
+              user_specified_job_metric_config=(
+                  job_metric_config
+              ),  # customize config
           )
           .to_name_gen_and_quarantine_task(run_name_env="RUN_NAME")
           .run()

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -153,7 +153,8 @@ with models.DAG(
           base_run_model_cmds=test_scripts_details["train_command"],
           sweep_params=sweep_params,
           enable_profile_config=True,  # add flag to enable profile extraction
+          quarantine_task_group=quarantine_task_group,
       )
 
       for test in maxtext_sweep_gke_test:
-        test.to_name_gen_and_quarantine_task(quarantine_task_group).run()
+        test.run()

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -24,7 +24,7 @@ from airflow import models
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
 from dags.common.vm_resource import XpkClusters, Project
-from dags.multipod.configs import maxtext_sweep_gke_config
+from dags.multipod.configs import maxtext_sweep_gke_config as sweep_config
 from xlml.apis import metric_config
 
 SCHEDULED_TIME = None
@@ -139,7 +139,7 @@ with models.DAG(
       # generate run_name and tensorboard/profile location for extraction
       num_slices = [1]
       sweep_params = {}
-      maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+      maxtext_sweep_gke_test = sweep_config.get_maxtext_sweep_gke_config(
           test_owner=test_owner.SHUNING_J,
           dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
           composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -38,8 +38,7 @@ def dict_to_arg(param_dict):
 
 docker_image = {
     "stable": (
-        "gcr.io/tpu-prod-env-multipod/"
-        "maxtext_jax_stable_stack:2025-05-20"
+        "gcr.io/tpu-prod-env-multipod/" "maxtext_jax_stable_stack:2025-05-20"
     ),
 }
 
@@ -140,22 +139,20 @@ with models.DAG(
       # generate run_name and tensorboard/profile location for extraction
       num_slices = [1]
       sweep_params = {}
-      maxtext_sweep_gke_test = (
-          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
-              test_owner=test_owner.SHUNING_J,
-              dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-              composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-              dataset_name=metric_config.DatasetOption.XLML_DATASET,
-              cluster=test_scripts_details["cluster"],
-              time_out_in_min=test_scripts_details["time_out_in_min"],
-              base_output_directory=BASE_OUTPUT_PATH,
-              num_slices=num_slices,
-              docker_image=img_val,
-              run_name_prefix=f"maxtext_{image}_{run_name}",
-              base_run_model_cmds=test_scripts_details["train_command"],
-              sweep_params=sweep_params,
-              enable_profile_config=True,  # add flag to enable profile extraction
-          )
+      maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+          test_owner=test_owner.SHUNING_J,
+          dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+          composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+          dataset_name=metric_config.DatasetOption.XLML_DATASET,
+          cluster=test_scripts_details["cluster"],
+          time_out_in_min=test_scripts_details["time_out_in_min"],
+          base_output_directory=BASE_OUTPUT_PATH,
+          num_slices=num_slices,
+          docker_image=img_val,
+          run_name_prefix=f"maxtext_{image}_{run_name}",
+          base_run_model_cmds=test_scripts_details["train_command"],
+          sweep_params=sweep_params,
+          enable_profile_config=True,  # add flag to enable profile extraction
       )
 
       for test in maxtext_sweep_gke_test:

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -14,7 +14,7 @@
 
 """
 An example DAG to extract profile metrics from pretraining mixtral-8x7b model on v6-256.
-Profile extraction can be seamlessly integrated with maxtext_sweep_gke_config + run_with_name_gen_and_quarantine.
+Profile extraction can be seamlessly integrated with maxtext_sweep_gke_config + (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime
@@ -142,4 +142,4 @@ with models.DAG(
       )
 
       for test in maxtext_sweep_gke_test:
-        test.run_with_name_gen_and_quarantine(quarantine_task_group)
+        test.to_name_gen_and_quarantine_task(quarantine_task_group).run()

--- a/dags/examples/maxtext_profile_sweep_example_dag.py
+++ b/dags/examples/maxtext_profile_sweep_example_dag.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-An example DAG to extract profile metrics from pretraining mixtral-8x7b model on v6-256.
-Profile extraction can be seamlessly integrated with maxtext_sweep_gke_config + (to_name_gen_and_quarantine_task + run).
+"""An example DAG to extract profile metrics.
+
+Pretraining mixtral-8x7b model on v6-256.
+Profile extraction can be seamlessly integrated with
+maxtext_sweep_gke_config + (to_name_gen_and_quarantine_task + run).
 """
 
 import datetime
 from airflow import models
 from airflow.utils.task_group import TaskGroup
 from dags.common import test_owner
-from dags.common.vm_resource import XpkClusters, DockerImage, Project
+from dags.common.vm_resource import XpkClusters, Project
 from dags.multipod.configs import maxtext_sweep_gke_config
 from xlml.apis import metric_config
 
@@ -35,7 +37,10 @@ def dict_to_arg(param_dict):
 
 
 docker_image = {
-    "stable": "gcr.io/tpu-prod-env-multipod/maxtext_jax_stable_stack:2025-05-20",
+    "stable": (
+        "gcr.io/tpu-prod-env-multipod/"
+        "maxtext_jax_stable_stack:2025-05-20"
+    ),
 }
 
 # https://github.com/AI-Hypercomputer/maxtext/blob/main/benchmarks/maxtext_trillium_model_configs.py
@@ -45,9 +50,14 @@ test_models_tpu = {
         "cluster": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
         "train_command": [
             f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-            "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} model_name=mixtral-8x7b "
-            # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
-            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            "python3 -m maxtext.trainers.pre_train.train "
+            "src/maxtext/configs/base.yml "
+            "base_output_directory=${BASE_OUTPUT_PATH} "
+            "model_name=mixtral-8x7b "
+            # add profiler config: ensure steps >
+            # skip_first_n_steps_for_profiler + profiler_steps
+            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 "
+            "profiler_steps=3 "
             + dict_to_arg({
                 "per_device_batch_size": 12,
                 "ici_fsdp_parallelism": -1,
@@ -81,9 +91,14 @@ test_models_tpu = {
         "base_output_directory": "gs://runner-maxtext-logs",
         "train_command": [
             f"export BASE_OUTPUT_PATH={BASE_OUTPUT_PATH} && "
-            "python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} model_name=mixtral-8x7b "
-            # add profiler config: ensure steps > skip_first_n_steps_for_profiler + profiler_steps
-            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 profiler_steps=3 "
+            "python3 -m maxtext.trainers.pre_train.train "
+            "src/maxtext/configs/base.yml "
+            "base_output_directory=${BASE_OUTPUT_PATH} "
+            "model_name=mixtral-8x7b "
+            # add profiler config: ensure steps >
+            # skip_first_n_steps_for_profiler + profiler_steps
+            "steps=10 profiler=xplane skip_first_n_steps_for_profiler=5 "
+            "profiler_steps=3 "
             + dict_to_arg({
                 "per_device_batch_size": 12,
                 "ici_fsdp_parallelism": -1,
@@ -120,25 +135,27 @@ with models.DAG(
   )
 
   for run_name, test_scripts_details in test_models_tpu.items():
-    for image in docker_image.keys():
+    for image, img_val in docker_image.items():
       # sweep num_slices and other training params
       # generate run_name and tensorboard/profile location for extraction
       num_slices = [1]
       sweep_params = {}
-      maxtext_sweep_gke_test = maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
-          test_owner=test_owner.SHUNING_J,
-          dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
-          dataset_name=metric_config.DatasetOption.XLML_DATASET,
-          cluster=test_scripts_details["cluster"],
-          time_out_in_min=test_scripts_details["time_out_in_min"],
-          base_output_directory=BASE_OUTPUT_PATH,
-          num_slices=num_slices,
-          docker_image=docker_image[image],
-          run_name_prefix=f"maxtext_{image}_{run_name}",
-          base_run_model_cmds=test_scripts_details["train_command"],
-          sweep_params=sweep_params,
-          enable_profile_config=True,  # add flag to enable profile extraction
+      maxtext_sweep_gke_test = (
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              test_owner=test_owner.SHUNING_J,
+              dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              dataset_name=metric_config.DatasetOption.XLML_DATASET,
+              cluster=test_scripts_details["cluster"],
+              time_out_in_min=test_scripts_details["time_out_in_min"],
+              base_output_directory=BASE_OUTPUT_PATH,
+              num_slices=num_slices,
+              docker_image=img_val,
+              run_name_prefix=f"maxtext_{image}_{run_name}",
+              base_run_model_cmds=test_scripts_details["train_command"],
+              sweep_params=sweep_params,
+              enable_profile_config=True,  # add flag to enable profile extraction
+          )
       )
 
       for test in maxtext_sweep_gke_test:

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -57,4 +57,4 @@ with models.DAG(
 
   # Run jobs
   for test in maxtext_sweep_gke_test:
-    test.run_with_run_name_generation()
+    test.to_name_gen_and_quarantine_task().run()

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -63,4 +63,4 @@ with models.DAG(
 
   # Run jobs
   for test in maxtext_sweep_gke_test:
-    test.to_name_gen_and_quarantine_task().run()
+    test.run()

--- a/dags/examples/maxtext_sweep_gke_example_dag.py
+++ b/dags/examples/maxtext_sweep_gke_example_dag.py
@@ -21,7 +21,7 @@ on 1xv4-128.
 import datetime
 from airflow import models
 from dags.common import test_owner
-from dags.common.vm_resource import TpuVersion, Zone, Project, XpkClusters, DockerImage
+from dags.common.vm_resource import XpkClusters, DockerImage
 from dags.multipod.configs import maxtext_sweep_gke_config
 
 # Set concurrency to number of workers otherwise tasks may time out
@@ -37,7 +37,13 @@ with models.DAG(
   # MaxText set up and run commands
   base_output_directory = "gs://maxtext-experiments-multipod"
   base_run_model_cmds = [
-      f"python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml base_output_directory={base_output_directory} dataset_path=gs://max-datasets-rogue enable_checkpointing=false global_parameter_scale=16 steps=10",
+      (
+          "python3 -m maxtext.trainers.pre_train.train "
+          "src/maxtext/configs/base.yml "
+          f"base_output_directory={base_output_directory} "
+          "dataset_path=gs://max-datasets-rogue enable_checkpointing=false "
+          "global_parameter_scale=16 steps=10"
+      ),
   ]
 
   # Get list of MaxText GKE XPK jobs

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -19,7 +19,7 @@ from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
 from dags import gcs_bucket
 from dags.common.vm_resource import TpuVersion, Project, XpkClusters, GpuVersion, CpuVersion
-from typing import Iterable
+from typing import Any, Iterable
 import datetime
 
 
@@ -78,6 +78,134 @@ def get_gke_config(
       task_test_config=job_test_config,
       task_gcp_config=job_gcp_config,
       task_metric_config=job_metric_config,
+  )
+
+
+def get_gke_config_with_interrupt(
+    time_out_in_min: int,
+    test_name: str,
+    docker_image: str,
+    test_owner: str,
+    run_model_cmds: Iterable[str],
+    expect_reach_to_step: int,
+    cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
+    num_slices: int = 1,
+    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    base_output_directory: str = None,
+    metric_aggregation_strategy: metric_config.AggregationStrategy = None,
+    user_specified_job_metric_config: metric_config.MetricConfig = None,
+    last_node: bool = False,
+    check_file_exists: bool = False,
+) -> task.XpkNodeInterruptionTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=cluster.project,
+      zone=cluster.zone,
+      dataset_name=dataset_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
+  )
+
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=cluster.device_version,
+          cores=cluster.core_count,
+      ),
+      test_name=test_name,
+      run_model_cmds=run_model_cmds,
+      set_up_cmds=None,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=test_owner,
+      num_slices=num_slices,
+      cluster_name=cluster.name,
+      docker_image=docker_image,
+  )
+  job_metric_config = user_specified_job_metric_config
+  if job_metric_config is None:
+    job_metric_config = (
+        metric_config.MetricConfig(
+            tensorboard_summary=metric_config.SummaryConfig(
+                file_location=base_output_directory,
+                aggregation_strategy=metric_aggregation_strategy,
+                use_regex_file_location=True,
+            ),
+        )
+        if base_output_directory and metric_aggregation_strategy
+        else None
+    )
+
+  return task.XpkNodeInterruptionTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
+      expect_reach_to_step=expect_reach_to_step,
+      last_node=last_node,
+      check_file_exists=check_file_exists,
+  )
+
+
+def get_gke_config_with_name_gen_and_quarantine(
+    time_out_in_min: int,
+    test_name: str,
+    docker_image: str,
+    test_owner: str,
+    run_model_cmds: Iterable[str],
+    cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
+    num_slices: int = 1,
+    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+    base_output_directory: str = None,
+    metric_aggregation_strategy: metric_config.AggregationStrategy = None,
+    user_specified_job_metric_config: metric_config.MetricConfig = None,
+    quarantine_task_group: Any = None,
+    run_name_env: str = "M_RUN_NAME",
+    nested_run_name_in_tb_file_location: bool = True,
+) -> task.XpkNameGenAndQuarantineTask:
+  job_gcp_config = gcp_config.GCPConfig(
+      project_name=cluster.project,
+      zone=cluster.zone,
+      dataset_name=dataset_name,
+      dataset_project=dataset_project,
+      composer_project=composer_project,
+  )
+
+  job_test_config = test_config.TpuGkeTest(
+      test_config.Tpu(
+          version=cluster.device_version,
+          cores=cluster.core_count,
+      ),
+      test_name=test_name,
+      run_model_cmds=run_model_cmds,
+      set_up_cmds=None,
+      timeout=datetime.timedelta(minutes=time_out_in_min),
+      task_owner=test_owner,
+      num_slices=num_slices,
+      cluster_name=cluster.name,
+      docker_image=docker_image,
+  )
+  job_metric_config = user_specified_job_metric_config
+  if job_metric_config is None:
+    job_metric_config = (
+        metric_config.MetricConfig(
+            tensorboard_summary=metric_config.SummaryConfig(
+                file_location=base_output_directory,
+                aggregation_strategy=metric_aggregation_strategy,
+                use_regex_file_location=True,
+            ),
+        )
+        if base_output_directory and metric_aggregation_strategy
+        else None
+    )
+
+  return task.XpkNameGenAndQuarantineTask(
+      task_test_config=job_test_config,
+      task_gcp_config=job_gcp_config,
+      task_metric_config=job_metric_config,
+      quarantine_task_group=quarantine_task_group,
+      run_name_env=run_name_env,
+      nested_run_name_in_tb_file_location=nested_run_name_in_tb_file_location,
   )
 
 

--- a/dags/multipod/configs/gke_config.py
+++ b/dags/multipod/configs/gke_config.py
@@ -14,13 +14,13 @@
 
 """Utilities to construct configs for maxtext DAG on GKE."""
 
-from dags.common import test_owner
+import datetime
+from typing import Any, Iterable
+
+from dags import gcs_bucket
+from dags.common.vm_resource import Project, XpkClusters
 from xlml.apis import gcp_config, metric_config, task, test_config
 from xlml.apis.xpk_cluster_config import XpkClusterConfig
-from dags import gcs_bucket
-from dags.common.vm_resource import TpuVersion, Project, XpkClusters, GpuVersion, CpuVersion
-from typing import Any, Iterable
-import datetime
 
 
 def get_gke_config(
@@ -31,7 +31,9 @@ def get_gke_config(
     run_model_cmds: Iterable[str],
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,
@@ -90,7 +92,9 @@ def get_gke_config_with_interrupt(
     expect_reach_to_step: int,
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,
@@ -153,7 +157,9 @@ def get_gke_config_with_name_gen_and_quarantine(
     run_model_cmds: Iterable[str],
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,
@@ -216,7 +222,9 @@ def get_gke_maxtext_nightly_config(
     test_owner: str,
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
 ) -> task.XpkTask:
@@ -234,18 +242,25 @@ def get_gke_maxtext_nightly_config(
   base_output_directory = (
       f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
   )
-  run_name = f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}-maxtext-nightly-{current_datetime}"
+  run_name = (
+      f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}"
+      f"-maxtext-nightly-{current_datetime}"
+  )
 
   run_model_cmds = (
       "bash src/dependencies/scripts/preflight.sh PLATFORM=GKE",
       (
           "JAX_PLATFORM_NAME=TPU XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/'"
           " ENABLE_PJRT_COMPATIBILITY=true"
-          f" python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml run_name={run_name}"
-          f" base_output_directory={base_output_directory}"
+          " python3 -m maxtext.trainers.pre_train.train"
+          " src/maxtext/configs/base.yml"
+          f" run_name={run_name} base_output_directory={base_output_directory}"
           " dataset_path=gs://max-datasets-rogue dataset_type=synthetic"
-          " model_name=llama3-8b per_device_batch_size=12 reuse_example_batch=1 metrics_file='metrics.txt'"
-          " steps=50 enable_checkpointing=false profiler=xplane upload_all_profiler_results=true skip_first_n_steps_for_profiler=10 profiler_steps=10 gcs_metrics=true"
+          " model_name=llama3-8b per_device_batch_size=12 reuse_example_batch=1"
+          " metrics_file='metrics.txt' steps=50 enable_checkpointing=false"
+          " profiler=xplane upload_all_profiler_results=true"
+          " skip_first_n_steps_for_profiler=10 profiler_steps=10"
+          " gcs_metrics=true"
       ),
   )
 
@@ -316,7 +331,9 @@ def get_gke_gpt3_6b_nightly_config(
     test_owner: str,
     cluster: XpkClusterConfig = XpkClusters.TPU_V4_8_MAXTEXT_CLUSTER,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
 ) -> task.XpkTask:
@@ -334,18 +351,26 @@ def get_gke_gpt3_6b_nightly_config(
   base_output_directory = (
       f"{gcs_bucket.BASE_OUTPUT_DIR}/maxtext/nightly/automated/{current_date}"
   )
-  run_name = f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}-gpt3-6b-nightly-{current_datetime}"
+  run_name = (
+      f"{num_slices}slice-V{cluster.device_version.value}_{cluster.core_count}"
+      f"-gpt3-6b-nightly-{current_datetime}"
+  )
 
   run_model_cmds = (
       "bash src/dependencies/scripts/preflight.sh PLATFORM=GKE",
       (
           "JAX_PLATFORM_NAME=TPU XLA_FLAGS='--xla_dump_to=/tmp/xla_dump/'"
           " ENABLE_PJRT_COMPATIBILITY=true"
-          f" python3 -m maxtext.trainers.pre_train.train src/maxtext/configs/base.yml run_name={run_name} model_name=gpt3-6b"
+          " python3 -m maxtext.trainers.pre_train.train"
+          " src/maxtext/configs/base.yml"
+          f" run_name={run_name} model_name=gpt3-6b"
           f" base_output_directory={base_output_directory}"
           " dataset_path=gs://max-datasets-rogue dataset_type=synthetic"
-          " per_device_batch_size=12 reuse_example_batch=1 global_parameter_scale=1 metrics_file='metrics.txt'"
-          " steps=50 enable_checkpointing=false profiler=xplane upload_all_profiler_results=true skip_first_n_steps_for_profiler=10 profiler_steps=10 gcs_metrics=true"
+          " per_device_batch_size=12 reuse_example_batch=1"
+          " global_parameter_scale=1 metrics_file='metrics.txt' steps=50"
+          " enable_checkpointing=false profiler=xplane"
+          " upload_all_profiler_results=true skip_first_n_steps_for_profiler=10"
+          " profiler_steps=10 gcs_metrics=true"
       ),
   )
 
@@ -379,7 +404,9 @@ def get_maxtext_cpu_end_to_end_gke_config(
     cluster: XpkClusterConfig = XpkClusters.CPU_N2_STANDARD_64_CLUSTER,
     machine_count: int = 1,
     num_slices: int = 1,
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.XLML_DATASET,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.XLML_DATASET
+    ),
     dataset_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     composer_project: str = Project.CLOUD_ML_AUTO_SOLUTIONS.value,
     base_output_directory: str = None,

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -16,7 +16,7 @@
 
 import datetime
 from xlml.apis import gcp_config, metric_config, task, test_config
-from dags.common.vm_resource import TpuVersion, XpkClusterConfig
+from dags.common.vm_resource import XpkClusterConfig
 import itertools
 from typing import List, Iterable, Dict, Any
 
@@ -49,8 +49,12 @@ def get_maxtext_sweep_gke_config(
     docker_image: str,
     base_output_directory: str,
     base_run_model_cmds: Iterable[str],
-    dataset_name: metric_config.DatasetOption = metric_config.DatasetOption.BENCHMARK_DATASET,
-    metric_aggregation_strategy: metric_config.AggregationStrategy = metric_config.AggregationStrategy.MEDIAN,
+    dataset_name: metric_config.DatasetOption = (
+        metric_config.DatasetOption.BENCHMARK_DATASET
+    ),
+    metric_aggregation_strategy: metric_config.AggregationStrategy = (
+        metric_config.AggregationStrategy.MEDIAN
+    ),
     dataset_project: str = None,
     composer_project: str = None,
     enable_profile_config: bool = False,
@@ -77,7 +81,8 @@ def get_maxtext_sweep_gke_config(
   for param, values in sweep_params.items():
     sweep_params_list.append([(param, val) for val in values])
 
-  # Generate all combinations of sweep param configurations and create a XpkTask for each one
+  # Generate all combinations of sweep param configurations
+  # and create a XpkTask for each one
   xpk_task_list = []
   for idx, config in enumerate(itertools.product(*sweep_params_list)):
     config_dict = {key: value for (key, value) in config}

--- a/dags/multipod/configs/maxtext_sweep_gke_config.py
+++ b/dags/multipod/configs/maxtext_sweep_gke_config.py
@@ -54,7 +54,8 @@ def get_maxtext_sweep_gke_config(
     dataset_project: str = None,
     composer_project: str = None,
     enable_profile_config: bool = False,
-) -> List[task.XpkTask]:
+    quarantine_task_group: Any = None,
+) -> List[task.XpkNameGenAndQuarantineTask]:
   if not dataset_project:
     dataset_project = cluster.project
   if not composer_project:
@@ -122,10 +123,11 @@ def get_maxtext_sweep_gke_config(
           file_location=base_output_directory,
       )
 
-    xpk_task = task.XpkTask(
+    xpk_task = task.XpkNameGenAndQuarantineTask(
         task_test_config=job_test_config,
         task_gcp_config=job_gcp_config,
         task_metric_config=job_metric_config,
+        quarantine_task_group=quarantine_task_group,
     )
     xpk_task_list.append(xpk_task)
 

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -87,16 +87,20 @@ with models.DAG(
     # The grain dataset takes longer to run, so we give it a longer timeout. The other tests are expected to complete within 5 hours.
     timeout_in_min = 360 if test_name == "maxtext-convergence-grain" else 300
 
-    test_task = gke_config.get_gke_config(
-        cluster=XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
-        time_out_in_min=timeout_in_min,
-        test_name=test_name,
-        run_model_cmds=run_command,
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
-        test_owner=test_owner.MATT_D,
-        base_output_directory=base_output_directory,
-        metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
-    ).run_with_run_name_generation()
+    test_task = (
+        gke_config.get_gke_config(
+            cluster=XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
+            time_out_in_min=timeout_in_min,
+            test_name=test_name,
+            run_model_cmds=run_command,
+            docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
+            test_owner=test_owner.MATT_D,
+            base_output_directory=base_output_directory,
+            metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
+        )
+        .to_name_gen_and_quarantine_task()
+        .run()
+    )
     if test_name not in parallel_test_names:
       sequential_tests.append(test_task)
 

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -88,20 +88,16 @@ with models.DAG(
     # The other tests are expected to complete within 5 hours.
     timeout_in_min = 360 if test_name == "maxtext-convergence-grain" else 300
 
-    test_task = (
-        gke_config.get_gke_config(
-            cluster=XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
-            time_out_in_min=timeout_in_min,
-            test_name=test_name,
-            run_model_cmds=run_command,
-            docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
-            test_owner=test_owner.MATT_D,
-            base_output_directory=base_output_directory,
-            metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
-        )
-        .to_name_gen_and_quarantine_task()
-        .run()
-    )
+    test_task = gke_config.get_gke_config_with_name_gen_and_quarantine(
+        cluster=XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
+        time_out_in_min=timeout_in_min,
+        test_name=test_name,
+        run_model_cmds=run_command,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE.value,
+        test_owner=test_owner.MATT_D,
+        base_output_directory=base_output_directory,
+        metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,
+    ).run()
     if test_name not in parallel_test_names:
       sequential_tests.append(test_task)
 

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -84,7 +84,8 @@ with models.DAG(
 
   sequential_tests = []
   for test_name, run_command in convergence_tests.items():
-    # The grain dataset takes longer to run, so we give it a longer timeout. The other tests are expected to complete within 5 hours.
+    # The grain dataset takes longer to run, so we give it a longer timeout.
+    # The other tests are expected to complete within 5 hours.
     timeout_in_min = 360 if test_name == "maxtext-convergence-grain" else 300
 
     test_task = (

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -16,9 +16,7 @@
 A DAG to run MaxText E2E TPU Post-Training tests.
 """
 import datetime
-import hashlib
 
-from click import command
 from airflow import models
 from airflow.models.param import Param
 from airflow.utils.task_group import TaskGroup
@@ -29,11 +27,6 @@ from dags.multipod.configs import gke_config
 
 # HF token retrieved from Airflow Variables for secure credential management
 HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
-
-
-def get_workload_name(model, mode, length=6):
-  hex_code = f"{mode}-{hashlib.sha256(model.encode()).hexdigest()}"
-  return hex_code[:length]
 
 
 with models.DAG(
@@ -163,25 +156,25 @@ with models.DAG(
               "export ENABLE_PATHWAYS_PERSISTENCE='1'",
           ]
 
-          with TaskGroup(group_id=f"train-{mode}-{model}") as model_group:
-            command = mode_test_config["command"]
-            training_cmd = (
-                " && ".join(
-                    environment_variables + [f"{command} {run_name} true"]
-                ),
-            )
-            training_task = gke_config.get_gke_config(
-                time_out_in_min=60,
-                num_slices=1,
-                cluster=XpkClusters.TPU_V5P_128_CLUSTER,
-                test_name=get_workload_name(model, mode),
-                run_model_cmds=training_cmd,
-                docker_image="{{ params.docker_image }}",
-                test_owner=test_owner.SURBHI_J,
-            ).run_model(
-                use_pathways=True,
-                priority="very-high",
-            )
+          command = mode_test_config["command"]
+          training_cmd = (
+              " && ".join(
+                  environment_variables + [f"{command} {run_name} true"]
+              ),
+          )
+          training_task = gke_config.get_gke_config(
+              time_out_in_min=60,
+              num_slices=1,
+              cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+              test_name=f"train-{mode}-{model}",
+              run_model_cmds=training_cmd,
+              docker_image="{{ params.docker_image }}",
+              test_owner=test_owner.SURBHI_J,
+          ).run(
+              use_pathways=True,
+              skip_post_process=True,
+              priority="very-high",
+          )
 
           to_hf_flags = mode_test_config.get("to_hf_flags", "false true")
 

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -128,12 +128,13 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run_with_node_interruption(
+        ).to_node_interruption_task(
+            expect_reach_to_step=step_to_interrupt,
+            last_node=True,
+        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
             skip_post_process=True,
-            last_node=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
         )
 

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -120,22 +120,26 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
-            num_slices=slice_num,
-            cluster=test_config.cluster,
-            time_out_in_min=60,
-            test_name=f"{test_config.short_id}-emc",
-            run_model_cmds=workload_command,
-            docker_image=image.value,
-            test_owner=test_owner.DEPP_L,
-        ).to_node_interruption_task(
-            expect_reach_to_step=step_to_interrupt,
-            last_node=True,
-        ).run(
-            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
-            mtc_enabled=True,
-            skip_post_process=True,
-            max_restart=15,
+        maxtext_chkpt_run_test = (
+            gke_config.get_gke_config(
+                num_slices=slice_num,
+                cluster=test_config.cluster,
+                time_out_in_min=60,
+                test_name=f"{test_config.short_id}-emc",
+                run_model_cmds=workload_command,
+                docker_image=image.value,
+                test_owner=test_owner.DEPP_L,
+            )
+            .to_node_interruption_task(
+                expect_reach_to_step=step_to_interrupt,
+                last_node=True,
+            )
+            .run(
+                ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+                mtc_enabled=True,
+                skip_post_process=True,
+                max_restart=15,
+            )
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_emc_restore_gcs.py
+++ b/dags/orbax/maxtext_emc_restore_gcs.py
@@ -120,26 +120,21 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = (
-            gke_config.get_gke_config(
-                num_slices=slice_num,
-                cluster=test_config.cluster,
-                time_out_in_min=60,
-                test_name=f"{test_config.short_id}-emc",
-                run_model_cmds=workload_command,
-                docker_image=image.value,
-                test_owner=test_owner.DEPP_L,
-            )
-            .to_node_interruption_task(
-                expect_reach_to_step=step_to_interrupt,
-                last_node=True,
-            )
-            .run(
-                ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
-                mtc_enabled=True,
-                skip_post_process=True,
-                max_restart=15,
-            )
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}-emc",
+            run_model_cmds=workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+            expect_reach_to_step=step_to_interrupt,
+            last_node=True,
+        ).run(
+            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+            mtc_enabled=True,
+            skip_post_process=True,
+            max_restart=15,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -126,11 +126,12 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run_with_node_interruption(
+        ).to_node_interruption_task(
+            expect_reach_to_step=step_to_interrupt,
+        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
             skip_post_process=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
         )
 

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -118,21 +118,25 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
-            num_slices=slice_num,
-            cluster=test_config.cluster,
-            time_out_in_min=60,
-            test_name=f"{test_config.short_id}-emc",
-            run_model_cmds=workload_command,
-            docker_image=image.value,
-            test_owner=test_owner.DEPP_L,
-        ).to_node_interruption_task(
-            expect_reach_to_step=step_to_interrupt,
-        ).run(
-            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
-            mtc_enabled=True,
-            skip_post_process=True,
-            max_restart=15,
+        maxtext_chkpt_run_test = (
+            gke_config.get_gke_config(
+                num_slices=slice_num,
+                cluster=test_config.cluster,
+                time_out_in_min=60,
+                test_name=f"{test_config.short_id}-emc",
+                run_model_cmds=workload_command,
+                docker_image=image.value,
+                test_owner=test_owner.DEPP_L,
+            )
+            .to_node_interruption_task(
+                expect_reach_to_step=step_to_interrupt,
+            )
+            .run(
+                ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+                mtc_enabled=True,
+                skip_post_process=True,
+                max_restart=15,
+            )
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_emc_restore_local.py
+++ b/dags/orbax/maxtext_emc_restore_local.py
@@ -118,25 +118,20 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = (
-            gke_config.get_gke_config(
-                num_slices=slice_num,
-                cluster=test_config.cluster,
-                time_out_in_min=60,
-                test_name=f"{test_config.short_id}-emc",
-                run_model_cmds=workload_command,
-                docker_image=image.value,
-                test_owner=test_owner.DEPP_L,
-            )
-            .to_node_interruption_task(
-                expect_reach_to_step=step_to_interrupt,
-            )
-            .run(
-                ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
-                mtc_enabled=True,
-                skip_post_process=True,
-                max_restart=15,
-            )
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}-emc",
+            run_model_cmds=workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+            expect_reach_to_step=step_to_interrupt,
+        ).run(
+            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+            mtc_enabled=True,
+            skip_post_process=True,
+            max_restart=15,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -121,21 +121,25 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
-            num_slices=slice_num,
-            cluster=test_config.cluster,
-            time_out_in_min=60,
-            test_name=f"{test_config.short_id}-mtc",
-            run_model_cmds=workload_command,
-            docker_image=image.value,
-            test_owner=test_owner.DEPP_L,
-        ).to_node_interruption_task(
-            expect_reach_to_step=step_to_interrupt,
-        ).run(
-            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
-            mtc_enabled=True,
-            skip_post_process=True,
-            max_restart=15,
+        maxtext_chkpt_run_test = (
+            gke_config.get_gke_config(
+                num_slices=slice_num,
+                cluster=test_config.cluster,
+                time_out_in_min=60,
+                test_name=f"{test_config.short_id}-mtc",
+                run_model_cmds=workload_command,
+                docker_image=image.value,
+                test_owner=test_owner.DEPP_L,
+            )
+            .to_node_interruption_task(
+                expect_reach_to_step=step_to_interrupt,
+            )
+            .run(
+                ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+                mtc_enabled=True,
+                skip_post_process=True,
+                max_restart=15,
+            )
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -129,11 +129,12 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.DEPP_L,
-        ).run_with_node_interruption(
+        ).to_node_interruption_task(
+            expect_reach_to_step=step_to_interrupt,
+        ).run(
             ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
             mtc_enabled=True,
             skip_post_process=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
         )
 

--- a/dags/orbax/maxtext_mtc_restore_local.py
+++ b/dags/orbax/maxtext_mtc_restore_local.py
@@ -121,25 +121,20 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = (
-            gke_config.get_gke_config(
-                num_slices=slice_num,
-                cluster=test_config.cluster,
-                time_out_in_min=60,
-                test_name=f"{test_config.short_id}-mtc",
-                run_model_cmds=workload_command,
-                docker_image=image.value,
-                test_owner=test_owner.DEPP_L,
-            )
-            .to_node_interruption_task(
-                expect_reach_to_step=step_to_interrupt,
-            )
-            .run(
-                ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
-                mtc_enabled=True,
-                skip_post_process=True,
-                max_restart=15,
-            )
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}-mtc",
+            run_model_cmds=workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.DEPP_L,
+            expect_reach_to_step=step_to_interrupt,
+        ).run(
+            ramdisk_directory=test_config_util.DEFAULT_RAM_DISK,
+            mtc_enabled=True,
+            skip_post_process=True,
+            max_restart=15,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -130,26 +130,21 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = (
-            gke_config.get_gke_config(
-                num_slices=slice_num,
-                cluster=test_config.cluster,
-                time_out_in_min=60,
-                test_name=f"{test_config.short_id}",
-                run_model_cmds=workload_command,
-                docker_image=image.value,
-                test_owner=test_owner.SHARON_Y,
-            )
-            .to_node_interruption_task(
-                expect_reach_to_step=step_to_interrupt,
-                check_file_exists=True,
-            )
-            .run(
-                gcs_location=gcs_location,
-                xpk_branch=MAIN_BRANCH,
-                skip_post_process=True,
-                max_restart=15,
-            )
+        maxtext_chkpt_run_test = gke_config.get_gke_config_with_interrupt(
+            num_slices=slice_num,
+            cluster=test_config.cluster,
+            time_out_in_min=60,
+            test_name=f"{test_config.short_id}",
+            run_model_cmds=workload_command,
+            docker_image=image.value,
+            test_owner=test_owner.SHARON_Y,
+            expect_reach_to_step=step_to_interrupt,
+            check_file_exists=True,
+        ).run(
+            gcs_location=gcs_location,
+            xpk_branch=MAIN_BRANCH,
+            skip_post_process=True,
+            max_restart=15,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -138,13 +138,14 @@ with models.DAG(
             run_model_cmds=workload_command,
             docker_image=image.value,
             test_owner=test_owner.SHARON_Y,
-        ).run_with_node_interruption(
+        ).to_node_interruption_task(
+            expect_reach_to_step=step_to_interrupt,
+            check_file_exists=True,
+        ).run(
             gcs_location=gcs_location,
             xpk_branch=MAIN_BRANCH,
             skip_post_process=True,
-            expect_reach_to_step=step_to_interrupt,
             max_restart=15,
-            check_file_exists=True,
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
+++ b/dags/orbax/maxtext_reg_restore_gcs_with_node_disruption.py
@@ -130,22 +130,26 @@ with models.DAG(
             task_id="generate_start_time"
         )()
 
-        maxtext_chkpt_run_test = gke_config.get_gke_config(
-            num_slices=slice_num,
-            cluster=test_config.cluster,
-            time_out_in_min=60,
-            test_name=f"{test_config.short_id}",
-            run_model_cmds=workload_command,
-            docker_image=image.value,
-            test_owner=test_owner.SHARON_Y,
-        ).to_node_interruption_task(
-            expect_reach_to_step=step_to_interrupt,
-            check_file_exists=True,
-        ).run(
-            gcs_location=gcs_location,
-            xpk_branch=MAIN_BRANCH,
-            skip_post_process=True,
-            max_restart=15,
+        maxtext_chkpt_run_test = (
+            gke_config.get_gke_config(
+                num_slices=slice_num,
+                cluster=test_config.cluster,
+                time_out_in_min=60,
+                test_name=f"{test_config.short_id}",
+                run_model_cmds=workload_command,
+                docker_image=image.value,
+                test_owner=test_owner.SHARON_Y,
+            )
+            .to_node_interruption_task(
+                expect_reach_to_step=step_to_interrupt,
+                check_file_exists=True,
+            )
+            .run(
+                gcs_location=gcs_location,
+                xpk_branch=MAIN_BRANCH,
+                skip_post_process=True,
+                max_restart=15,
+            )
         )
 
         end_time = validation_util.generate_timestamp.override(

--- a/scripts/code-style.sh
+++ b/scripts/code-style.sh
@@ -22,14 +22,37 @@ FOLDERS_TO_FORMAT=("dags" "xlml")
 echo "[code-style] Running Semgrep static analysis..."
 semgrep --config scripts/semgrep-rules.yaml --error
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pyink "$folder" --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
-done
+HEAD_SHA="$(git rev-parse HEAD)"
+BASE_BRANCH="dev"
 
-for folder in "${FOLDERS_TO_FORMAT[@]}"
-do
-  pylint "./$folder" --fail-under=9.6
-done
+if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch origin "$BASE_BRANCH":"$BASE_BRANCH" || {
+    echo "[code-style] base branch '$BASE_BRANCH' not found, skip diff-based check."
+    exit 0
+  }
+fi
+
+CHANGED_PY_FILES="$(
+  git diff --name-only --diff-filter=ACM "${BASE_BRANCH}" "${HEAD_SHA}" \
+    | grep '\.py$' \
+    | while read -r f; do
+        for folder in "${FOLDERS_TO_FORMAT[@]}"; do
+          if [[ "$f" == "$folder/"* ]]; then
+            echo "$f"
+            break
+          fi
+        done
+      done \
+    | sort -u
+)"
+
+if [[ -z "${CHANGED_PY_FILES}" ]]; then
+  echo "[pre-push hook] no changed files detected between ${HEAD_SHA} and ${BASE_BRANCH}"
+  exit 1
+fi
+
+pyink ${CHANGED_PY_FILES} --pyink-indentation=2 --pyink-use-majority-quotes --line-length=80 --check --diff
+
+pylint ${CHANGED_PY_FILES} --fail-under=9.6 --disable=E1123
 
 echo "Successfully clean up all codes."

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -15,12 +15,15 @@
 """Base task file for a test job."""
 
 import abc
+import contextlib
 import dataclasses
 import datetime
 import shlex
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Tuple, Union
 
 import airflow
+from airflow.models import BaseOperator
+from airflow.models.baseoperator import chain
 from airflow.models.taskmixin import DAGNode
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
@@ -62,12 +65,12 @@ def run_queued_resource_test(
     # TODO(wcromar): make these args less verbose
     task_test_config: test_config.TestConfig[test_config.Tpu],
     task_gcp_config: gcp_config.GCPConfig,
-    task_metric_config: Optional[metric_config.MetricConfig] = None,
+    task_metric_config: metric_config.MetricConfig | None = None,
     tpu_create_timeout: datetime.timedelta = datetime.timedelta(minutes=60),
     tpu_name_env_var: bool = False,
     all_workers: bool = True,
     skip_post_process: bool = False,
-    custom_env: Optional[dict[str, str]] = None,
+    custom_env: dict[str, str] | None = None,
 ):
   """This is a class to set up tasks for TPU provisioned by Queued Resource.
 
@@ -304,21 +307,156 @@ class AXLearnTask(BaseTask):
           setups=dummy_op_for_teardown, on_failure_fail_dagrun=True
       )
 
-      # flow1: The launcher task (Kubernetes Pod) that runs the workload.
-      # flow2: The monitoring sidecar that tracks status and handles cleanup.
-      # We run them in parallel because flow1 blocks until completion;
-      # flow2 must run concurrently to monitor progress and ensure cleanup.
+      chain(wait_for_workload_start, wait_for_workload_completion, cleanup)
       flow1 = run_workload
-      flow2 = wait_for_workload_start >> wait_for_workload_completion >> cleanup
+      flow2 = wait_for_workload_start
 
-      _ = (
-          update_image_tag_cmd
-          >> gen_cmds
-          >> dummy_op_for_teardown
-          >> [flow1, flow2]
+      chain(
+          update_image_tag_cmd,
+          gen_cmds,
+          dummy_op_for_teardown,
+          # We run them in parallel because flow1 blocks until completion and
+          # flow2 must run concurrently to monitor progress and ensure cleanup.
+          [flow1, flow2],
       )
 
     return group
+
+
+@dataclasses.dataclass
+class XpkRunner:
+  """XpkRunner executes XPK workloads and manages their lifecycle."""
+
+  task_test_config: Union[
+      test_config.TpuGkeTest, test_config.GpuXpkTest, test_config.CpuGkeTest
+  ]
+  task_gcp_config: gcp_config.GCPConfig
+  workload_id: airflow.XComArg
+  gcs_path: airflow.XComArg
+  workload_provision_timeout: datetime.timedelta
+  use_vertex_tensorboard: bool = False
+  use_pathways: bool = False
+  ramdisk_directory: str = ""
+  mtc_enabled: bool = False
+  xpk_branch: str = xpk.MAIN_BRANCH
+  max_restart: int = 0
+  priority: str = "high"
+
+  def launch_workload(self) -> DAGNode:
+    """Create the workload and wait for it to provision."""
+    with TaskGroup(group_id="launch_workload") as group:
+      run_workload = xpk.run_workload.override(
+          owner=self.task_test_config.task_owner
+      )(
+          task_id="run_workload",
+          cluster_project=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          benchmark_id=self.task_test_config.benchmark_id,
+          workload_id=self.workload_id,
+          gcs_path=self.gcs_path,
+          docker_image=self.task_test_config.docker_image,
+          accelerator_type=self.task_test_config.accelerator.name,
+          run_cmds=self.task_test_config.test_script,
+          num_slices=self.task_test_config.num_slices,
+          use_vertex_tensorboard=self.use_vertex_tensorboard,
+          use_pathways=self.use_pathways,
+          ramdisk_directory=self.ramdisk_directory,
+          mtc_enabled=self.mtc_enabled,
+          xpk_branch=self.xpk_branch,
+          max_restart=self.max_restart,
+          priority=self.priority,
+      )
+      wait_for_workload_start = xpk.wait_for_workload_start.override(
+          timeout=self.workload_provision_timeout.total_seconds()
+      )(
+          workload_id=self.workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.task_gcp_config.zone),
+          cluster_name=self.task_test_config.cluster_name,
+      )
+      chain(run_workload, wait_for_workload_start)
+      return group
+
+  def wait_workload_complete(self) -> BaseOperator:
+    return xpk.wait_for_workload_completion.override(
+        timeout=int(self.task_test_config.timeout.total_seconds()),
+    )(
+        workload_id=self.workload_id,
+        project_id=self.task_gcp_config.project_name,
+        region=gke.zone_to_region(self.task_gcp_config.zone),
+        cluster_name=self.task_test_config.cluster_name,
+    )
+
+  def cleanup_workload(self, tear_down_of: BaseOperator) -> DAGNode:
+    return xpk.clean_up_workload(
+        workload_id=self.workload_id,
+        project_id=self.task_gcp_config.project_name,
+        zone=self.task_gcp_config.zone,
+        cluster_name=self.task_test_config.cluster_name,
+        xpk_branch=self.xpk_branch,
+    ).as_teardown(
+        setups=tear_down_of,
+        on_failure_fail_dagrun=True,
+    )
+
+  def wait_workload_reach_to_step(
+      self,
+      expect_reach_to_step: int,
+      check_file_exists: bool,
+  ) -> DAGNode:
+    with TaskGroup(group_id="wait_workload") as group:
+      wait_reach_to_step = xpk.wait_for_workload_reach_step.override(
+          task_id="wait_for_workload_reach_step"
+      )(
+          workload_id=self.workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.task_gcp_config.zone),
+          cluster_name=self.task_test_config.cluster_name,
+          expect_reach_to_step=str(expect_reach_to_step),
+      )
+
+      task_id_wait_file_exist = "wait_for_file_to_exist"
+      wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
+          task_id=task_id_wait_file_exist
+      )(
+          file_path=(
+              f"{self.gcs_path}/{str(expect_reach_to_step)}/commit_success.txt"
+          ),
+      )
+      task_id_do_nothing = "do_nothing"
+      do_nothing = EmptyOperator(task_id=task_id_do_nothing)
+
+      @task.branch
+      def task_path_decider(check_file_exists: bool = False) -> str:
+        """Dynamically route the workflow depending on check_file_exists."""
+        if check_file_exists:
+          return f"{group.group_id}.{task_id_wait_file_exist}"
+        return f"{group.group_id}.{task_id_do_nothing}"
+
+      # Conditional checks: depending on the `check_file_exists` argument
+      # specified by the upper-level caller.
+      maybe_check_file_exists = task_path_decider(check_file_exists)
+
+      chain(
+          wait_reach_to_step,
+          maybe_check_file_exists,
+          [wait_for_file_to_exist, do_nothing],
+      )
+
+      return group
+
+  def interrupt_workload(self, is_targeting_on_last_node: bool) -> DAGNode:
+    return xpk.delete_node.override(
+        owner=self.task_test_config.task_owner, trigger_rule="none_failed"
+    )(
+        project=self.task_gcp_config.project_name,
+        zone=self.task_gcp_config.zone,
+        cluster_name=self.task_test_config.cluster_name,
+        workload_id=self.workload_id,
+        dry_run=False,
+        last_node=is_targeting_on_last_node,
+    )
 
 
 @dataclasses.dataclass
@@ -336,7 +474,7 @@ class XpkTask(BaseTask):
       test_config.TpuGkeTest, test_config.GpuXpkTest, test_config.CpuGkeTest
   ]
   task_gcp_config: gcp_config.GCPConfig
-  task_metric_config: Optional[metric_config.MetricConfig] = None
+  task_metric_config: metric_config.MetricConfig | None = None
   workload_provision_timeout: datetime.timedelta = datetime.timedelta(
       # Set the provision timeout from 300 to 60 minutes for decreasing the
       # duration of failed tasks
@@ -346,7 +484,7 @@ class XpkTask(BaseTask):
   def run(
       self,
       *,
-      gcs_location: Optional[airflow.XComArg] = None,
+      gcs_location: airflow.XComArg | None = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
       skip_post_process: bool = False,
@@ -368,138 +506,73 @@ class XpkTask(BaseTask):
       post_process.
     """
     with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      pre_process = self.pre_process()
-      run_model, gcs_path = self.run_model(
+      pre_process, xpk_runner = self._pre_process(
           gcs_location=gcs_location,
           use_vertex_tensorboard=use_vertex_tensorboard,
           use_pathways=use_pathways,
-          skip_post_process=skip_post_process,
           ramdisk_directory=ramdisk_directory,
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
       )
-      if pre_process:
-        _ = pre_process >> run_model
 
+      run_model = self._run_model(xpk_runner)
+
+      nodes = [pre_process, run_model]
       if not skip_post_process:
-        _ = run_model >> self.post_process(gcs_path)
+        nodes.append(self._post_process(xpk_runner.gcs_path))
+
+      chain(*nodes)
 
     return group
 
-  def run_model(
+  def _run_model(self, xpk_runner: XpkRunner) -> DAGNode:
+    with TaskGroup(group_id="run_model") as group:
+      dummy_op = self._dummy_op_for_teardown()
+
+      chain(
+          dummy_op,
+          xpk_runner.launch_workload(),
+          xpk_runner.wait_workload_complete(),
+          xpk_runner.cleanup_workload(tear_down_of=dummy_op),
+      )
+      return group
+
+  def _maybe_generate_gcs_location(
       self,
-      gcs_location: Optional[airflow.XComArg] = None,
+      gcs_location: airflow.XComArg | None = None,
+  ) -> airflow.XComArg:
+    if gcs_location:
+      return gcs_location
+
+    return name_format.generate_gcs_folder_location(
+        self.task_test_config.gcs_subfolder,
+        self.task_test_config.benchmark_id,
+    )
+
+  def _pre_process(
+      self,
+      gcs_location: airflow.XComArg | None = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
-      skip_post_process: bool = False,  # pylint: disable=unused-argument
       ramdisk_directory: str = "",
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
-      check_file_exists: bool = False,  # pylint: disable=unused-argument
       priority: str = "high",
-  ) -> Tuple[DAGNode, str]:
-    """Run a test job within a docker image.
-
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
-      use_pathways: Set to True to use the Pathways execution framework.
-      skip_post_process: If True, the post processing step will be skipped.
-      ramdisk_directory: The directory for enabling emergency checkpointing.
-      mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
-      xpk_branch: The specific git branch of the xpk tool to use.
-      max_restart: By default, this is 0.
-        This will restart the job with flag "--max-restarts"
-    Returns:
-      A tuple of a DAG node that executes the model test and the GCS path.
-    """
-    with TaskGroup(group_id="run_model") as group:
+  ) -> tuple[DAGNode, XpkRunner]:
+    with TaskGroup(group_id="pre_process") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      if gcs_location:
-        gcs_path = gcs_location
-      else:
-        gcs_path = name_format.generate_gcs_folder_location(
-            self.task_test_config.gcs_subfolder,
-            self.task_test_config.benchmark_id,
-        )
 
-      dummy_op_for_teardown = EmptyOperator(
-          task_id="dummy_op_for_teardown"
-      ).as_setup()
+      gcs_path = self._maybe_generate_gcs_location(gcs_location)
 
-      launch_workload = self.launch_workload(
-          workload_id,
-          gcs_path,
-          use_vertex_tensorboard,
-          use_pathways,
-          ramdisk_directory,
-          mtc_enabled,
-          xpk_branch,
-          max_restart,
-          priority=priority,
-      )
-      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-          timeout=int(self.task_test_config.timeout.total_seconds()),
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
-
-      clean_up_workload = xpk.clean_up_workload(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          xpk_branch=xpk_branch,
-      ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
-
-      intermediary_flow = self.intermediary_flow(
-          launch_workload, workload_id, gcs_path, xpk_branch
-      )
-
-      _ = dummy_op_for_teardown >> launch_workload
-      _ = (
-          (workload_id, gcs_path)
-          >> intermediary_flow
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
-      return group, gcs_path
-
-  def launch_workload(
-      self,
-      workload_id: str,
-      gcs_path: str,
-      use_vertex_tensorboard: bool,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
-  ) -> DAGNode:
-    """Create the workload and wait for it to provision."""
-    with TaskGroup(group_id="launch_workload") as group:
-      run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
-      )(
-          task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
+      xpk_runner = XpkRunner(
+          task_test_config=self.task_test_config,
+          task_gcp_config=self.task_gcp_config,
           workload_id=workload_id,
           gcs_path=gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
+          workload_provision_timeout=self.workload_provision_timeout,
           use_vertex_tensorboard=use_vertex_tensorboard,
           use_pathways=use_pathways,
           ramdisk_directory=ramdisk_directory,
@@ -508,26 +581,10 @@ class XpkTask(BaseTask):
           max_restart=max_restart,
           priority=priority,
       )
-      wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
-      _ = run_workload >> wait_for_workload_start
-      return group
 
-  def pre_process(self) -> Optional[DAGNode]:
-    """Perform pre-processing tasks before running the workload.
+    return group, xpk_runner
 
-    Returns:
-      An optional DAG node that executes before run_model.
-    """
-    return None
-
-  def post_process(self, result_location: Optional[str] = None) -> DAGNode:
+  def _post_process(self, result_location: str | None = None) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
     Returns:
@@ -549,24 +606,18 @@ class XpkTask(BaseTask):
                 self.task_metric_config.profile.file_location
             )
         )
-        _ = (
-            process_id
-            >> self.task_metric_config.profile.metrics
-            >> post_process_metrics
+        chain(
+            process_id,
+            self.task_metric_config.profile.metrics,
+            post_process_metrics,
         )
       else:
-        _ = process_id >> post_process_metrics
+        chain(process_id, post_process_metrics)
 
       return group
 
-  def intermediary_flow(
-      self,
-      launch_workload: DAGNode,
-      workload_id: str,  # pylint: disable=unused-argument
-      gcs_path: str,  # pylint: disable=unused-argument
-      xpk_branch: str,  # pylint: disable=unused-argument
-  ) -> DAGNode:
-    return launch_workload
+  def _dummy_op_for_teardown(self) -> BaseOperator:
+    return EmptyOperator(task_id="dummy_op_for_teardown").as_setup()
 
 
 @dataclasses.dataclass
@@ -577,85 +628,23 @@ class XpkNodeInterruptionTask(XpkTask):
   last_node: bool = False
   check_file_exists: bool = False
 
-  def intermediary_flow(
-      self,
-      launch_workload: DAGNode,
-      workload_id: str,
-      gcs_path: str,
-      xpk_branch: str,
-  ) -> DAGNode:
-    """Inject interruption steps after launch_workload."""
-    return self.wait_for_workload_reach_step_and_interruption(
-        launch_workload, workload_id, gcs_path, xpk_branch
-    )
+  def _run_model(self, xpk_runner: XpkRunner) -> DAGNode:
+    with TaskGroup(group_id="run_model") as group:
+      dummy_op = self._dummy_op_for_teardown()
 
-  def wait_for_workload_reach_step_and_interruption(
-      self,
-      launch_workload: DAGNode,
-      workload_id: str,
-      gcs_path: str,
-      xpk_branch: str,  # pylint: disable=unused-argument
-  ) -> DAGNode:
-    """Wait for workload to reach specific step and trigger node deletion."""
-    with TaskGroup(
-        group_id="wait_for_workload_reach_step_and_interruption"
-    ) as group:
-      wait_for_workload_to_reach_step = (
-          xpk.wait_for_workload_reach_step.override(
-              task_id="wait_for_workload_reach_step"
-          )(
-              workload_id=workload_id,
-              project_id=self.task_gcp_config.project_name,
-              region=gke.zone_to_region(self.task_gcp_config.zone),
-              cluster_name=self.task_test_config.cluster_name,
-              expect_reach_to_step=str(self.expect_reach_to_step),
-          )
-      )
-
-      task_id_wait_file_exist = "wait_for_file_to_exist"
-      wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
-          task_id=task_id_wait_file_exist
-      )(
-          file_path=(
-              f"{gcs_path}/{str(self.expect_reach_to_step)}/commit_success.txt"
+      chain(
+          dummy_op,
+          xpk_runner.launch_workload(),
+          xpk_runner.wait_workload_reach_to_step(
+              self.expect_reach_to_step,
+              self.check_file_exists,
           ),
-      )
-      task_id_do_nothing = "do_nothing"
-      do_nothing = EmptyOperator(task_id=task_id_do_nothing)
-
-      @task.branch
-      def task_path_decider(check_file_exists: bool = False) -> str:
-        """Dynamically route the workflow depending on the
-        `check_file_exists`.
-        """
-        if check_file_exists:
-          return f"{group.group_id}.{task_id_wait_file_exist}"
-        return f"{group.group_id}.{task_id_do_nothing}"
-
-      # Conditional checks: depending on the `check_file_exists` argument
-      # specified by the upper-level caller.
-      maybe_check_file_exists = task_path_decider(self.check_file_exists)
-
-      run_node_interruption = xpk.delete_node.override(
-          owner=self.task_test_config.task_owner, trigger_rule="none_failed"
-      )(
-          project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          workload_id=workload_id,
-          dry_run=False,
-          last_node=self.last_node,
+          xpk_runner.interrupt_workload(self.last_node),
+          xpk_runner.wait_workload_complete(),
+          xpk_runner.cleanup_workload(tear_down_of=dummy_op),
       )
 
-      _ = (
-          launch_workload
-          >> wait_for_workload_to_reach_step
-          >> maybe_check_file_exists
-      )
-      _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
-      _ = [wait_for_file_to_exist, do_nothing] >> run_node_interruption
-
-    return group
+      return group
 
 
 @dataclasses.dataclass
@@ -666,51 +655,10 @@ class XpkNameGenAndQuarantineTask(XpkTask):
   run_name_env: str = "M_RUN_NAME"
   nested_run_name_in_tb_file_location: bool = True
 
-  def pre_process(self) -> Optional[DAGNode]:
-    """Generate run name and update metric file locations."""
-    with TaskGroup(group_id="pre_process") as group:
-      run_name_task = name_format.generate_run_name(
-          self.task_test_config.benchmark_id
-      )
-      tb_file_location_task = name_format.generate_tb_file_location(
-          run_name_task,
-          self.task_metric_config.tensorboard_summary.file_location,
-          self.nested_run_name_in_tb_file_location,
-      )
-
-      # Set run_name in run_model_cmds
-      new_run_model_cmds = [f"export {self.run_name_env}={run_name_task}"]
-      for cmd in self.task_test_config.run_model_cmds:
-        new_run_model_cmds.append(cmd)
-      self.task_test_config.run_model_cmds = new_run_model_cmds
-
-      # Update tensorboard file location
-      self.task_metric_config.tensorboard_summary.file_location = (
-          tb_file_location_task
-      )
-
-      # Update profile file location if profile config exists
-      if self.task_metric_config and self.task_metric_config.profile:
-        profile_file_location_task = name_format.generate_profile_file_location(
-            run_name_task,
-            self.task_metric_config.profile.file_location,
-        )
-        self.task_metric_config.profile.file_location = (
-            profile_file_location_task
-        )
-        _ = run_name_task >> (
-            tb_file_location_task,
-            profile_file_location_task,
-        )
-      else:
-        _ = run_name_task >> tb_file_location_task
-
-      return group
-
   def run(
       self,
       *,
-      gcs_location: Optional[airflow.XComArg] = None,
+      gcs_location: airflow.XComArg | None = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
       skip_post_process: bool = False,
@@ -720,24 +668,25 @@ class XpkNameGenAndQuarantineTask(XpkTask):
       max_restart: int = 0,
       priority: str = "high",
   ) -> DAGNode:
-    """Run a test job with name generation and quarantine."""
-    test_name = self.task_test_config.benchmark_id
+    """Generate a unique run name, tensorboard file location,
+    and profile file location (if metric config has profile),
+    then run a test job within a docker image.
 
-    # Run under quarantine task group if applicable
-    if QuarantineTests.is_quarantined(test_name) and self.quarantine_task_group:
-      with self.quarantine_task_group:
-        return super().run(
-            gcs_location=gcs_location,
-            use_vertex_tensorboard=use_vertex_tensorboard,
-            use_pathways=use_pathways,
-            skip_post_process=skip_post_process,
-            ramdisk_directory=ramdisk_directory,
-            mtc_enabled=mtc_enabled,
-            xpk_branch=xpk_branch,
-            max_restart=max_restart,
-            priority=priority,
-        )
-    else:
+    Returns:
+      A task group with the following tasks chained: generate_run_name,
+      generate_tb_file_location, generate_profile_file_location (optional),
+      run provision, run_model, post_process.
+    """
+
+    test_name = self.task_test_config.benchmark_id
+    cm = (
+        self.quarantine_task_group
+        if QuarantineTests.is_quarantined(test_name)
+        and self.quarantine_task_group
+        else contextlib.nullcontext()
+    )
+
+    with cm:
       return super().run(
           gcs_location=gcs_location,
           use_vertex_tensorboard=use_vertex_tensorboard,
@@ -749,6 +698,73 @@ class XpkNameGenAndQuarantineTask(XpkTask):
           max_restart=max_restart,
           priority=priority,
       )
+
+  def _pre_process(
+      self,
+      gcs_location: airflow.XComArg | None = None,
+      use_vertex_tensorboard: bool = False,
+      use_pathways: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      max_restart: int = 0,
+      priority: str = "high",
+  ) -> tuple[DAGNode, XpkRunner]:
+    with TaskGroup(group_id="pre_process") as group:
+      run_name = name_format.generate_run_name(
+          self.task_test_config.benchmark_id
+      )
+      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+
+      gcs_path = self._maybe_generate_gcs_location(gcs_location)
+
+      nodes = [run_name]
+
+      tb_file_location = name_format.generate_tb_file_location(
+          run_name,
+          self.task_metric_config.tensorboard_summary.file_location,
+          self.nested_run_name_in_tb_file_location,
+      )
+
+      # Set run_name in run_model_cmds
+      new_run_model_cmds = [f"export {self.run_name_env}={run_name}"]
+      for cmd in self.task_test_config.run_model_cmds:
+        new_run_model_cmds.append(cmd)
+      self.task_test_config.run_model_cmds = new_run_model_cmds
+
+      # Update tensorboard file location
+      self.task_metric_config.tensorboard_summary.file_location = (
+          tb_file_location
+      )
+
+      # Update profile file location
+      if self.task_metric_config and self.task_metric_config.profile:
+        profile_file_location = name_format.generate_profile_file_location(
+            run_name, self.task_metric_config.profile.file_location
+        )
+        self.task_metric_config.profile.file_location = profile_file_location
+        nodes.append([tb_file_location, profile_file_location])
+      else:
+        nodes.append(tb_file_location)
+
+      xpk_runner = XpkRunner(
+          task_test_config=self.task_test_config,
+          task_gcp_config=self.task_gcp_config,
+          workload_id=workload_id,
+          gcs_path=gcs_path,
+          workload_provision_timeout=self.workload_provision_timeout,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=use_pathways,
+          ramdisk_directory=ramdisk_directory,
+          mtc_enabled=mtc_enabled,
+          xpk_branch=xpk_branch,
+          max_restart=max_restart,
+          priority=priority,
+      )
+
+      chain(*nodes)
+
+    return group, xpk_runner
 
 
 @dataclasses.dataclass
@@ -771,7 +787,7 @@ class GpuCreateResourceTask(BaseTask):
   image_family: str
   task_test_config: test_config.TestConfig[test_config.Gpu]
   task_gcp_config: gcp_config.GCPConfig
-  task_metric_config: Optional[metric_config.MetricConfig] = None
+  task_metric_config: metric_config.MetricConfig | None = None
   gpu_create_timeout: datetime.timedelta = datetime.timedelta(minutes=60)
   install_nvidia_drivers: bool = False
   existing_instance_name: str = None
@@ -928,7 +944,7 @@ class GpuCreateResourceTask(BaseTask):
       self,
       resource: airflow.XComArg,
       ssh_keys: airflow.XComArg,
-      env: Optional[airflow.XComArg] = None,
+      env: airflow.XComArg | None = None,
   ) -> DAGNode:
     """Run the GPU test in `task_test_config`.
 
@@ -952,7 +968,7 @@ class GpuCreateResourceTask(BaseTask):
 
   def post_process(
       self,
-      result_location: Optional[airflow.XComArg] = None,
+      result_location: airflow.XComArg | None = None,
   ) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
@@ -1022,7 +1038,7 @@ class GpuGkeTask(BaseTask):
   task_gcp_config: gcp_config.GCPConfig
   cluster_name: str
   job_create_timeout: datetime.timedelta = datetime.timedelta(minutes=10)
-  task_metric_config: Optional[metric_config.MetricConfig] = None
+  task_metric_config: metric_config.MetricConfig | None = None
 
   def run(self) -> DAGNode:
     """Run a test job and do post data process.
@@ -1054,7 +1070,7 @@ class GpuGkeTask(BaseTask):
     return group
 
   def post_process(
-      self, result_location: Optional[airflow.XComArg] = None
+      self, result_location: airflow.XComArg | None = None
   ) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -387,7 +387,6 @@ class XpkTask(BaseTask):
       self,
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
-      expect_reach_to_step: int,
       use_pathways: bool = False,
       skip_post_process: bool = False,
       ramdisk_directory: str = "",
@@ -396,6 +395,7 @@ class XpkTask(BaseTask):
       last_node: bool = False,
       max_restart: int = 0,
       check_file_exists: bool = False,
+      priority: str = "high",
   ) -> DAGNode:
     """Run a test job within a docker image.
 
@@ -431,6 +431,11 @@ class XpkTask(BaseTask):
             self.task_test_config.gcs_subfolder,
             self.task_test_config.benchmark_id,
         )
+
+      dummy_op_for_teardown = EmptyOperator(
+          task_id="dummy_op_for_teardown"
+      ).as_setup()
+
       launch_workload = self.launch_workload(
           workload_id,
           gcs_path,
@@ -440,6 +445,7 @@ class XpkTask(BaseTask):
           mtc_enabled,
           xpk_branch,
           max_restart,
+          priority=priority,
       )
       wait_for_workload_completion = xpk.wait_for_workload_completion.override(
           timeout=int(self.task_test_config.timeout.total_seconds()),
@@ -458,9 +464,13 @@ class XpkTask(BaseTask):
           xpk_branch=xpk_branch,
       )
 
+      intermediary_flow = self.intermediary_flow(
+          launch_workload, workload_id, gcs_path, xpk_branch
+      )
+
       _ = (
           (workload_id, gcs_path)
-          >> launch_workload
+          >> intermediary_flow
           >> wait_for_workload_completion
           >> clean_up_workload
       )
@@ -476,6 +486,7 @@ class XpkTask(BaseTask):
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
+      priority: str = "high",
   ) -> DAGNode:
     """Create the workload and wait for it to provision."""
     with TaskGroup(group_id="launch_workload") as group:
@@ -499,6 +510,7 @@ class XpkTask(BaseTask):
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
           max_restart=max_restart,
+          priority=priority,
       )
       wait_for_workload_start = xpk.wait_for_workload_start.override(
           timeout=self.workload_provision_timeout.total_seconds()
@@ -543,6 +555,15 @@ class XpkTask(BaseTask):
 
       return group
 
+  def intermediary_flow(
+      self,
+      launch_workload: DAGNode,
+      workload_id: str,
+      gcs_path: str,
+      xpk_branch: str,
+  ) -> DAGNode:
+    return launch_workload
+
 
 @dataclasses.dataclass
 class XpkNodeInterruptionTask(XpkTask):
@@ -552,131 +573,55 @@ class XpkNodeInterruptionTask(XpkTask):
   last_node: bool = False
   check_file_exists: bool = False
 
-  def run_model(
+  def run(
       self,
+      *,
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
+      skip_post_process: bool = False,
       ramdisk_directory: str = "",
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
-  ) -> Tuple[DAGNode, str]:
-    """Run the TPU/GPU test in `task_test_config` using xpk.
+      priority: str = "high",
+  ) -> DAGNode:
+    """Run a test job with node interruption."""
+    return super().run(
+        gcs_location=gcs_location,
+        use_vertex_tensorboard=use_vertex_tensorboard,
+        use_pathways=use_pathways,
+        skip_post_process=skip_post_process,
+        ramdisk_directory=ramdisk_directory,
+        mtc_enabled=mtc_enabled,
+        xpk_branch=xpk_branch,
+        max_restart=max_restart,
+        priority=priority,
+    )
 
-    with interruption.
-    """
-    with TaskGroup(group_id="run_model") as group:
-      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      if gcs_location:
-        gcs_path = gcs_location
-      else:
-        gcs_path = name_format.generate_gcs_folder_location(
-            self.task_test_config.gcs_subfolder,
-            self.task_test_config.benchmark_id,
-        )
-
-      dummy_op_for_teardown = EmptyOperator(
-          task_id="dummy_op_for_teardown"
-      ).as_setup()
-
-      launch_workload_and_wait_for_reach_step = (
-          self.launch_workload_with_node_reach_to_step(
-              workload_id,
-              gcs_path,
-              expect_reach_to_step,
-              use_vertex_tensorboard,
-              use_pathways,
-              ramdisk_directory,
-              mtc_enabled,
-              xpk_branch,
-              max_restart,
-              check_file_exists,
-          )
-      )
-
-      run_node_interruption = xpk.delete_node.override(
-          owner=self.task_test_config.task_owner, trigger_rule="none_failed"
-      )(
-          project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          workload_id=workload_id,
-          dry_run=False,
-          last_node=last_node,
-      )
-
-      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-          timeout=int(self.task_test_config.timeout.total_seconds()),
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
-
-      clean_up_workload = xpk.clean_up_workload(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          xpk_branch=xpk_branch,
-      ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
-
-      _ = (
-          (workload_id, gcs_path)
-          >> dummy_op_for_teardown
-          >> launch_workload_and_wait_for_reach_step
-          >> run_node_interruption
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
-    return group, gcs_path
-
-  def launch_workload_with_node_reach_to_step(
+  def intermediary_flow(
       self,
+      launch_workload: DAGNode,
       workload_id: str,
       gcs_path: str,
-      expect_reach_to_step: int,
-      use_vertex_tensorboard: bool,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
+      xpk_branch: str,
   ) -> DAGNode:
-    """Create the workload and wait for it to provision."""
-    with TaskGroup(group_id="launch_workload_with_node_reach_to_step") as group:
-      run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
-      )(
-          task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
-          workload_id=workload_id,
-          gcs_path=gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          max_restart=max_restart,
-      )
-      wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
+    """Inject interruption steps after launch_workload."""
+    return self.wait_for_workload_reach_step_and_interruption(
+        launch_workload, workload_id, gcs_path, xpk_branch
+    )
+
+  def wait_for_workload_reach_step_and_interruption(
+      self,
+      launch_workload: DAGNode,
+      workload_id: str,
+      gcs_path: str,
+      xpk_branch: str,
+  ) -> DAGNode:
+    """Wait for workload to reach specific step and trigger node deletion."""
+    with TaskGroup(
+        group_id="wait_for_workload_reach_step_and_interruption"
+    ) as group:
       wait_for_workload_to_reach_step = (
           xpk.wait_for_workload_reach_step.override(
               task_id="wait_for_workload_reach_step"
@@ -685,7 +630,7 @@ class XpkNodeInterruptionTask(XpkTask):
               project_id=self.task_gcp_config.project_name,
               region=gke.zone_to_region(self.task_gcp_config.zone),
               cluster_name=self.task_test_config.cluster_name,
-              expect_reach_to_step=str(expect_reach_to_step),
+              expect_reach_to_step=str(self.expect_reach_to_step),
           )
       )
 
@@ -694,7 +639,7 @@ class XpkNodeInterruptionTask(XpkTask):
           task_id=task_id_wait_file_exist
       )(
           file_path=(
-              f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt"
+              f"{gcs_path}/{str(self.expect_reach_to_step)}/commit_success.txt"
           ),
       )
       task_id_do_nothing = "do_nothing"
@@ -711,258 +656,136 @@ class XpkNodeInterruptionTask(XpkTask):
 
       # Conditional checks: depending on the `check_file_exists` argument
       # specified by the upper-level caller.
-      maybe_check_file_exists = task_path_decider(check_file_exists)
+      maybe_check_file_exists = task_path_decider(self.check_file_exists)
+
+      run_node_interruption = xpk.delete_node.override(
+          owner=self.task_test_config.task_owner, trigger_rule="none_failed"
+      )(
+          project=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          workload_id=workload_id,
+          dry_run=False,
+          last_node=self.last_node,
+      )
 
       _ = (
-          run_workload
-          >> wait_for_workload_start
+          launch_workload
           >> wait_for_workload_to_reach_step
           >> maybe_check_file_exists
       )
       _ = maybe_check_file_exists >> [wait_for_file_to_exist, do_nothing]
+      _ = [wait_for_file_to_exist, do_nothing] >> run_node_interruption
 
-      return group
-
-  def run_with_name_gen_and_quarantine(
-      self,
-      quarantine_task_group,
-      use_pathways: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      run_name_env: str = "M_RUN_NAME",
-      nested_run_name_in_tb_file_location: bool = True,
-  ) -> DAGNode:
-    test_name = self.task_test_config.benchmark_id
-    if QuarantineTests.is_quarantined(test_name) and self.quarantine_task_group:
-      with self.quarantine_task_group:
-        return self.run_with_run_name_generation(
-            use_pathways,
-            xpk_branch,
-            run_name_env,
-            nested_run_name_in_tb_file_location,
-        )
-    else:
-      return self.run_with_run_name_generation(
-          use_pathways,
-          xpk_branch,
-          run_name_env,
-          nested_run_name_in_tb_file_location,
-      )
-
-  def run_with_run_name_generation(
-      self,
-      use_pathways: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      run_name_env: str = "M_RUN_NAME",
-      nested_run_name_in_tb_file_location: bool = True,
-  ) -> DAGNode:
-    """Generate a unique run name, tensorboard file location,
-    and profile file location (if metric config has profile),
-    then run a test job within a docker image.
-
-    Returns:
-      A task group with the following tasks chained: generate_run_name,
-      generate_tb_file_location, generate_profile_file_location (optional),
-      run provision, run_model, post_process.
-    """
-    with TaskGroup(
-        group_id=self.task_test_config.benchmark_id, prefix_group_id=True
-    ) as group:
-      run_name = name_format.generate_run_name(
-          self.task_test_config.benchmark_id
-      )
-      tb_file_location = name_format.generate_tb_file_location(
-          run_name,
-          self.task_metric_config.tensorboard_summary.file_location,
-          nested_run_name_in_tb_file_location,
-      )
-
-      # Set run_name in run_model_cmds
-      new_run_model_cmds = [f"export {run_name_env}={run_name}"]
-      for cmd in self.task_test_config.run_model_cmds:
-        new_run_model_cmds.append(cmd)
-      self.task_test_config.run_model_cmds = new_run_model_cmds
-
-      # Update tensorboard file location
-      self.task_metric_config.tensorboard_summary.file_location = (
-          tb_file_location
-      )
-
-      # Update profile file location
-      if self.task_metric_config.profile:
-        profile_file_location = name_format.generate_profile_file_location(
-            run_name, self.task_metric_config.profile.file_location
-        )
-        self.task_metric_config.profile.file_location = profile_file_location
-        run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
-        )
-        flow = (
-            run_name >> (tb_file_location, profile_file_location) >> run_model
-        )
-        if not skip_post_process:
-          _ = flow >> self.post_process(gcs_path)
-      else:
-        run_model, gcs_path = self.run_model(
-            use_pathways=use_pathways, xpk_branch=xpk_branch
-        )
-        _ = (
-            run_name
-            >> tb_file_location
-            >> run_model
-            >> self.post_process(gcs_path)
-        )
     return group
 
-  def run_model(
+@dataclasses.dataclass
+class XpkNameGenAndQuarantineTask(XpkTask):
+  """Task for running XPK workloads with name generation and quarantine."""
+
+  quarantine_task_group: Any = None
+  run_name_env: str = "M_RUN_NAME"
+  nested_run_name_in_tb_file_location: bool = True
+
+  # Temporary variables to pass tasks from run() to intermediary_flow()
+  _run_name_task: Any = dataclasses.field(default=None, init=False, repr=False)
+  _tb_file_location_task: Any = dataclasses.field(default=None, init=False, repr=False)
+  _profile_file_location_task: Any = dataclasses.field(default=None, init=False, repr=False)
+
+  def run(
       self,
+      *,
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
+      skip_post_process: bool = False,
       ramdisk_directory: str = "",
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
       priority: str = "high",
   ) -> DAGNode:
-    """Run the TPU/GPU test in `task_test_config` using xpk.
+    """Run a test job with name generation and quarantine."""
+    test_name = self.task_test_config.benchmark_id
 
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
+    # 1. Generate run name and file location tasks first (they are Airflow task objects)
+    self._run_name_task = name_format.generate_run_name(
+        self.task_test_config.benchmark_id
+    )
+    self._tb_file_location_task = name_format.generate_tb_file_location(
+        self._run_name_task,
+        self.task_metric_config.tensorboard_summary.file_location,
+        self.nested_run_name_in_tb_file_location,
+    )
 
-    Returns:
-      A DAG node that executes the model test.
-    """
-    with TaskGroup(group_id="run_model") as group:
-      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
-      if gcs_location:
-        gcs_path = gcs_location
-      else:
-        gcs_path = name_format.generate_gcs_folder_location(
-            self.task_test_config.gcs_subfolder,
-            self.task_test_config.benchmark_id,
+    # Set run_name in run_model_cmds
+    new_run_model_cmds = [f"export {self.run_name_env}={self._run_name_task}"]
+    for cmd in self.task_test_config.run_model_cmds:
+      new_run_model_cmds.append(cmd)
+    self.task_test_config.run_model_cmds = new_run_model_cmds
+
+    # Update tensorboard file location
+    self.task_metric_config.tensorboard_summary.file_location = (
+        self._tb_file_location_task
+    )
+
+    # Update profile file location if profile config exists
+    if self.task_metric_config.profile:
+      self._profile_file_location_task = name_format.generate_profile_file_location(
+          self._run_name_task, self.task_metric_config.profile.file_location
+      )
+      self.task_metric_config.profile.file_location = self._profile_file_location_task
+
+    # 2. Run under quarantine task group if applicable
+    if QuarantineTests.is_quarantined(test_name) and self.quarantine_task_group:
+      with self.quarantine_task_group:
+        return super().run(
+            gcs_location=gcs_location,
+            use_vertex_tensorboard=use_vertex_tensorboard,
+            use_pathways=use_pathways,
+            skip_post_process=skip_post_process,
+            ramdisk_directory=ramdisk_directory,
+            mtc_enabled=mtc_enabled,
+            xpk_branch=xpk_branch,
+            max_restart=max_restart,
+            priority=priority,
         )
-
-      dummy_op_for_teardown = EmptyOperator(
-          task_id="dummy_op_for_teardown"
-      ).as_setup()
-
-      launch_workload = self.launch_workload(
-          workload_id,
-          gcs_path,
-          use_vertex_tensorboard,
-          use_pathways,
-          ramdisk_directory,
-          mtc_enabled,
-          xpk_branch,
-          max_restart,
-          priority=priority,
-      )
-      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
-          timeout=int(self.task_test_config.timeout.total_seconds()),
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
-      )
-
-      clean_up_workload = xpk.clean_up_workload(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          xpk_branch=xpk_branch,
-      ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
-
-      _ = (
-          (workload_id, gcs_path)
-          >> dummy_op_for_teardown
-          >> launch_workload
-          >> wait_for_workload_completion
-          >> clean_up_workload
-      )
-      return group, gcs_path
-
-  def launch_workload(
-      self,
-      workload_id: str,
-      gcs_path: str,
-      use_vertex_tensorboard: bool,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
-  ) -> DAGNode:
-    """Create the workload and wait for it to provision."""
-    with TaskGroup(group_id="launch_workload") as group:
-      run_workload = xpk.run_workload.override(
-          owner=self.task_test_config.task_owner
-      )(
-          task_id="run_workload",
-          cluster_project=self.task_gcp_config.project_name,
-          zone=self.task_gcp_config.zone,
-          cluster_name=self.task_test_config.cluster_name,
-          benchmark_id=self.task_test_config.benchmark_id,
-          workload_id=workload_id,
-          gcs_path=gcs_path,
-          docker_image=self.task_test_config.docker_image,
-          accelerator_type=self.task_test_config.accelerator.name,
-          run_cmds=self.task_test_config.test_script,
-          num_slices=self.task_test_config.num_slices,
+    else:
+      return super().run(
+          gcs_location=gcs_location,
           use_vertex_tensorboard=use_vertex_tensorboard,
           use_pathways=use_pathways,
+          skip_post_process=skip_post_process,
           ramdisk_directory=ramdisk_directory,
           mtc_enabled=mtc_enabled,
           xpk_branch=xpk_branch,
           max_restart=max_restart,
           priority=priority,
       )
-      wait_for_workload_start = xpk.wait_for_workload_start.override(
-          timeout=self.workload_provision_timeout.total_seconds()
-      )(
-          workload_id=workload_id,
-          project_id=self.task_gcp_config.project_name,
-          region=gke.zone_to_region(self.task_gcp_config.zone),
-          cluster_name=self.task_test_config.cluster_name,
+
+  def intermediary_flow(
+      self,
+      launch_workload: DAGNode,
+      workload_id: str,
+      gcs_path: str,
+      xpk_branch: str,
+  ) -> DAGNode:
+    """Inject name generation tasks before launch_workload."""
+    if self.task_metric_config.profile:
+      flow = (
+          self._run_name_task
+          >> (self._tb_file_location_task, self._profile_file_location_task)
+          >> launch_workload
       )
-      _ = run_workload >> wait_for_workload_start
-      return group
-
-  def post_process(self, result_location: Optional[str] = None) -> DAGNode:
-    """Process metrics and metadata, and insert them into BigQuery tables.
-
-    Returns:
-      A DAG node that executes the post process.
-    """
-    with TaskGroup(group_id="post_process") as group:
-      process_id = metric.generate_process_id.override(retries=0)()
-      post_process_metrics = metric.process_metrics.override(retries=0)(
-          process_id,
-          self.task_test_config,
-          self.task_metric_config,
-          self.task_gcp_config,
-          folder_location=result_location,
+    else:
+      flow = (
+          self._run_name_task
+          >> self._tb_file_location_task
+          >> launch_workload
       )
+    return flow
 
-      if self.task_metric_config and self.task_metric_config.profile:
-        self.task_metric_config.profile.metrics = (
-            metric.xplane_to_metrics.override(retries=0)(
-                self.task_metric_config.profile.file_location
-            )
-        )
-        _ = (
-            process_id
-            >> self.task_metric_config.profile.metrics
-            >> post_process_metrics
-        )
-      else:
-        _ = process_id >> post_process_metrics
 
-      return group
 
 
 @dataclasses.dataclass

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -681,6 +681,7 @@ class XpkNodeInterruptionTask(XpkTask):
 
     return group
 
+
 @dataclasses.dataclass
 class XpkNameGenAndQuarantineTask(XpkTask):
   """Task for running XPK workloads with name generation and quarantine."""
@@ -691,8 +692,12 @@ class XpkNameGenAndQuarantineTask(XpkTask):
 
   # Temporary variables to pass tasks from run() to intermediary_flow()
   _run_name_task: Any = dataclasses.field(default=None, init=False, repr=False)
-  _tb_file_location_task: Any = dataclasses.field(default=None, init=False, repr=False)
-  _profile_file_location_task: Any = dataclasses.field(default=None, init=False, repr=False)
+  _tb_file_location_task: Any = dataclasses.field(
+      default=None, init=False, repr=False
+  )
+  _profile_file_location_task: Any = dataclasses.field(
+      default=None, init=False, repr=False
+  )
 
   def run(
       self,
@@ -733,10 +738,14 @@ class XpkNameGenAndQuarantineTask(XpkTask):
 
     # Update profile file location if profile config exists
     if self.task_metric_config.profile:
-      self._profile_file_location_task = name_format.generate_profile_file_location(
-          self._run_name_task, self.task_metric_config.profile.file_location
+      self._profile_file_location_task = (
+          name_format.generate_profile_file_location(
+              self._run_name_task, self.task_metric_config.profile.file_location
+          )
       )
-      self.task_metric_config.profile.file_location = self._profile_file_location_task
+      self.task_metric_config.profile.file_location = (
+          self._profile_file_location_task
+      )
 
     # 2. Run under quarantine task group if applicable
     if QuarantineTests.is_quarantined(test_name) and self.quarantine_task_group:
@@ -781,13 +790,9 @@ class XpkNameGenAndQuarantineTask(XpkTask):
       )
     else:
       flow = (
-          self._run_name_task
-          >> self._tb_file_location_task
-          >> launch_workload
+          self._run_name_task >> self._tb_file_location_task >> launch_workload
       )
     return flow
-
-
 
 
 @dataclasses.dataclass

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -383,38 +383,6 @@ class XpkTask(BaseTask):
 
     return group
 
-  def run_with_node_interruption(
-      self,
-      expect_reach_to_step: int,
-      last_node: bool = False,
-      check_file_exists: bool = False,
-  ) -> "XpkNodeInterruptionTask":
-    return XpkNodeInterruptionTask(
-        task_test_config=self.task_test_config,
-        task_gcp_config=self.task_gcp_config,
-        task_metric_config=self.task_metric_config,
-        workload_provision_timeout=self.workload_provision_timeout,
-        expect_reach_to_step=expect_reach_to_step,
-        last_node=last_node,
-        check_file_exists=check_file_exists,
-    )
-
-  def to_name_gen_and_quarantine_task(
-      self,
-      quarantine_task_group: Any = None,
-      run_name_env: str = "M_RUN_NAME",
-      nested_run_name_in_tb_file_location: bool = True,
-  ) -> "XpkNameGenAndQuarantineTask":
-    return XpkNameGenAndQuarantineTask(
-        task_test_config=self.task_test_config,
-        task_gcp_config=self.task_gcp_config,
-        task_metric_config=self.task_metric_config,
-        workload_provision_timeout=self.workload_provision_timeout,
-        quarantine_task_group=quarantine_task_group,
-        run_name_env=run_name_env,
-        nested_run_name_in_tb_file_location=nested_run_name_in_tb_file_location,
-    )
-
   def run_model(
       self,
       gcs_location: Optional[airflow.XComArg] = None,
@@ -584,50 +552,16 @@ class XpkNodeInterruptionTask(XpkTask):
   last_node: bool = False
   check_file_exists: bool = False
 
-  def run(
+  def run_model(
       self,
-      *,
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
-      skip_post_process: bool = False,
       ramdisk_directory: str = "",
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
       max_restart: int = 0,
-  ) -> DAGNode:
-    """Run a test job with node interruption."""
-    with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
-      run_model, gcs_path = self.run_model_with_node_interruption(
-          gcs_location=gcs_location,
-          use_vertex_tensorboard=use_vertex_tensorboard,
-          expect_reach_to_step=expect_reach_to_step,
-          use_pathways=use_pathways,
-          ramdisk_directory=ramdisk_directory,
-          mtc_enabled=mtc_enabled,
-          xpk_branch=xpk_branch,
-          last_node=last_node,
-          max_restart=max_restart,
-          check_file_exists=check_file_exists,
-      )
-      if not skip_post_process:
-        _ = run_model >> self.post_process(gcs_path)
-    return group
-
-  def run_model_with_node_interruption(
-      self,
-      *,
-      gcs_location: Optional[airflow.XComArg] = None,
-      use_vertex_tensorboard: bool = False,
-      expect_reach_to_step: int,
-      use_pathways: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      last_node: bool = False,
-      max_restart: int = 0,
-      check_file_exists: bool = False,
-  ) -> DAGNode:
+  ) -> Tuple[DAGNode, str]:
     """Run the TPU/GPU test in `task_test_config` using xpk.
 
     with interruption.

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -798,8 +798,8 @@ class XpkNodeInterruptionTask(XpkTask):
       nested_run_name_in_tb_file_location: bool = True,
   ) -> DAGNode:
     test_name = self.task_test_config.benchmark_id
-    if QuarantineTests.is_quarantined(test_name):
-      with quarantine_task_group:
+    if QuarantineTests.is_quarantined(test_name) and self.quarantine_task_group:
+      with self.quarantine_task_group:
         return self.run_with_run_name_generation(
             use_pathways,
             xpk_branch,

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -389,13 +389,13 @@ class XpkTask(BaseTask):
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
       use_pathways: bool = False,
-      skip_post_process: bool = False,
+      skip_post_process: bool = False,  # pylint: disable=unused-argument
       ramdisk_directory: str = "",
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
-      last_node: bool = False,
+      last_node: bool = False,  # pylint: disable=unused-argument
       max_restart: int = 0,
-      check_file_exists: bool = False,
+      check_file_exists: bool = False,  # pylint: disable=unused-argument
       priority: str = "high",
   ) -> DAGNode:
     """Run a test job within a docker image.
@@ -560,9 +560,9 @@ class XpkTask(BaseTask):
   def intermediary_flow(
       self,
       launch_workload: DAGNode,
-      workload_id: str,
-      gcs_path: str,
-      xpk_branch: str,
+      workload_id: str,  # pylint: disable=unused-argument
+      gcs_path: str,  # pylint: disable=unused-argument
+      xpk_branch: str,  # pylint: disable=unused-argument
   ) -> DAGNode:
     return launch_workload
 
@@ -618,7 +618,7 @@ class XpkNodeInterruptionTask(XpkTask):
       launch_workload: DAGNode,
       workload_id: str,
       gcs_path: str,
-      xpk_branch: str,
+      xpk_branch: str,  # pylint: disable=unused-argument
   ) -> DAGNode:
     """Wait for workload to reach specific step and trigger node deletion."""
     with TaskGroup(
@@ -715,7 +715,8 @@ class XpkNameGenAndQuarantineTask(XpkTask):
     """Run a test job with name generation and quarantine."""
     test_name = self.task_test_config.benchmark_id
 
-    # 1. Generate run name and file location tasks first (they are Airflow task objects)
+    # 1. Generate run name and file location tasks first
+    # (they are Airflow task objects)
     self._run_name_task = name_format.generate_run_name(
         self.task_test_config.benchmark_id
     )

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -18,7 +18,7 @@ import abc
 import dataclasses
 import datetime
 import shlex
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import airflow
 from airflow.models.taskmixin import DAGNode
@@ -42,7 +42,7 @@ class BaseTask(abc.ABC):
     Returns:
       A DAG node that executes this test.
     """
-    ...
+    pass
 
   def run_with_quarantine(self, quarantine_task_group):
     """Run a test job. If the test job is flaky, wrap it in a special task grop.
@@ -67,7 +67,7 @@ def run_queued_resource_test(
     tpu_name_env_var: bool = False,
     all_workers: bool = True,
     skip_post_process: bool = False,
-    custom_env: dict[str, str] = {},
+    custom_env: Optional[dict[str, str]] = None,
 ):
   """This is a class to set up tasks for TPU provisioned by Queued Resource.
 
@@ -93,6 +93,9 @@ def run_queued_resource_test(
       A task group with the following tasks chained: provision, run_model,
       post_process and clean_up.
   """
+
+  if custom_env is None:
+    custom_env = {}
 
   with TaskGroup(
       group_id=task_test_config.benchmark_id, prefix_group_id=True
@@ -335,7 +338,8 @@ class XpkTask(BaseTask):
   task_gcp_config: gcp_config.GCPConfig
   task_metric_config: Optional[metric_config.MetricConfig] = None
   workload_provision_timeout: datetime.timedelta = datetime.timedelta(
-      # Set the provision timeout from 300 to 60 minutes for decreasing the duration of failed tasks
+      # Set the provision timeout from 300 to 60 minutes for decreasing the
+      # duration of failed tasks
       minutes=60
   )
 
@@ -626,26 +630,7 @@ class XpkNodeInterruptionTask(XpkTask):
   ) -> DAGNode:
     """Run the TPU/GPU test in `task_test_config` using xpk.
 
-      Different behavior for testing node interruption.
-
-    Attributes:
-      gcs_location: GCS path for all artifacts of the test.
-      use_vertex_tensorboard: Set to True to view workload data on
-        Vertex AI Tensorboard.
-      expect_reach_to_step: The training step at which the node interruption
-        should be triggered.
-      use_pathways: Set to True to use the Pathways execution framework.
-      ramdisk_directory: The directory for enabling emergency checkpointing.
-      mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
-      xpk_branch: The specific git branch of the xpk tool to use.
-      last_node: If True, the interruption will target the last node in the
-        workload; otherwise, it targets the first node.
-      max_restart: By default, this is 0.
-        This will restart the job with flag "--max-restarts"
-      check_file_exists: By default, this is False. If set to True,
-        task branch task_path_decider will be performed.
-    Returns:
-      A DAG node that executes the model test.
+    with interruption.
     """
     with TaskGroup(group_id="run_model") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
@@ -774,15 +759,17 @@ class XpkNodeInterruptionTask(XpkTask):
       wait_for_file_to_exist = gcs.wait_for_file_to_exist.override(
           task_id=task_id_wait_file_exist
       )(
-          file_path=f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt",
+          file_path=(
+              f"{gcs_path}/{str(expect_reach_to_step)}/commit_success.txt"
+          ),
       )
       task_id_do_nothing = "do_nothing"
       do_nothing = EmptyOperator(task_id=task_id_do_nothing)
 
       @task.branch
       def task_path_decider(check_file_exists: bool = False) -> str:
-        """
-        Dynamically route the workflow depending on the `check_file_exists`.
+        """Dynamically route the workflow depending on the
+        `check_file_exists`.
         """
         if check_file_exists:
           return f"{group.group_id}.{task_id_wait_file_exist}"

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -462,12 +462,13 @@ class XpkTask(BaseTask):
           zone=self.task_gcp_config.zone,
           cluster_name=self.task_test_config.cluster_name,
           xpk_branch=xpk_branch,
-      )
+      ).as_teardown(setups=dummy_op_for_teardown, on_failure_fail_dagrun=True)
 
       intermediary_flow = self.intermediary_flow(
           launch_workload, workload_id, gcs_path, xpk_branch
       )
 
+      _ = dummy_op_for_teardown >> launch_workload
       _ = (
           (workload_id, gcs_path)
           >> intermediary_flow

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -369,13 +369,14 @@ class XpkTask(BaseTask):
     """
     with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
       run_model, gcs_path = self.run_model(
-          gcs_location,
-          use_vertex_tensorboard,
-          use_pathways,
-          ramdisk_directory,
-          mtc_enabled,
-          xpk_branch,
-          max_restart,
+          gcs_location=gcs_location,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=use_pathways,
+          skip_post_process=skip_post_process,
+          ramdisk_directory=ramdisk_directory,
+          mtc_enabled=mtc_enabled,
+          xpk_branch=xpk_branch,
+          max_restart=max_restart,
           priority=priority,
       )
       if not skip_post_process:

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -368,6 +368,7 @@ class XpkTask(BaseTask):
       post_process.
     """
     with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
+      pre_process = self.pre_process()
       run_model, gcs_path = self.run_model(
           gcs_location=gcs_location,
           use_vertex_tensorboard=use_vertex_tensorboard,
@@ -379,6 +380,9 @@ class XpkTask(BaseTask):
           max_restart=max_restart,
           priority=priority,
       )
+      if pre_process:
+        _ = pre_process >> run_model
+
       if not skip_post_process:
         _ = run_model >> self.post_process(gcs_path)
 
@@ -393,35 +397,25 @@ class XpkTask(BaseTask):
       ramdisk_directory: str = "",
       mtc_enabled: bool = False,
       xpk_branch: str = xpk.MAIN_BRANCH,
-      last_node: bool = False,  # pylint: disable=unused-argument
       max_restart: int = 0,
       check_file_exists: bool = False,  # pylint: disable=unused-argument
       priority: str = "high",
-  ) -> DAGNode:
+  ) -> Tuple[DAGNode, str]:
     """Run a test job within a docker image.
-
-       Will run a workload with an injected interruption of a GKE node.
-       Then is expected to automatically restart and continuing running.
 
     Attributes:
       gcs_location: GCS path for all artifacts of the test.
       use_vertex_tensorboard: Set to True to view workload data on
         Vertex AI Tensorboard.
-      expect_reach_to_step: The training step at which the node interruption
-        should be triggered.
       use_pathways: Set to True to use the Pathways execution framework.
       skip_post_process: If True, the post processing step will be skipped.
       ramdisk_directory: The directory for enabling emergency checkpointing.
       mtc_enabled: Set to True to enable Multi-tier Checkpointing (MTC).
       xpk_branch: The specific git branch of the xpk tool to use.
-      last_node: If True, the interruption will target the last node in the
-        workload; otherwise, it targets the first node.
       max_restart: By default, this is 0.
         This will restart the job with flag "--max-restarts"
-      check_file_exists: By default, this is False. If set to True,
-        task branch task_path_decider will be performed.
     Returns:
-      A DAG node that executes the model test.
+      A tuple of a DAG node that executes the model test and the GCS path.
     """
     with TaskGroup(group_id="run_model") as group:
       workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
@@ -525,6 +519,14 @@ class XpkTask(BaseTask):
       _ = run_workload >> wait_for_workload_start
       return group
 
+  def pre_process(self) -> Optional[DAGNode]:
+    """Perform pre-processing tasks before running the workload.
+
+    Returns:
+      An optional DAG node that executes before run_model.
+    """
+    return None
+
   def post_process(self, result_location: Optional[str] = None) -> DAGNode:
     """Process metrics and metadata, and insert them into BigQuery tables.
 
@@ -574,32 +576,6 @@ class XpkNodeInterruptionTask(XpkTask):
   expect_reach_to_step: int = 0
   last_node: bool = False
   check_file_exists: bool = False
-
-  def run(
-      self,
-      *,
-      gcs_location: Optional[airflow.XComArg] = None,
-      use_vertex_tensorboard: bool = False,
-      use_pathways: bool = False,
-      skip_post_process: bool = False,
-      ramdisk_directory: str = "",
-      mtc_enabled: bool = False,
-      xpk_branch: str = xpk.MAIN_BRANCH,
-      max_restart: int = 0,
-      priority: str = "high",
-  ) -> DAGNode:
-    """Run a test job with node interruption."""
-    return super().run(
-        gcs_location=gcs_location,
-        use_vertex_tensorboard=use_vertex_tensorboard,
-        use_pathways=use_pathways,
-        skip_post_process=skip_post_process,
-        ramdisk_directory=ramdisk_directory,
-        mtc_enabled=mtc_enabled,
-        xpk_branch=xpk_branch,
-        max_restart=max_restart,
-        priority=priority,
-    )
 
   def intermediary_flow(
       self,
@@ -690,14 +666,46 @@ class XpkNameGenAndQuarantineTask(XpkTask):
   run_name_env: str = "M_RUN_NAME"
   nested_run_name_in_tb_file_location: bool = True
 
-  # Temporary variables to pass tasks from run() to intermediary_flow()
-  _run_name_task: Any = dataclasses.field(default=None, init=False, repr=False)
-  _tb_file_location_task: Any = dataclasses.field(
-      default=None, init=False, repr=False
-  )
-  _profile_file_location_task: Any = dataclasses.field(
-      default=None, init=False, repr=False
-  )
+  def pre_process(self) -> Optional[DAGNode]:
+    """Generate run name and update metric file locations."""
+    with TaskGroup(group_id="pre_process") as group:
+      run_name_task = name_format.generate_run_name(
+          self.task_test_config.benchmark_id
+      )
+      tb_file_location_task = name_format.generate_tb_file_location(
+          run_name_task,
+          self.task_metric_config.tensorboard_summary.file_location,
+          self.nested_run_name_in_tb_file_location,
+      )
+
+      # Set run_name in run_model_cmds
+      new_run_model_cmds = [f"export {self.run_name_env}={run_name_task}"]
+      for cmd in self.task_test_config.run_model_cmds:
+        new_run_model_cmds.append(cmd)
+      self.task_test_config.run_model_cmds = new_run_model_cmds
+
+      # Update tensorboard file location
+      self.task_metric_config.tensorboard_summary.file_location = (
+          tb_file_location_task
+      )
+
+      # Update profile file location if profile config exists
+      if self.task_metric_config and self.task_metric_config.profile:
+        profile_file_location_task = name_format.generate_profile_file_location(
+            run_name_task,
+            self.task_metric_config.profile.file_location,
+        )
+        self.task_metric_config.profile.file_location = (
+            profile_file_location_task
+        )
+        _ = run_name_task >> (
+            tb_file_location_task,
+            profile_file_location_task,
+        )
+      else:
+        _ = run_name_task >> tb_file_location_task
+
+      return group
 
   def run(
       self,
@@ -715,40 +723,7 @@ class XpkNameGenAndQuarantineTask(XpkTask):
     """Run a test job with name generation and quarantine."""
     test_name = self.task_test_config.benchmark_id
 
-    # 1. Generate run name and file location tasks first
-    # (they are Airflow task objects)
-    self._run_name_task = name_format.generate_run_name(
-        self.task_test_config.benchmark_id
-    )
-    self._tb_file_location_task = name_format.generate_tb_file_location(
-        self._run_name_task,
-        self.task_metric_config.tensorboard_summary.file_location,
-        self.nested_run_name_in_tb_file_location,
-    )
-
-    # Set run_name in run_model_cmds
-    new_run_model_cmds = [f"export {self.run_name_env}={self._run_name_task}"]
-    for cmd in self.task_test_config.run_model_cmds:
-      new_run_model_cmds.append(cmd)
-    self.task_test_config.run_model_cmds = new_run_model_cmds
-
-    # Update tensorboard file location
-    self.task_metric_config.tensorboard_summary.file_location = (
-        self._tb_file_location_task
-    )
-
-    # Update profile file location if profile config exists
-    if self.task_metric_config.profile:
-      self._profile_file_location_task = (
-          name_format.generate_profile_file_location(
-              self._run_name_task, self.task_metric_config.profile.file_location
-          )
-      )
-      self.task_metric_config.profile.file_location = (
-          self._profile_file_location_task
-      )
-
-    # 2. Run under quarantine task group if applicable
+    # Run under quarantine task group if applicable
     if QuarantineTests.is_quarantined(test_name) and self.quarantine_task_group:
       with self.quarantine_task_group:
         return super().run(
@@ -774,26 +749,6 @@ class XpkNameGenAndQuarantineTask(XpkTask):
           max_restart=max_restart,
           priority=priority,
       )
-
-  def intermediary_flow(
-      self,
-      launch_workload: DAGNode,
-      workload_id: str,
-      gcs_path: str,
-      xpk_branch: str,
-  ) -> DAGNode:
-    """Inject name generation tasks before launch_workload."""
-    if self.task_metric_config.profile:
-      flow = (
-          self._run_name_task
-          >> (self._tb_file_location_task, self._profile_file_location_task)
-          >> launch_workload
-      )
-    else:
-      flow = (
-          self._run_name_task >> self._tb_file_location_task >> launch_workload
-      )
-    return flow
 
 
 @dataclasses.dataclass

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -381,7 +381,38 @@ class XpkTask(BaseTask):
 
   def run_with_node_interruption(
       self,
-      *,
+      expect_reach_to_step: int,
+      last_node: bool = False,
+      check_file_exists: bool = False,
+  ) -> "XpkNodeInterruptionTask":
+    return XpkNodeInterruptionTask(
+        task_test_config=self.task_test_config,
+        task_gcp_config=self.task_gcp_config,
+        task_metric_config=self.task_metric_config,
+        workload_provision_timeout=self.workload_provision_timeout,
+        expect_reach_to_step=expect_reach_to_step,
+        last_node=last_node,
+        check_file_exists=check_file_exists,
+    )
+
+  def to_name_gen_and_quarantine_task(
+      self,
+      quarantine_task_group,
+      run_name_env: str = "M_RUN_NAME",
+      nested_run_name_in_tb_file_location: bool = True,
+  ) -> "XpkNameGenAndQuarantineTask":
+    return XpkNameGenAndQuarantineTask(
+        task_test_config=self.task_test_config,
+        task_gcp_config=self.task_gcp_config,
+        task_metric_config=self.task_metric_config,
+        workload_provision_timeout=self.workload_provision_timeout,
+        quarantine_task_group=quarantine_task_group,
+        run_name_env=run_name_env,
+        nested_run_name_in_tb_file_location=nested_run_name_in_tb_file_location,
+    )
+
+  def run_model(
+      self,
       gcs_location: Optional[airflow.XComArg] = None,
       use_vertex_tensorboard: bool = False,
       expect_reach_to_step: int,
@@ -417,9 +448,151 @@ class XpkTask(BaseTask):
       check_file_exists: By default, this is False. If set to True,
         task branch task_path_decider will be performed.
     Returns:
-      A task group with the following tasks chained: run_model and
-      post_process.
+      A DAG node that executes the model test.
     """
+    with TaskGroup(group_id="run_model") as group:
+      workload_id = xpk.generate_workload_id(self.task_test_config.benchmark_id)
+      if gcs_location:
+        gcs_path = gcs_location
+      else:
+        gcs_path = name_format.generate_gcs_folder_location(
+            self.task_test_config.gcs_subfolder,
+            self.task_test_config.benchmark_id,
+        )
+      launch_workload = self.launch_workload(
+          workload_id,
+          gcs_path,
+          use_vertex_tensorboard,
+          use_pathways,
+          ramdisk_directory,
+          mtc_enabled,
+          xpk_branch,
+          max_restart,
+      )
+      wait_for_workload_completion = xpk.wait_for_workload_completion.override(
+          timeout=int(self.task_test_config.timeout.total_seconds()),
+      )(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.task_gcp_config.zone),
+          cluster_name=self.task_test_config.cluster_name,
+      )
+
+      clean_up_workload = xpk.clean_up_workload(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          xpk_branch=xpk_branch,
+      )
+
+      _ = (
+          (workload_id, gcs_path)
+          >> launch_workload
+          >> wait_for_workload_completion
+          >> clean_up_workload
+      )
+      return group, gcs_path
+
+  def launch_workload(
+      self,
+      workload_id: str,
+      gcs_path: str,
+      use_vertex_tensorboard: bool,
+      use_pathways: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      max_restart: int = 0,
+  ) -> DAGNode:
+    """Create the workload and wait for it to provision."""
+    with TaskGroup(group_id="launch_workload") as group:
+      run_workload = xpk.run_workload.override(
+          owner=self.task_test_config.task_owner
+      )(
+          task_id="run_workload",
+          cluster_project=self.task_gcp_config.project_name,
+          zone=self.task_gcp_config.zone,
+          cluster_name=self.task_test_config.cluster_name,
+          benchmark_id=self.task_test_config.benchmark_id,
+          workload_id=workload_id,
+          gcs_path=gcs_path,
+          docker_image=self.task_test_config.docker_image,
+          accelerator_type=self.task_test_config.accelerator.name,
+          run_cmds=self.task_test_config.test_script,
+          num_slices=self.task_test_config.num_slices,
+          use_vertex_tensorboard=use_vertex_tensorboard,
+          use_pathways=use_pathways,
+          ramdisk_directory=ramdisk_directory,
+          mtc_enabled=mtc_enabled,
+          xpk_branch=xpk_branch,
+          max_restart=max_restart,
+      )
+      wait_for_workload_start = xpk.wait_for_workload_start.override(
+          timeout=self.workload_provision_timeout.total_seconds()
+      )(
+          workload_id=workload_id,
+          project_id=self.task_gcp_config.project_name,
+          region=gke.zone_to_region(self.task_gcp_config.zone),
+          cluster_name=self.task_test_config.cluster_name,
+      )
+      _ = run_workload >> wait_for_workload_start
+      return group
+
+  def post_process(self, result_location: Optional[str] = None) -> DAGNode:
+    """Process metrics and metadata, and insert them into BigQuery tables.
+
+    Returns:
+      A DAG node that executes the post process.
+    """
+    with TaskGroup(group_id="post_process") as group:
+      process_id = metric.generate_process_id.override(retries=0)()
+      post_process_metrics = metric.process_metrics.override(retries=0)(
+          process_id,
+          self.task_test_config,
+          self.task_metric_config,
+          self.task_gcp_config,
+          folder_location=result_location,
+      )
+
+      if self.task_metric_config and self.task_metric_config.profile:
+        self.task_metric_config.profile.metrics = (
+            metric.xplane_to_metrics.override(retries=0)(
+                self.task_metric_config.profile.file_location
+            )
+        )
+        _ = (
+            process_id
+            >> self.task_metric_config.profile.metrics
+            >> post_process_metrics
+        )
+      else:
+        _ = process_id >> post_process_metrics
+
+      return group
+
+
+@dataclasses.dataclass
+class XpkNodeInterruptionTask(XpkTask):
+  """Task for running XPK workloads with node interruption."""
+
+  expect_reach_to_step: int = 0
+  last_node: bool = False
+  check_file_exists: bool = False
+
+  def run(
+      self,
+      *,
+      gcs_location: Optional[airflow.XComArg] = None,
+      use_vertex_tensorboard: bool = False,
+      use_pathways: bool = False,
+      skip_post_process: bool = False,
+      ramdisk_directory: str = "",
+      mtc_enabled: bool = False,
+      xpk_branch: str = xpk.MAIN_BRANCH,
+      max_restart: int = 0,
+  ) -> DAGNode:
+    """Run a test job with node interruption."""
     with TaskGroup(group_id=self.task_test_config.benchmark_id) as group:
       run_model, gcs_path = self.run_model_with_node_interruption(
           gcs_location=gcs_location,
@@ -702,12 +875,11 @@ class XpkTask(BaseTask):
         run_model, gcs_path = self.run_model(
             use_pathways=use_pathways, xpk_branch=xpk_branch
         )
-        _ = (
-            run_name
-            >> (tb_file_location, profile_file_location)
-            >> run_model
-            >> self.post_process(gcs_path)
+        flow = (
+            run_name >> (tb_file_location, profile_file_location) >> run_model
         )
+        if not skip_post_process:
+          _ = flow >> self.post_process(gcs_path)
       else:
         run_model, gcs_path = self.run_model(
             use_pathways=use_pathways, xpk_branch=xpk_branch

--- a/xlml/apis/task.py
+++ b/xlml/apis/task.py
@@ -401,7 +401,7 @@ class XpkTask(BaseTask):
 
   def to_name_gen_and_quarantine_task(
       self,
-      quarantine_task_group,
+      quarantine_task_group: Any = None,
       run_name_env: str = "M_RUN_NAME",
       nested_run_name_in_tb_file_location: bool = True,
   ) -> "XpkNameGenAndQuarantineTask":


### PR DESCRIPTION
# Description
This PR refactors the XpkTask class structure to follow OOP principles, introducing clean inheritance subclasses for specific test sub-workflows (node interruption and name generation/quarantine).

This allows `XpkTask` to maintain a clean interface and establishes a uniform polymorphic run() entry point across all tasks.

# Tests
DAG that uses `XpkNameGenAndQuarantineTask` class:
* With Quarantine
[maxtext_profile_sweep_example_dag](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_profile_sweep_example_dag/grid?search=maxtext_profile_sweep_example_dag&dag_run_id=manual__2026-07-31T10%3A07%3A20.865725%2B00%3A00&tab=graph)
* Without Quarantine
[maxtext_profile_namegen_example_dag](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_profile_namegen_example_dag/grid?search=maxtext_profile_namegen_example_dag&dag_run_id=manual__2026-07-31T09%3A35%3A59.189113%2B00%3A00&tab=graph)

DAG that uses `XpkNodeInterruptionTask` class:
* Has `generate_gcs_folder_location`
[maxtext_emc_orbax_res_gcs](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_emc_orbax_res_gcs/grid?search=maxtext_emc_orbax_res_gcs&dag_run_id=manual__2026-07-31T09%3A28%3A26.148164%2B00%3A00&tab=graph)
* Doesn't have `generate_gcs_folder_location`
[maxtext_regular_restore_with_node_disruption](https://df8ed769e47c4961bc18061e2518cb1c-dot-us-central1.composer.googleusercontent.com/dags/maxtext_regular_restore_with_node_disruption/grid?search=maxtext_regular_restore_with_node_disruption&dag_run_id=manual__2026-07-31T09%3A18%3A10.121549%2B00%3A00&tab=graph)

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.