### PR TITLE
feat: Separate out GitHub callback job for pre-training and post-training DAG

### DIFF
--- a/dags/multipod/maxtext_e2e_tests.py
+++ b/dags/multipod/maxtext_e2e_tests.py
@@ -14,8 +14,8 @@
 
 """
 Parent DAG that triggers MaxText E2E TPU pre-training and post-training child
-DAGs in parallel, waits for both to complete, then fires a GitHub
-repository_dispatch callback with the aggregated result.
+DAGs in parallel, firing separate GitHub repository_dispatch callbacks for
+pre-training and post-training upon completion of each job.
 """
 import datetime
 from airflow import models
@@ -79,10 +79,18 @@ with models.DAG(
       poke_interval=600,  # check every 10 minutes for child DAG completion
   )
 
-  github_callback = PythonOperator(
-      task_id="fire_github_callback",
+  github_callback_pre_training = PythonOperator(
+      task_id="fire_github_callback_pre_training",
       python_callable=fire_github_callback,
-      trigger_rule=TriggerRule.ALL_SUCCESS,  # Only fire if all upstream tasks succeeded
+      op_kwargs={"test_type": "pre_training"},
+      trigger_rule=TriggerRule.ALL_SUCCESS,
+  )
+
+  github_callback_post_training = PythonOperator(
+      task_id="fire_github_callback_post_training",
+      python_callable=fire_github_callback,
+      op_kwargs={"test_type": "post_training"},
+      trigger_rule=TriggerRule.ALL_SUCCESS,
   )
 
   validate_task = PythonOperator(
@@ -90,8 +98,5 @@ with models.DAG(
       python_callable=validate_git_trigger,
   )
 
-  (
-      validate_task
-      >> [trigger_pre_training, trigger_post_training]
-      >> github_callback
-  )
+  (validate_task >> trigger_pre_training >> github_callback_pre_training)
+  (validate_task >> trigger_post_training >> github_callback_post_training)

--- a/xlml/utils/github.py
+++ b/xlml/utils/github.py
@@ -36,10 +36,20 @@ def validate_git_trigger(**context):
     )
 
 
-def fire_github_callback(**context):
+def fire_github_callback(test_type: str | None = None, **context):
   """Fires a GitHub repository_dispatch callback with the DAG run result."""
   params = context["params"]
   dag_run = context["dag_run"]
+
+  client_payload = {
+      "state": "success",
+      "dag_id": dag_run.dag_id,
+      "dag_run_id": dag_run.run_id,
+      "sha": params["maxtext_sha"],
+      "github_run_id": params["github_run_id"],
+  }
+  if test_type:
+    client_payload["test_type"] = test_type
 
   response = requests.post(
       f"https://api.github.com/repos/{params['github_repo']}/dispatches",
@@ -50,13 +60,7 @@ def fire_github_callback(**context):
       },
       json={
           "event_type": "airflow-dag-complete",
-          "client_payload": {
-              "state": "success",
-              "dag_id": dag_run.dag_id,
-              "dag_run_id": dag_run.run_id,
-              "sha": params["maxtext_sha"],
-              "github_run_id": params["github_run_id"],
-          },
+          "client_payload": client_payload,
       },
       timeout=30,
   )


### PR DESCRIPTION
# Description

In `xlml` for `maxtext-e2e-test`, separated out the GitHub `repository_dispatch` callback job so that pre-training (`maxtext_e2e_tpu_pre_training`) and post-training (`maxtext_e2e_tpu_post_training`) child DAGs trigger their respective GitHub callbacks independently upon completion.

- Refactored `fire_github_callback` into `xlml/utils/github.py` with `test_type` parameter (`"pre_training"` / `"post_training"`).
- Split the single aggregated `github_callback` task into two separate PythonOperators: `fire_github_callback_pre_training` and `fire_github_callback_post_training`.
- Configured task dependencies so each callback runs immediately after its target trigger task completes in parallel (`trigger_pre_training >> github_callback_pre_training` and `trigger_post_training >> github_callback_post_training`).

# Tests

Uploaded modified `xlml/utils/github.py` and `dags/multipod/maxtext_e2e_tests.py` to Cloud Composer environment `jackyf-test` in project `cloud-ml-auto-solutions` and verified:
1. Checked for DAG import errors with `airflow dags list-import-errors` (0 errors found).
2. Verified task structure with `airflow tasks list maxtext_e2e_tests` showing `fire_github_callback_pre_training` and `fire_github_callback_post_training`.

**Instruction and/or command lines to reproduce your tests:**
```bash
gcloud storage cp xlml/utils/github.py gs://us-east1-jackyf-test-3fc56b08-bucket/dags/xlml/utils/github.py
gcloud storage cp dags/multipod/maxtext_e2e_tests.py gs://us-east1-jackyf-test-3fc56b08-bucket/dags/dags/multipod/maxtext_e2e_tests.py
gcloud composer environments run jackyf-test --location us-east1 --project cloud-ml-auto-solutions dags list-import-errors
gcloud composer environments run jackyf-test --location us-east1 --project cloud-ml-auto-solutions tasks list -- maxtext_e2e_tests
```

**List links for your tests (use go/shortn-gen for any internal link):**
- Airflow UI: https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com
- DAG Grid: https://06ba93284e31466eb62067a2f46710a7-dot-us-east1.composer.googleusercontent.com/dags/maxtext_e2e_tests/grid

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.
