### PR TITLE
fix: Correct GCS path mismatch and support multimodal HF conversion for gemma3-4b for DAG `maxtext_e2e_tpu_post_training`

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -66,7 +66,7 @@ with models.DAG(
               },
               "multimodal_sft": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh",
-                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/multimodal_sft/{run_name}/checkpoints/5/model_params",
+                  "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/multimodal/sft/{run_name}/checkpoints/4/items",
               },
               "lora": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh",
@@ -128,11 +128,16 @@ with models.DAG(
                 priority="very-high",
             )
 
+          if model == "gemma3-4b" and mode == "multimodal_sft":
+            to_hf_flags = "true true"
+          else:
+            to_hf_flags = "false true"
+
           model_path = mode_test_config["maxtext_ckpt_path"].format(
               run_name=run_name
           )
           convert_to_huggingface_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
-              f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path} false true",
+              f"{test_config['checkpoint_conversion']['to_huggingface']} {run_name} {model_path} {to_hf_flags}",
           )
           convert_to_huggingface_task = gke_config.get_gke_config(
               time_out_in_min=60,

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -67,6 +67,7 @@ with models.DAG(
               "multimodal_sft": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_multimodal_sft.sh",
                   "maxtext_ckpt_path": "gs://runner-maxtext-logs/gemma3-4b/multimodal/sft/{run_name}/checkpoints/4/items",
+                  "to_hf_flags": "true true",
               },
               "lora": {
                   "command": "bash tests/end_to_end/tpu/gemma3/4b/test_gemma3_lora.sh",
@@ -128,10 +129,7 @@ with models.DAG(
                 priority="very-high",
             )
 
-          if model == "gemma3-4b" and mode == "multimodal_sft":
-            to_hf_flags = "true true"
-          else:
-            to_hf_flags = "false true"
+          to_hf_flags = mode_test_config.get("to_hf_flags", "false true")
 
           model_path = mode_test_config["maxtext_ckpt_path"].format(
               run_name=run_name


### PR DESCRIPTION
# Description

This change updates the maxtext_e2e_tpu_post_training Airflow DAG to resolve a GCS checkpoint path mismatch and to dynamically adjust the checkpoint conversion flags when transforming MaxText weights back to Hugging Face format.

Specifically, it fixes the loading failures in downstream tasks and ensures that gemma3-4b under the multimodal_sft training pipeline uses the appropriate multimodal flags without causing regressions in other post-training pipelines.

# Tests

Manually tested on the v6e-8 TPU VM: https://paste.googleplex.com/4927671602642944

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.