### PR TITLE
fix: Fix vLLM rollout GRPC timeouts in `maxtext_e2e_tpu_post_training` DAG

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -206,6 +206,8 @@ with models.DAG(
               f"export HF_TOKEN={HF_TOKEN}",
               "export TPU_MIN_LOG_LEVEL=0",
               "export TF_CPP_MIN_LOG_LEVEL=0",
+              "export GRPC_KEEPALIVE_TIME_MS=60000",
+              "export GRPC_KEEPALIVE_TIMEOUT_MS=120000",
               "export TPU_STDERR_LOG_LEVEL=0",
               "export JAX_PLATFORMS=proxy,cpu",
               "export JAX_BACKEND_TARGET=grpc://127.0.0.1:29000",


### PR DESCRIPTION
# Description

Timeouts: Added `GRPC_KEEPALIVE_TIME_MS` to `maxtext_e2e_tpu_post_training` DAG to prevent GCP 5-min idle disconnects (Exit Code 143) during large checkpoint loads.

# Tests

Llama3.1-70b RL end-to-end: https://cloudlogging.app.goo.gl/fef9HAjXLGc7mM1A6


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.