### PR TITLE
feat: Add retry mechanism to e2e DAGs

### DIFF
--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -202,6 +202,17 @@ with models.DAG(
 
       for mode, mode_test_config in test_config["post_training"].items():
         with TaskGroup(group_id=f"{mode}-{model}") as mode_group:
+          model_path = mode_test_config["maxtext_ckpt_path"].format(
+              run_name=run_name
+          )
+          base_output_dir = model_path.split("/checkpoints/")[0]
+          cleanup_cmd = (
+              f"if gsutil ls {base_output_dir} >/dev/null 2>&1; then "
+              f"echo 'Retry detected (directory exists). Cleaning up previous checkpoints...'; "
+              f"gsutil -m rm -rf {base_output_dir} || true; "
+              f"fi"
+          )
+
           environment_variables = [
               f"export HF_TOKEN={HF_TOKEN}",
               "export TPU_MIN_LOG_LEVEL=0",
@@ -212,6 +223,7 @@ with models.DAG(
               "export JAX_PLATFORMS=proxy,cpu",
               "export JAX_BACKEND_TARGET=grpc://127.0.0.1:29000",
               "export ENABLE_PATHWAYS_PERSISTENCE='1'",
+              cleanup_cmd,
           ]
 
           command = mode_test_config["command"]
@@ -236,13 +248,11 @@ with models.DAG(
               test_owner=test_owner.SURBHI_J,
               use_pathways=True,
               priority="very-high",
+              max_restart=2,
           ).run(skip_post_process=True)
 
           to_hf_flags = mode_test_config.get("to_hf_flags", "false true")
 
-          model_path = mode_test_config["maxtext_ckpt_path"].format(
-              run_name=run_name
-          )
           convert_to_huggingface_cmd = (
               f"export HF_TOKEN={HF_TOKEN}",
               'export HF_HOME="/dev/shm/hf_cache"',

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -15,10 +15,14 @@
 """
 MaxText E2E TPU Post-Training Tests DAG (Stage 2).
 
-Executes end-to-end MaxText post-training workflows (SFT, Multimodal SFT, LoRA, RL) on Cloud TPU:
-- Waits for model conversion in maxtext_e2e_tpu_checkpoint_conversion via ExternalTaskSensor.
-- Executes post-training scripts with Pathways runtime persistence on TPU slices.
-- Converts post-trained checkpoints back to Hugging Face format to verify weight fidelity.
+Executes end-to-end MaxText post-training workflows
+(SFT, Multimodal SFT, LoRA, RL) on Cloud TPU:
+- Waits for model conversion in maxtext_e2e_tpu_checkpoint_conversion
+  via ExternalTaskSensor.
+- Executes post-training scripts with Pathways runtime persistence
+  on TPU slices.
+- Converts post-trained checkpoints back to Hugging Face format
+  to verify weight fidelity.
 """
 import datetime
 
@@ -38,7 +42,8 @@ HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
 class ExternalTaskSensorWithBypass(ExternalTaskSensor):
-  """ExternalTaskSensor that passes immediately if wait_for_conversion param is False."""
+  """ExternalTaskSensor that passes immediately if
+  wait_for_conversion param is False."""
 
   @provide_session
   def poke(self, context, session=None):
@@ -66,7 +71,10 @@ with models.DAG(
         "run_name": Param(
             default="",
             type="string",
-            description="Shared run name for checkpoints (defaults to post-{{ ts_nodash }})",
+            description=(
+                "Shared run name for checkpoints "
+                "(defaults to post-{{ ts_nodash }})"
+            ),
         ),
         "wait_for_conversion": Param(
             default=True,
@@ -205,10 +213,11 @@ with models.DAG(
           model_path = mode_test_config["maxtext_ckpt_path"].format(
               run_name=run_name
           )
-          base_output_dir = model_path.split("/checkpoints/")[0]
+          base_output_dir = model_path.split("/checkpoints/", maxsplit=1)[0]
           cleanup_cmd = (
               f"if gsutil ls {base_output_dir} >/dev/null 2>&1; then "
-              f"echo 'Retry detected (directory exists). Cleaning up previous checkpoints...'; "
+              f"echo 'Retry detected. "
+              f"Cleaning up previous checkpoints...'; "
               f"gsutil -m rm -rf {base_output_dir} || true; "
               f"fi"
           )

--- a/dags/multipod/maxtext_e2e_tpu_post_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_post_training.py
@@ -257,7 +257,7 @@ with models.DAG(
               test_owner=test_owner.SURBHI_J,
               use_pathways=True,
               priority="very-high",
-              max_restart=2,
+              max_restart=3,
           ).run(skip_post_process=True)
 
           to_hf_flags = mode_test_config.get("to_hf_flags", "false true")

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -16,9 +16,12 @@
 MaxText E2E TPU Pre-Training Tests DAG (Stage 2).
 
 Executes end-to-end MaxText pre-training test workloads on Cloud TPU:
-- Waits for model conversion in maxtext_e2e_tpu_checkpoint_conversion via ExternalTaskSensor.
-- Runs pre-training on dedicated TPU v5p topologies configured per model architecture.
-- Converts trained checkpoints back to Hugging Face format to verify weight fidelity.
+- Waits for model conversion in maxtext_e2e_tpu_checkpoint_conversion
+  via ExternalTaskSensor.
+- Runs pre-training on dedicated TPU v5p topologies configured per
+  model architecture.
+- Converts trained checkpoints back to Hugging Face format
+  to verify weight fidelity.
 """
 import datetime
 from airflow import models
@@ -36,7 +39,8 @@ HF_TOKEN = safe_get_from_variable("HF_TOKEN", None)
 
 
 class ExternalTaskSensorWithBypass(ExternalTaskSensor):
-  """ExternalTaskSensor that passes immediately if wait_for_conversion param is False."""
+  """ExternalTaskSensor that passes immediately if
+  wait_for_conversion param is False."""
 
   @provide_session
   def poke(self, context, session=None):
@@ -64,7 +68,10 @@ with models.DAG(
         "run_name": Param(
             default="",
             type="string",
-            description="Shared run name for checkpoints (e.g. conv-20260813T123008)",
+            description=(
+                "Shared run name for checkpoints "
+                "(e.g. conv-20260813T123008)"
+            ),
         ),
         "wait_for_conversion": Param(
             default=True,
@@ -131,7 +138,7 @@ with models.DAG(
       model_path = test_config["training"]["maxtext_ckpt_path"].format(
           run_name=run_name
       )
-      base_output_dir = model_path.split("/checkpoints/")[0]
+      base_output_dir = model_path.split("/checkpoints/", maxsplit=1)[0]
       cleanup_cmd = (
           f"if gsutil ls {base_output_dir} >/dev/null 2>&1; then "
           f'echo "Retry detected (directory exists). Cleaning up..."; '

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -159,7 +159,7 @@ with models.DAG(
           ),
           test_owner=test_owner.SURBHI_J,
           priority="very-high",
-          max_restart=2,
+          max_restart=3,
       ).run(skip_post_process=True)
 
       to_hf_flags = test_config.get("to_hf_flags", "")

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -145,7 +145,9 @@ with models.DAG(
           f"fi"
       )
 
-      training_cmd = (f"export HF_TOKEN={HF_TOKEN}", cleanup_cmd) + (
+      training_cmd = (
+          f"export HF_TOKEN={HF_TOKEN}",
+          cleanup_cmd,
           f"{test_config['training']['command']} {run_name}",
       )
       training_core_count = test_config.get("core_count", 8)

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -69,8 +69,7 @@ with models.DAG(
             default="",
             type="string",
             description=(
-                "Shared run name for checkpoints "
-                "(e.g. conv-20260813T123008)"
+                "Shared run name for checkpoints " "(e.g. conv-20260813T123008)"
             ),
         ),
         "wait_for_conversion": Param(

--- a/dags/multipod/maxtext_e2e_tpu_pre_training.py
+++ b/dags/multipod/maxtext_e2e_tpu_pre_training.py
@@ -128,7 +128,18 @@ with models.DAG(
           "{{ params.run_name if params.run_name else 'pre-' ~ ts_nodash }}"
       )
 
-      training_cmd = (f"export HF_TOKEN={HF_TOKEN}",) + (
+      model_path = test_config["training"]["maxtext_ckpt_path"].format(
+          run_name=run_name
+      )
+      base_output_dir = model_path.split("/checkpoints/")[0]
+      cleanup_cmd = (
+          f"if gsutil ls {base_output_dir} >/dev/null 2>&1; then "
+          f'echo "Retry detected (directory exists). Cleaning up..."; '
+          f"gsutil -m rm -rf {base_output_dir} || true; "
+          f"fi"
+      )
+
+      training_cmd = (f"export HF_TOKEN={HF_TOKEN}", cleanup_cmd) + (
           f"{test_config['training']['command']} {run_name}",
       )
       training_core_count = test_config.get("core_count", 8)
@@ -142,11 +153,9 @@ with models.DAG(
           ),
           test_owner=test_owner.SURBHI_J,
           priority="very-high",
+          max_restart=2,
       ).run(skip_post_process=True)
 
-      model_path = test_config["training"]["maxtext_ckpt_path"].format(
-          run_name=run_name
-      )
       to_hf_flags = test_config.get("to_hf_flags", "")
 
       convert_to_huggingface_cmd = (


### PR DESCRIPTION
# Description

This PR resolves the issue of XPK pods periodically crashing with `EXIT_CODE=143` (often due to Kueue preemption or Spot eviction).

Specific changes:                                                                                                                     
- **Added `max_restart=3`**: Allows GKE JobSet to seamlessly and automatically retry interrupted TPU training tasks without failing the Airflow DAG.
- **Added `cleanup_cmd` pre-flight step**: Idempotently purges the `base_output_dir` upon startup. If a pod is preempted and the JobSet restarts it in place, this ensures the new pod has a pristine workspace to start training, avoiding Orbax read errors from previously corrupted checkpoints.

# Tests

Tested with XPK.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.